### PR TITLE
Convert AddFile to FileStatus directly to save FileSystem RPC calls

### DIFF
--- a/hive/src/main/scala/io/delta/hive/DeltaInputFormat.scala
+++ b/hive/src/main/scala/io/delta/hive/DeltaInputFormat.scala
@@ -39,8 +39,6 @@ class DeltaInputFormat(realInput: ParquetInputFormat[ArrayWritable]) extends Fil
   override def listStatus(job: JobConf): Array[FileStatus] = {
     val deltaRootPath = new Path(job.get(DeltaStorageHandler.DELTA_TABLE_PATH))
     TokenCache.obtainTokensForNamenodes(job.getCredentials(), Array(deltaRootPath), job)
-
-    val filteredDeltaFiles = DeltaHelper.listDeltaFiles(deltaRootPath, job)
-    filteredDeltaFiles.toArray(new Array[FileStatus](filteredDeltaFiles.size))
+    DeltaHelper.listDeltaFiles(deltaRootPath, job)
   }
 }

--- a/hive/src/main/scala/org/apache/spark/sql/delta/DeltaHelper.scala
+++ b/hive/src/main/scala/org/apache/spark/sql/delta/DeltaHelper.scala
@@ -1,10 +1,12 @@
 package org.apache.spark.sql.delta
 
-import io.delta.hive.DeltaStorageHandler
+import java.net.URI
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.hadoop.fs.{FileStatus, Path}
+import io.delta.hive.DeltaStorageHandler
+import org.apache.hadoop.fs._
 import org.apache.hadoop.hive.metastore.api.{FieldSchema, MetaException}
 import org.apache.hadoop.hive.ql.plan.TableScanDesc
 import org.apache.hadoop.mapred.JobConf
@@ -65,26 +67,84 @@ object DeltaHelper extends Logging {
     }
   }
 
-  def listDeltaFiles(rootPath: Path, job: JobConf): java.util.List[FileStatus] = {
+  def listDeltaFiles(nonNormalizedPath: Path, job: JobConf): Array[FileStatus] = {
+    val fs = nonNormalizedPath.getFileSystem(job)
+    // TODO It seems Hive doesn't work without "makeQualified". We should understand this deeply to
+    // make sure we call "makeQualified" in all places properly, because missing "makeQualified"
+    // returns an incorrect answer rather than failing the query, which is pretty bad.
+    val rootPath = fs.makeQualified(nonNormalizedPath)
     val deltaLog = DeltaLog.forTable(spark, rootPath)
     // get the snapshot of the version
     val snapshotToUse = deltaLog.snapshot
 
-    val fs = rootPath.getFileSystem(job)
+    // TODO Verify the table schema is consistent with `snapshotToUse.metadata`.
 
     // get the partition prune exprs
     val filterExprSerialized = job.get(TableScanDesc.FILTER_EXPR_CONF_STR)
 
     val convertedFilterExpr = DeltaPushFilter.partitionFilterConverter(filterExprSerialized)
 
+    // The default value 128M is the same as the default value of
+    // "spark.sql.files.maxPartitionBytes" in Spark. It's also the default parquet row group size
+    // which is usually the best split size for parquet files.
+    val blockSize = job.getLong("parquet.block.size", 128L * 1024 * 1024)
+
     // selected files to Hive to be processed
     DeltaLog.filterFileList(
       snapshotToUse.metadata.partitionColumns, snapshotToUse.allFiles.toDF(), convertedFilterExpr)
       .as[AddFile](SingleAction.addFileEncoder)
-      .collect().par.map { f =>
+      .collect().map { f =>
         logInfo(s"selected delta file ${f.path} under $rootPath")
-        fs.getFileStatus(new Path(rootPath, f.path))
-      }.toList.asJava
+        toFileStatus(fs, rootPath, f, blockSize)
+      }
+  }
+
+  /**
+   * Convert an [[AddFile]] to Hadoop's [[FileStatus]].
+   *
+   * @param root the table path which will be used to create the real path from relative path.
+   */
+  private def toFileStatus(fs: FileSystem, root: Path, f: AddFile, blockSize: Long): FileStatus = {
+    val status = new FileStatus(
+      f.size, // length
+      false, // isDir
+      1, // blockReplication, FileInputFormat doesn't use this
+      blockSize, // blockSize
+      f.modificationTime, // modificationTime
+      absolutePath(fs, root, f.path) // path
+    )
+    // We don't have `blockLocations` in `AddFile`. However, fetching them by calling
+    // `getFileStatus` for each file is unacceptable because that's pretty inefficient and it will
+    // make Delta look worse than a parquet table because of these FileSystem RPC calls.
+    //
+    // But if we don't set the block locations, [[FileInputFormat]] will try to fetch them. Hence,
+    // we create a `LocatedFileStatus` with dummy block locations to save FileSystem RPC calls. We
+    // lose the locality but this is fine today since most of storage systems are on Cloud and the
+    // computation is running separately.
+    //
+    // An alternative solution is using "listStatus" recursively to get all `FileStatus`s and keep
+    // those present in `AddFile`s. This is much cheaper and the performance should be the same as a
+    // parquet table. However, it's pretty complicated as we need to be careful to avoid listing
+    // unnecessary directories. So we decide to not do this right now.
+    val dummyBlockLocations =
+      Array(new BlockLocation(Array("localhost:50010"), Array("localhost"), 0, f.size))
+    new LocatedFileStatus(status, dummyBlockLocations)
+  }
+
+  /**
+   * Create an absolute [[Path]] from `child` using the `root` path if `child` is a relative path.
+   * Return a [[Path]] version of child` if it is an absolute path.
+   *
+   * @param child an escaped string read from Delta's [[AddFile]] directly which requires to
+   *              unescape before creating the [[Path]] object.
+   */
+  private def absolutePath(fs: FileSystem, root: Path, child: String): Path = {
+    val p = new Path(new URI(child))
+    if (p.isAbsolute) {
+      fs.makeQualified(p)
+    } else {
+      new Path(root, p)
+    }
   }
 
   def checkHiveColsInDelta(


### PR DESCRIPTION
This PR creates `FileStatus` directly from `AddFile` to save FileSystem RPC calls. As `AddFile` doesn't have the block locations, we lose the locality. But this is fine today since most of storage systems are on Cloud and the computation is running separately.

I also fixes a bug that we return incorrect file paths to Hive when the partition values have some special values that are escaped in the file path.