### PR TITLE
Consistent schema in Hive and Delta metadata

### DIFF
--- a/hive/src/main/java/io/delta/hive/DeltaInputSplit.java
+++ b/hive/src/main/java/io/delta/hive/DeltaInputSplit.java
@@ -1,0 +1,56 @@
+package io.delta.hive;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileSplit;
+
+/**
+ * A special {@link FileSplit} that holds the corresponding partition information of the file.
+ *
+ * This file is written in Java because we need to call two different constructors of
+ * {@link FileSplit} but Scala doesn't support it.
+ */
+public class DeltaInputSplit extends FileSplit {
+
+    private PartitionColumnInfo[] partitionColumns;
+
+    protected DeltaInputSplit() {
+        super();
+        partitionColumns = new PartitionColumnInfo[0];
+    }
+
+    public DeltaInputSplit(Path file, long start, long length, String[] hosts, PartitionColumnInfo[] partitionColumns) {
+        super(file, start, length, hosts);
+        this.partitionColumns = partitionColumns;
+    }
+
+    public DeltaInputSplit(Path file, long start, long length, String[] hosts, String[] inMemoryHosts, PartitionColumnInfo[] partitionColumns) {
+        super(file, start, length, hosts, inMemoryHosts);
+        this.partitionColumns = partitionColumns;
+    }
+
+    public PartitionColumnInfo[] getPartitionColumns() {
+        return partitionColumns;
+    }
+
+    public void write(DataOutput out) throws IOException {
+        super.write(out);
+        out.writeInt(partitionColumns.length);
+        for (PartitionColumnInfo partitionColumn : partitionColumns) {
+            partitionColumn.write(out);
+        }
+    }
+
+    public void readFields(DataInput in) throws IOException {
+        super.readFields(in);
+        int size = in.readInt();
+        partitionColumns = new PartitionColumnInfo[size];
+        for (int i = 0; i < size; i++) {
+            PartitionColumnInfo partitionColumn = new PartitionColumnInfo();
+            partitionColumn.readFields(in);
+            partitionColumns[i] = partitionColumn;
+        }
+    }
+}

--- a/hive/src/main/scala/io/delta/hive/DeltaInputFormat.scala
+++ b/hive/src/main/scala/io/delta/hive/DeltaInputFormat.scala
@@ -1,11 +1,12 @@
 package io.delta.hive
 
-import java.io.IOException
+import java.net.URI
 
 import org.apache.hadoop.fs.FileStatus
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.ql.exec.Utilities
 import org.apache.hadoop.hive.ql.io.parquet.read.DataWritableReadSupport
+import org.apache.hadoop.hive.serde.serdeConstants
 import org.apache.hadoop.io.ArrayWritable
 import org.apache.hadoop.io.NullWritable
 import org.apache.hadoop.mapred._
@@ -18,27 +19,59 @@ class DeltaInputFormat(realInput: ParquetInputFormat[ArrayWritable]) extends Fil
 
   private val LOG = LoggerFactory.getLogger(classOf[DeltaInputFormat])
 
+  /**
+   * A temp [[Map]] to store the path uri and its partition information. We build this map in
+   * `listStatus` and `makeSplit` will use it to retrieve the partition information for each split.
+   * */
+  private var fileToPartition: Map[URI, Array[PartitionColumnInfo]] = Map.empty
+
   def this() {
     this(new ParquetInputFormat[ArrayWritable](classOf[DataWritableReadSupport]))
   }
 
   override def getRecordReader(split: InputSplit, job: JobConf, reporter: Reporter): RecordReader[NullWritable, ArrayWritable] = {
-    if (Utilities.getUseVectorizedInputFileFormat(job)) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Using vectorized record reader")
-      }
-      throw new IOException("Currently not support Delta VectorizedReader")
-    } else {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Using row-mode record reader")
-      }
-      new DeltaRecordReaderWrapper(this.realInput, split, job, reporter)
+    split match {
+      case deltaSplit: DeltaInputSplit =>
+        if (Utilities.getUseVectorizedInputFileFormat(job)) {
+          throw new UnsupportedOperationException(
+            "Reading Delta tables using Parquet's VectorizedReader is not supported")
+        } else {
+          new DeltaRecordReaderWrapper(this.realInput, deltaSplit, job, reporter)
+        }
+      case _ =>
+        throw new IllegalArgumentException("Expected DeltaInputSplit but it was: " + split)
     }
   }
 
   override def listStatus(job: JobConf): Array[FileStatus] = {
     val deltaRootPath = new Path(job.get(DeltaStorageHandler.DELTA_TABLE_PATH))
     TokenCache.obtainTokensForNamenodes(job.getCredentials(), Array(deltaRootPath), job)
-    DeltaHelper.listDeltaFiles(deltaRootPath, job)
+    val (files, partitions) = DeltaHelper.listDeltaFiles(deltaRootPath, job)
+    fileToPartition = partitions.filter(_._2.nonEmpty)
+    files
+  }
+
+  override def makeSplit(
+      file: Path,
+      start: Long,
+      length: Long,
+      hosts: Array[String]): FileSplit = {
+    new DeltaInputSplit(file, start, length, hosts, fileToPartition.getOrElse(file.toUri, Array.empty))
+  }
+
+  override def makeSplit(
+      file: Path,
+      start: Long,
+      length: Long,
+      hosts: Array[String],
+      inMemoryHosts: Array[String]): FileSplit = {
+    new DeltaInputSplit(file, start, length, hosts, inMemoryHosts, fileToPartition.getOrElse(file.toUri, Array.empty))
+  }
+
+  override def getSplits(job: JobConf, numSplits: Int): Array[InputSplit] = {
+    val splits = super.getSplits(job, numSplits)
+    // Reset the temp [[Map]] to release the memory
+    fileToPartition = Map.empty
+    splits
   }
 }

--- a/hive/src/main/scala/io/delta/hive/DeltaRecordReaderWrapper.scala
+++ b/hive/src/main/scala/io/delta/hive/DeltaRecordReaderWrapper.scala
@@ -36,16 +36,19 @@ class DeltaRecordReaderWrapper(
       val oi = PrimitiveObjectInspectorFactory
         .getPrimitiveWritableObjectInspector(TypeInfoFactory
           .getPrimitiveTypeInfo(partition.tpe))
-      partition.index -> ObjectInspectorConverters.getConverter(
-        PrimitiveObjectInspectorFactory.javaStringObjectInspector, oi)
-        .convert(partition.value).asInstanceOf[Writable]
+      val partitionValue = ObjectInspectorConverters.getConverter(
+        PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+        oi).convert(partition.value).asInstanceOf[Writable]
+      (partition.index, partitionValue)
     }
 
   override def next(key: NullWritable, value: ArrayWritable): Boolean = {
     val hasNext = super.next(key, value)
     // TODO Figure out when the parent reader resets partition columns to null so that we may come
     // out a better solution to not insert partition values for each row.
-    insertPartitionValues(value)
+    if (hasNext) {
+      insertPartitionValues(value)
+    }
     hasNext
   }
 

--- a/hive/src/main/scala/io/delta/hive/DeltaRecordReaderWrapper.scala
+++ b/hive/src/main/scala/io/delta/hive/DeltaRecordReaderWrapper.scala
@@ -1,8 +1,5 @@
 package io.delta.hive
 
-import com.google.common.base.Joiner
-import scala.collection.JavaConverters._
-
 import org.apache.hadoop.hive.ql.io.parquet.read.ParquetRecordReaderWrapper
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorConverters
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory
@@ -10,72 +7,55 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory
 import org.apache.hadoop.io.ArrayWritable
 import org.apache.hadoop.io.NullWritable
 import org.apache.hadoop.io.Writable
-import org.apache.hadoop.mapred.FileSplit
-import org.apache.hadoop.mapred.InputSplit
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.mapred.Reporter
 import org.apache.parquet.hadoop.ParquetInputFormat
-import org.apache.spark.sql.delta.DeltaHelper
 import org.slf4j.LoggerFactory
 
-class DeltaRecordReaderWrapper(newInputFormat: ParquetInputFormat[ArrayWritable], oldSplit: InputSplit, oldJobConf: JobConf, reporter: Reporter) extends ParquetRecordReaderWrapper(newInputFormat, oldSplit, oldJobConf, reporter) {
+/**
+ * A record reader that reads data from the underlying Parquet reader and inserts partition values
+ * which don't exist in the Parquet files.
+ */
+class DeltaRecordReaderWrapper(
+    inputFormat: ParquetInputFormat[ArrayWritable],
+    split: DeltaInputSplit,
+    jobConf: JobConf,
+    reporter: Reporter) extends ParquetRecordReaderWrapper(inputFormat, split, jobConf, reporter) {
 
   private val LOG = LoggerFactory.getLogger(classOf[DeltaRecordReaderWrapper])
 
-  private val partitionWritable: Array[Writable] =
-    if (!oldSplit.isInstanceOf[FileSplit]) {
-      throw new IllegalArgumentException("Unknown split type: " + oldSplit)
-    } else {
-      val columnNameProperty = oldJobConf.get(DeltaStorageHandler.DELTA_PARTITION_COLS_NAMES)
-      val columnTypeProperty = oldJobConf.get(DeltaStorageHandler.DELTA_PARTITION_COLS_TYPES)
-      LOG.info("Delta partition cols: " + columnNameProperty + " with types: " + columnTypeProperty)
-
-      if (columnNameProperty == null || columnNameProperty.trim().length() == 0
-        || columnTypeProperty == null || columnTypeProperty.trim().length() == 0) {
-        LOG.info("No partition info is provided...")
-        null
-      } else {
-        // generate partition writale values which will be appended after data values from parquet
-        val columnNames = columnNameProperty.split(",")
-        val columnTypes = columnTypeProperty.split(":")
-
-        val filePath = oldSplit.asInstanceOf[FileSplit].getPath()
-        val parsedPartitions = DeltaHelper.parsePathPartition(filePath, columnNames).asJava
-
-        val partitionWritable = new Array[Writable](columnNames.length)
-        // inspect partition values
-        for (i <- 0 until columnNames.length) {
-          val oi = PrimitiveObjectInspectorFactory
-            .getPrimitiveWritableObjectInspector(TypeInfoFactory
-              .getPrimitiveTypeInfo(columnTypes(i)))
-
-          partitionWritable(i) = ObjectInspectorConverters.getConverter(
-            PrimitiveObjectInspectorFactory.javaStringObjectInspector, oi).convert(parsedPartitions.get(columnNames(i))).asInstanceOf[Writable]
-        }
-        LOG.info("Parsed partition values from " + filePath.toString() + " list: " + Joiner.on(",").withKeyValueSeparator("=").join(parsedPartitions)
-          + ", partitionWritable length:" + partitionWritable.length)
-        partitionWritable
-      }
+  /** The indices of partition columns in schema and their values. */
+  private val partitionValues: Array[(Int, Writable)] =
+    split.getPartitionColumns.map { partition =>
+      val oi = PrimitiveObjectInspectorFactory
+        .getPrimitiveWritableObjectInspector(TypeInfoFactory
+          .getPrimitiveTypeInfo(partition.tpe))
+      partition.index -> ObjectInspectorConverters.getConverter(
+        PrimitiveObjectInspectorFactory.javaStringObjectInspector, oi)
+        .convert(partition.value).asInstanceOf[Writable]
     }
 
   override def next(key: NullWritable, value: ArrayWritable): Boolean = {
     val hasNext = super.next(key, value)
-    if (partitionWritable != null && partitionWritable.length != 0) {
-      // append partition values to data values
-      for (i <- 0 until partitionWritable.length) {
-        value.get()(value.get().length - partitionWritable.length + i) = partitionWritable(i)
-      }
-    }
+    // TODO Figure out when the parent reader resets partition columns to null so that we may come
+    // out a better solution to not insert partition values for each row.
+    insertPartitionValues(value)
     hasNext
   }
 
-  override def createValue(): ArrayWritable = {
-    val value = super.createValue()
-    if (partitionWritable != null && partitionWritable.length != 0) {
-      for (i <- 0 until partitionWritable.length) {
-        value.get()(value.get().length - partitionWritable.length + i) = partitionWritable(i)
-      }
+  /**
+   * As partition columns are not in the parquet files, they will be set to `null`s every time
+   * `next` is called. We should insert partition values manually for each row.
+   */
+  private def insertPartitionValues(value: ArrayWritable): Unit = {
+    val valueArray = value.get()
+    var i = 0
+    val n = partitionValues.length
+    // Using while loop for better performance since this method is called for each row.
+    while (i < n) {
+      val partition = partitionValues(i)
+      valueArray(partition._1) = partition._2
+      i += 1
     }
-    value
   }
 }

--- a/hive/src/main/scala/io/delta/hive/DeltaStorageHandler.scala
+++ b/hive/src/main/scala/io/delta/hive/DeltaStorageHandler.scala
@@ -200,7 +200,7 @@ object DeltaStorageHandler {
    * A config we use to remember the table schema in the table properties.
    *
    * TODO Maybe Hive can tell us this in the `configureInputJobProperties` method. Then we don't
-   * * need to store this extra information.
+   * need to store this extra information.
    */
   val DELTA_TABLE_SCHEMA = "delta.table.schema"
 }

--- a/hive/src/main/scala/io/delta/hive/DeltaStorageHandler.scala
+++ b/hive/src/main/scala/io/delta/hive/DeltaStorageHandler.scala
@@ -18,10 +18,9 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc
 import org.apache.hadoop.hive.ql.plan.TableDesc
 import org.apache.hadoop.hive.serde2.AbstractSerDe
 import org.apache.hadoop.hive.serde2.Deserializer
-import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory
+import org.apache.hadoop.hive.serde2.typeinfo.{StructTypeInfo, TypeInfo, TypeInfoFactory, TypeInfoUtils}
 import org.apache.hadoop.mapred.{InputFormat, JobConf, OutputFormat}
-import org.apache.spark.sql.delta.DeltaHelper
-import org.apache.spark.sql.delta.DeltaPushFilter
+import org.apache.spark.sql.delta.{DeltaHelper, DeltaPushFilter}
 import org.slf4j.LoggerFactory
 
 class DeltaStorageHandler extends DefaultStorageHandler with HiveMetaHook with HiveStoragePredicateHandler {
@@ -44,8 +43,7 @@ class DeltaStorageHandler extends DefaultStorageHandler with HiveMetaHook with H
   override def configureInputJobProperties(tableDesc: TableDesc, jobProperties: java.util.Map[String, String]): Unit = {
     super.configureInputJobProperties(tableDesc, jobProperties)
     jobProperties.put(DELTA_TABLE_PATH, tableDesc.getProperties().getProperty(DELTA_TABLE_PATH))
-    jobProperties.put(DELTA_PARTITION_COLS_NAMES, tableDesc.getProperties().getProperty(DELTA_PARTITION_COLS_NAMES))
-    jobProperties.put(DELTA_PARTITION_COLS_TYPES, tableDesc.getProperties().getProperty(DELTA_PARTITION_COLS_TYPES))
+    jobProperties.put(DELTA_TABLE_SCHEMA, tableDesc.getProperties().getProperty(DELTA_TABLE_SCHEMA))
   }
 
   override def decomposePredicate(jobConf: JobConf, deserializer: Deserializer, predicate: ExprNodeDesc): DecomposedPredicate = {
@@ -141,48 +139,68 @@ class DeltaStorageHandler extends DefaultStorageHandler with HiveMetaHook with H
           s"${tbl.getDbName}:${tbl.getTableName}. The partition columns in a Delta table " +
           s"will be read from its own metadata and should not be set manually.")    }
 
-    val deltaRootString = tbl.getSd().getLocation()
-    if (deltaRootString == null || deltaRootString.trim().length() == 0) {
-      throw new MetaException("table location should be set when creating table")
-    } else {
-      val deltaPath = new Path(deltaRootString)
-      val fs = deltaPath.getFileSystem(getConf())
-      if (!fs.exists(deltaPath)) {
-        throw new MetaException("delta.table.path(" + deltaRootString + ") does not exist...")
-      } else {
-        val partitionProps = DeltaHelper.checkHiveColsInDelta(deltaPath, tbl.getSd().getCols())
-        tbl.getSd().getSerdeInfo().getParameters().putAll(partitionProps.asJava)
-        tbl.getSd().getSerdeInfo().getParameters().put(DELTA_TABLE_PATH, deltaRootString)
-        tbl.getParameters.put("spark.sql.sources.provider", "DELTA")
-        LOG.info("write partition cols/types to table properties " +
-          partitionProps.map(kv => s"${kv._1}=${kv._2}").mkString(", "))
-      }
+    val deltaRootString = tbl.getSd.getLocation
+    if (deltaRootString == null || deltaRootString.trim.isEmpty) {
+      throw new MetaException("table location should be set when creating a Delta table")
     }
+
+    val snapshot = DeltaHelper.loadDeltaLog(new Path(deltaRootString)).snapshot
+    if (snapshot.version < 0) {
+      throw new MetaException(s"$deltaRootString does not exist or it's not a Delta table")
+    }
+
+    // Extract the table schema in Hive and put it into the table property. Then we can compare it
+    // with the latest table schema in Delta logs and fail the query if it was changed.
+    // TODO Investigate if we can get the table schema without manually storing it in the table
+    // property.
+    val cols = tbl.getSd.getCols
+    val columnNames = new java.util.ArrayList[String](cols.size)
+    val columnTypes = new java.util.ArrayList[TypeInfo](cols.size)
+    cols.asScala.foreach { col =>
+      columnNames.add(col.getName)
+      columnTypes.add(TypeInfoUtils.getTypeInfoFromTypeString(col.getType))
+    }
+    val hiveSchema = TypeInfoFactory.getStructTypeInfo(columnNames, columnTypes)
+      .asInstanceOf[StructTypeInfo]
+    DeltaHelper.checkTableSchema(snapshot.metadata.schema, hiveSchema)
+    tbl.getParameters.put(DELTA_TABLE_PATH, deltaRootString)
+    tbl.getParameters.put(DELTA_TABLE_SCHEMA, hiveSchema.toString)
+    tbl.getParameters.put("spark.sql.sources.provider", "DELTA")
   }
 
   override def rollbackCreateTable(table: Table): Unit = {
-    // TODO What should we do?
+    // We don't change the Delta table on the file system. Nothing to do
   }
 
   override def commitCreateTable(table: Table): Unit = {
-    // TODO What should we do?
+    // Nothing to do
   }
 
   override def preDropTable(table: Table): Unit = {
-    // TODO What should we do?
+    // Nothing to do
   }
 
   override def rollbackDropTable(table: Table): Unit = {
-    // TODO What should we do?
+    // Nothing to do
   }
 
   override def commitDropTable(table: Table, b: Boolean): Unit = {
-    // TODO What should we do?
+    // Nothing to do
   }
 }
 
 object DeltaStorageHandler {
+  /**
+   * The Delta table path we store in the table properties and it's also passed into `JobConf` so
+   * that `DeltaLog` can be accessed everywhere.
+   */
   val DELTA_TABLE_PATH = "delta.table.path"
-  val DELTA_PARTITION_COLS_NAMES = "delta.partition.columns"
-  val DELTA_PARTITION_COLS_TYPES = "delta.partition.columns.types"
+
+  /**
+   * A config we use to remember the table schema in the table properties.
+   *
+   * TODO Maybe Hive can tell us this in the `configureInputJobProperties` method. Then we don't
+   * * need to store this extra information.
+   */
+  val DELTA_TABLE_SCHEMA = "delta.table.schema"
 }

--- a/hive/src/main/scala/io/delta/hive/DeltaStorageHandler.scala
+++ b/hive/src/main/scala/io/delta/hive/DeltaStorageHandler.scala
@@ -144,7 +144,7 @@ class DeltaStorageHandler extends DefaultStorageHandler with HiveMetaHook with H
       throw new MetaException("table location should be set when creating a Delta table")
     }
 
-    val snapshot = DeltaHelper.loadDeltaLog(new Path(deltaRootString)).snapshot
+    val snapshot = DeltaHelper.loadDeltaLatestSnapshot(new Path(deltaRootString))
     if (snapshot.version < 0) {
       throw new MetaException(s"$deltaRootString does not exist or it's not a Delta table")
     }

--- a/hive/src/main/scala/io/delta/hive/PartitionColumnInfo.scala
+++ b/hive/src/main/scala/io/delta/hive/PartitionColumnInfo.scala
@@ -1,0 +1,33 @@
+package io.delta.hive
+
+import java.io.{DataInput, DataOutput}
+
+import org.apache.hadoop.io.Writable
+
+/**
+ * @param index the index of a partition column in the schema.
+ * @param tpe the Hive type of a partition column.
+ * @param value the string value of a partition column. The actual partition value should be
+ *              parsed according to its type.
+ */
+case class PartitionColumnInfo(
+    var index: Int,
+    var tpe: String,
+    var value: String) extends Writable {
+
+  def this() {
+    this(0, null, null)
+  }
+
+  override def write(out: DataOutput): Unit = {
+    out.writeInt(index)
+    out.writeUTF(tpe)
+    out.writeUTF(value)
+  }
+
+  override def readFields(in: DataInput): Unit = {
+    index = in.readInt()
+    tpe = in.readUTF()
+    value = in.readUTF()
+  }
+}

--- a/hive/src/main/scala/org/apache/spark/sql/delta/DeltaHelper.scala
+++ b/hive/src/main/scala/org/apache/spark/sql/delta/DeltaHelper.scala
@@ -3,21 +3,22 @@ package org.apache.spark.sql.delta
 import java.net.URI
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ArrayBuffer
-
-import io.delta.hive.DeltaStorageHandler
+import scala.collection.mutable
+import io.delta.hive.{DeltaStorageHandler, PartitionColumnInfo}
 import org.apache.hadoop.fs._
 import org.apache.hadoop.hive.metastore.api.{FieldSchema, MetaException}
 import org.apache.hadoop.hive.ql.plan.TableScanDesc
+import org.apache.hadoop.hive.serde2.typeinfo._
 import org.apache.hadoop.mapred.JobConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.actions.{AddFile, SingleAction}
+import org.apache.spark.sql.types._
 
 object DeltaHelper extends Logging {
 
   def parsePathPartition(path: Path, partitionCols: Seq[String]): Map[String, String] = {
-    val columns = ArrayBuffer.empty[(String, String)]
+    val columns = mutable.ArrayBuffer.empty[(String, String)]
     // Old Hadoop versions don't have `Path.isRoot`
     var finished = path.getParent == null
     // currentPath is the current path that we will use to parse partition column value.
@@ -67,7 +68,16 @@ object DeltaHelper extends Logging {
     }
   }
 
-  def listDeltaFiles(nonNormalizedPath: Path, job: JobConf): Array[FileStatus] = {
+  /**
+   * List the file paths in the Delta table. The provided `JobConf` may consider pushed partition
+   * filters to do the partition pruning.
+   *
+   * The return value has two parts: all of the files matching the pushed partition filter and the
+   * mapping from file path to its partition information.
+   */
+  def listDeltaFiles(
+      nonNormalizedPath: Path,
+      job: JobConf): (Array[FileStatus], Map[URI, Array[PartitionColumnInfo]]) = {
     val fs = nonNormalizedPath.getFileSystem(job)
     // We need to normalize the table path so that all paths we return to Hive will be normalized
     // This is necessary because `HiveInputFormat.pushProjectionsAndFilters` will try to figure out
@@ -77,13 +87,18 @@ object DeltaHelper extends Logging {
     // `pushProjectionsAndFilters` doesn't find a table for a Delta split path.
     val rootPath = fs.makeQualified(nonNormalizedPath)
     val deltaLog = DeltaLog.forTable(spark, rootPath)
-    // get the snapshot of the version
     val snapshotToUse = deltaLog.snapshot
 
-    // TODO Verify the table schema is consistent with `snapshotToUse.metadata`.
+    val hiveSchema = TypeInfoUtils.getTypeInfoFromTypeString(
+      job.get(DeltaStorageHandler.DELTA_TABLE_SCHEMA)).asInstanceOf[StructTypeInfo]
+    DeltaHelper.checkTableSchema(snapshotToUse.metadata.schema, hiveSchema)
 
     // get the partition prune exprs
     val filterExprSerialized = job.get(TableScanDesc.FILTER_EXPR_CONF_STR)
+
+    // TODO Check whether valid types of a partition column in Spark can still be used in Hive.
+    // TODO Verify the partition columns are not changed so that the pushed filters are still
+    // correct. E.g., verify the filters are all partition filters.
 
     val convertedFilterExpr = DeltaPushFilter.partitionFilterConverter(filterExprSerialized)
 
@@ -92,14 +107,29 @@ object DeltaHelper extends Logging {
     // which is usually the best split size for parquet files.
     val blockSize = job.getLong("parquet.block.size", 128L * 1024 * 1024)
 
+    val localFileToPartition = mutable.Map[URI, Array[PartitionColumnInfo]]()
+
+    val partitionColumns = snapshotToUse.metadata.partitionColumns.toSet
+    val partitionColumnWithIndex = snapshotToUse.metadata.schema.zipWithIndex
+      .filter { case (t, _) =>
+        partitionColumns.contains(t.name)
+      }.sortBy(_._2).toArray
+
     // selected files to Hive to be processed
-    DeltaLog.filterFileList(
+    val files = DeltaLog.filterFileList(
       snapshotToUse.metadata.partitionColumns, snapshotToUse.allFiles.toDF(), convertedFilterExpr)
       .as[AddFile](SingleAction.addFileEncoder)
       .collect().map { f =>
         logInfo(s"selected delta file ${f.path} under $rootPath")
-        toFileStatus(fs, rootPath, f, blockSize)
+        val status = toFileStatus(fs, rootPath, f, blockSize)
+        localFileToPartition += status.getPath.toUri -> partitionColumnWithIndex.map { case (t, index) =>
+            // TODO Is `catalogString` always correct? We may need to add our own conversion rather
+            // than relying on Spark.
+            new PartitionColumnInfo(index, t.dataType.catalogString, f.partitionValues(t.name))
+          }
+        status
       }
+    (files, localFileToPartition.toMap)
   }
 
   /**
@@ -150,35 +180,100 @@ object DeltaHelper extends Logging {
     }
   }
 
-  def checkHiveColsInDelta(
-      rootPath: Path,
-      hiveSchema: java.util.List[FieldSchema]): Map[String, String] = {
-    val deltaMeta = DeltaLog.forTable(spark, rootPath).snapshot.metadata
-    assert(hiveSchema.size() == deltaMeta.schema.size,
-      s"Hive cols(${hiveSchema.asScala.map(_.getName).mkString(",")}) number does not match " +
-        s"Delta cols(${deltaMeta.schema.map(_.name).mkString(",")})")
-
-    assert(hiveSchema.asScala.forall(h => deltaMeta.schema.exists(_.name == h.getName)),
-      s"Hive cols(${hiveSchema.asScala.map(_.getName).mkString(",")}) name does not match " +
-        s"Delta cols(${deltaMeta.schema.map(_.name).mkString(",")})")
-
-    val (ds, ps) = hiveSchema.asScala.splitAt(hiveSchema.size() - deltaMeta.partitionColumns.size)
-
-    if (ds.forall(s => deltaMeta.dataSchema.exists(_.name == s.getName))
-      && ps.forall(s => deltaMeta.partitionColumns.contains(s.getName))) {
-      Map(DeltaStorageHandler.DELTA_PARTITION_COLS_NAMES -> ps.map(_.getName).mkString(","),
-        DeltaStorageHandler.DELTA_PARTITION_COLS_TYPES -> ps.map(_.getType).mkString(":"))
-    } else {
-      throw new MetaException(s"The partition cols of Delta should be after data cols " +
-        s"when creating hive table. Delta dataschema is " +
-        s"${deltaMeta.dataSchema.json} and partitionschema is ${deltaMeta.partitionSchema.json}")
-    }
-  }
-
   def getPartitionCols(rootPath: Path): Seq[String] = {
     DeltaLog.forTable(spark, rootPath).snapshot.metadata.partitionColumns
   }
 
+  def loadDeltaLog(rootPath: Path): DeltaLog = {
+    DeltaLog.forTable(spark, rootPath)
+  }
+
+  /**
+   * Verify the underlying Delta table schema is the same as the Hive schema defined in metastore.
+   */
+  def checkTableSchema(deltaSchema: StructType, hiveSchema: StructTypeInfo): Unit = {
+    // TODO How to check column nullables?
+    if (!isSameStructType(deltaSchema, hiveSchema)) {
+      throw metaInconsistencyException(deltaSchema, hiveSchema)
+    }
+  }
+
+  private def isSameStructType(sparkStruct: StructType, hiveStruct: StructTypeInfo): Boolean = {
+    if (sparkStruct.size == hiveStruct.getAllStructFieldNames.size) {
+      (0 until sparkStruct.size).forall { i =>
+        val sparkField = sparkStruct(i)
+        val hiveFieldName = hiveStruct.getAllStructFieldNames.get(i)
+        val hiveFieldType = hiveStruct.getAllStructFieldTypeInfos.get(i)
+        // TODO Do we need to respect case insensitive config?
+        sparkField.name == hiveFieldName && isSameType(sparkField.dataType, hiveFieldType)
+      }
+    } else {
+      false
+    }
+  }
+
+  private def isSameType(sparkType: DataType, hiveType: TypeInfo): Boolean = {
+    sparkType match {
+      case ByteType => hiveType == TypeInfoFactory.byteTypeInfo
+      case BinaryType => hiveType == TypeInfoFactory.binaryTypeInfo
+      case BooleanType => hiveType == TypeInfoFactory.booleanTypeInfo
+      case IntegerType => hiveType == TypeInfoFactory.intTypeInfo
+      case LongType => hiveType == TypeInfoFactory.longTypeInfo
+      case StringType => hiveType == TypeInfoFactory.stringTypeInfo
+      case FloatType => hiveType == TypeInfoFactory.floatTypeInfo
+      case DoubleType => hiveType == TypeInfoFactory.doubleTypeInfo
+      case ShortType => hiveType == TypeInfoFactory.shortTypeInfo
+      case DateType => hiveType == TypeInfoFactory.dateTypeInfo
+      case TimestampType => hiveType == TypeInfoFactory.timestampTypeInfo
+      case decimalType: DecimalType =>
+        hiveType match {
+          case hiveDecimalType: DecimalTypeInfo =>
+            decimalType.precision == hiveDecimalType.precision() &&
+              decimalType.scale == hiveDecimalType.scale()
+          case _ => false
+        }
+      case arrayType: ArrayType =>
+        hiveType match {
+          case hiveListType: ListTypeInfo =>
+            isSameType(arrayType.elementType, hiveListType.getListElementTypeInfo)
+          case _ => false
+        }
+      case mapType: MapType =>
+        hiveType match {
+          case hiveMapType: MapTypeInfo =>
+            isSameType(mapType.keyType, hiveMapType.getMapKeyTypeInfo) &&
+              isSameType(mapType.valueType, hiveMapType.getMapValueTypeInfo)
+          case _ => false
+        }
+      case structType: StructType =>
+        hiveType match {
+          case hiveStructType: StructTypeInfo => isSameStructType(structType, hiveStructType)
+          case _ => false
+        }
+      case _ =>
+        // TODO More Hive types:
+        //  - void
+        //  - char
+        //  - varchar
+        //  - intervalYearMonthType
+        //  - intervalDayTimeType
+        //  - UnionType
+        //  - Others?
+        throw new UnsupportedOperationException(s"Spark type $sparkType is not supported Hive")
+    }
+  }
+
+  private def metaInconsistencyException(
+      deltaSchema: StructType,
+      hiveSchema: StructTypeInfo): MetaException = {
+    new MetaException(
+      s"""The Delta table schema is not the same as the Hive schema. Please update your Hive
+         |table's schema to match the Delta table schema.
+         |Delta table schema: $deltaSchema
+         |Hive schema: $hiveSchema""".stripMargin)
+  }
+
+  // TODO Configure `spark` to pick up the right Hadoop configuration.
   def spark: SparkSession = SparkSession.builder()
     .master("local[*]")
     .appName("HiveOnDelta Get Files")

--- a/hive/src/test/scala/io/delta/hive/HiveConnectorSuite.scala
+++ b/hive/src/test/scala/io/delta/hive/HiveConnectorSuite.scala
@@ -39,8 +39,8 @@ class HiveConnectorSuite extends HiveTest with BeforeAndAfterEach {
              |stored by 'io.delta.hive.DeltaStorageHandler'
          """.stripMargin
         )
-      }.getMessage
-      assert(e.contains("table location should be set when creating table"))
+      }
+      assert(e.getMessage.contains("table location should be set"))
     }
   }
 
@@ -82,45 +82,33 @@ class HiveConnectorSuite extends HiveTest with BeforeAndAfterEach {
     }
   }
 
-  test("the delta root path should be existed when create hive table") {
+  test("the table path should point to a Delta table") {
     withTable("deltaTbl") {
       withTempDir { dir =>
-        JavaUtils.deleteRecursively(dir)
-
-        val e = intercept[Exception] {
+        // path exists but is not a Delta table should fail
+        assert(dir.exists())
+        var e = intercept[Exception] {
           runQuery(
             s"""
                |create external table deltaTbl(a string, b int)
                |stored by 'io.delta.hive.DeltaStorageHandler' location '${dir.getCanonicalPath}'
          """.stripMargin
           )
-        }.getMessage
-        assert(e.contains(s"delta.table.path(${dir.getCanonicalPath}) does not exist..."))
-      }
-    }
-  }
-
-  test("when creating hive table on a partitioned delta, " +
-    "the partition columns should be after data columns") {
-    withTable("deltaTbl") {
-      withTempDir { dir =>
-        val testData = (0 until 10).map(x => (x, s"foo${x % 2}"))
-
-        withSparkSession { spark =>
-          import spark.implicits._
-          testData.toDS.toDF("a", "b").write.format("delta")
-            .partitionBy("b").save(dir.getCanonicalPath)
         }
+        assert(e.getMessage.contains("not a Delta table"))
 
-        val e = intercept[Exception] {
+        // path doesn't exist should fail as well
+        JavaUtils.deleteRecursively(dir)
+        assert(!dir.exists())
+        e = intercept[Exception] {
           runQuery(
             s"""
-               |create external table deltaTbl(b string, a string)
+               |create external table deltaTbl(a string, b int)
                |stored by 'io.delta.hive.DeltaStorageHandler' location '${dir.getCanonicalPath}'
          """.stripMargin
           )
-        }.getMessage
-        assert(e.contains(s"The partition cols of Delta should be after data cols"))
+        }
+        assert(e.getMessage.contains("does not exist"))
       }
     }
   }
@@ -139,26 +127,26 @@ class HiveConnectorSuite extends HiveTest with BeforeAndAfterEach {
         }
 
         // column number mismatch
-        val e1 = intercept[Exception] {
+        var e = intercept[Exception] {
           runQuery(
             s"""
                |create external table deltaTbl(a string, b string)
                |stored by 'io.delta.hive.DeltaStorageHandler' location '${dir.getCanonicalPath}'
          """.stripMargin
           )
-        }.getMessage
-        assert(e1.contains(s"number does not match"))
+        }
+        assert(e.getMessage.contains(s"schema is not the same"))
 
         // column name mismatch
-        val e2 = intercept[Exception] {
+        e = intercept[Exception] {
           runQuery(
             s"""
                |create external table deltaTbl(e string, c string, b string)
                |stored by 'io.delta.hive.DeltaStorageHandler' location '${dir.getCanonicalPath}'
          """.stripMargin
           )
-        }.getMessage
-        assert(e2.contains(s"name does not match"))
+        }
+        assert(e.getMessage.contains(s"schema is not the same"))
       }
     }
   }
@@ -181,9 +169,7 @@ class HiveConnectorSuite extends HiveTest with BeforeAndAfterEach {
          """.stripMargin
         )
 
-        assert(runQuery(
-          "select * from deltaNonPartitionTbl").sorted ===
-          testData.map(r => s"${r._1}\t${r._2}").sorted)
+        checkAnswer("select * from deltaNonPartitionTbl", testData)
       }
     }
   }
@@ -207,18 +193,14 @@ class HiveConnectorSuite extends HiveTest with BeforeAndAfterEach {
          """.stripMargin
         )
 
-        assert(runQuery(
-          "select * from deltaPartitionTbl").sorted ===
-          testData.map(r => s"${r._1}\t${r._2}").sorted)
+        checkAnswer("select * from deltaPartitionTbl", testData)
 
         // select partition column order change
-        assert(runQuery(
-          "select c2, c1 from deltaPartitionTbl").sorted ===
-          testData.map(r => s"${r._2}\t${r._1}").sorted)
+        checkAnswer("select c2, c1 from deltaPartitionTbl", testData.map(_.swap))
 
-        assert(runQuery(
-          "select c2, c1, c2 as c3 from deltaPartitionTbl").sorted ===
-          testData.map(r => s"${r._2}\t${r._1}\t${r._2}").sorted)
+        checkAnswer(
+          "select c2, c1, c2 as c3 from deltaPartitionTbl",
+          testData.map(r => (r._2, r._1, r._2)))
       }
     }
   }
@@ -245,9 +227,9 @@ class HiveConnectorSuite extends HiveTest with BeforeAndAfterEach {
         // Delete the partition not needed in the below query to verify the partition pruning works
         JavaUtils.deleteRecursively(new File(dir, "c2=foo1"))
         assert(dir.listFiles.map(_.getName).sorted === Seq("_delta_log", "c2=foo0").sorted)
-        assert(runQuery(
-          "select * from deltaPartitionTbl where c2 = 'foo0'").sorted ===
-          testData.filter(_._2 == "foo0").map(r => s"${r._1}\t${r._2}").sorted)
+        checkAnswer(
+          "select * from deltaPartitionTbl where c2 = 'foo0'",
+          testData.filter(_._2 == "foo0"))
       }
     }
   }
@@ -271,7 +253,7 @@ class HiveConnectorSuite extends HiveTest with BeforeAndAfterEach {
 
         runQuery(
           s"""
-             |create external table deltaPartitionTbl(name string, cnt int, city string, `date` string)
+             |create external table deltaPartitionTbl(city string, `date` string, name string, cnt int)
              |stored by 'io.delta.hive.DeltaStorageHandler' location '${dir.getCanonicalPath}'
          """.stripMargin
         )
@@ -280,87 +262,76 @@ class HiveConnectorSuite extends HiveTest with BeforeAndAfterEach {
         assert(runQuery(
           "explain select city, `date`, name, cnt from deltaPartitionTbl where `date` = '20180520'")
           .mkString(" ").contains("filterExpr: (date = '20180520')"))
-        assert(runQuery(
-          "select city, `date`, name, cnt from deltaPartitionTbl where `date` = '20180520'")
-          .toList.sorted === testData.filter(_._2 == "20180520")
-          .map(r => s"${r._1}\t${r._2}\t${r._3}\t${r._4}").sorted)
+        checkAnswer(
+          "select city, `date`, name, cnt from deltaPartitionTbl where `date` = '20180520'",
+          testData.filter(_._2 == "20180520"))
 
         assert(runQuery(
           "explain select city, `date`, name, cnt from deltaPartitionTbl where `date` != '20180520'")
           .mkString(" ").contains("filterExpr: (date <> '20180520')"))
-        assert(runQuery(
-          "select city, `date`, name, cnt from deltaPartitionTbl where `date` != '20180520'")
-          .toList.sorted === testData.filter(_._2 != "20180520")
-          .map(r => s"${r._1}\t${r._2}\t${r._3}\t${r._4}").sorted)
+        checkAnswer(
+          "select city, `date`, name, cnt from deltaPartitionTbl where `date` != '20180520'",
+          testData.filter(_._2 != "20180520"))
 
         assert(runQuery(
           "explain select city, `date`, name, cnt from deltaPartitionTbl where `date` > '20180520'")
           .mkString(" ").contains("filterExpr: (date > '20180520')"))
-        assert(runQuery(
-          "select city, `date`, name, cnt from deltaPartitionTbl where `date` > '20180520'")
-          .toList.sorted === testData.filter(_._2 > "20180520")
-          .map(r => s"${r._1}\t${r._2}\t${r._3}\t${r._4}").sorted)
+        checkAnswer(
+          "select city, `date`, name, cnt from deltaPartitionTbl where `date` > '20180520'",
+          testData.filter(_._2 > "20180520"))
 
         assert(runQuery(
           "explain select city, `date`, name, cnt from deltaPartitionTbl where `date` >= '20180520'")
           .mkString(" ").contains("filterExpr: (date >= '20180520')"))
-        assert(runQuery(
-          "select city, `date`, name, cnt from deltaPartitionTbl where `date` >= '20180520'")
-          .toList.sorted === testData.filter(_._2 >= "20180520")
-          .map(r => s"${r._1}\t${r._2}\t${r._3}\t${r._4}").sorted)
+        checkAnswer(
+          "select city, `date`, name, cnt from deltaPartitionTbl where `date` >= '20180520'",
+          testData.filter(_._2 >= "20180520"))
 
         assert(runQuery(
           "explain select city, `date`, name, cnt from deltaPartitionTbl where `date` < '20180520'")
           .mkString(" ").contains("filterExpr: (date < '20180520')"))
-        assert(runQuery(
-          "select city, `date`, name, cnt from deltaPartitionTbl where `date` < '20180520'")
-          .toList.sorted === testData.filter(_._2 < "20180520")
-          .map(r => s"${r._1}\t${r._2}\t${r._3}\t${r._4}").sorted)
+        checkAnswer(
+          "select city, `date`, name, cnt from deltaPartitionTbl where `date` < '20180520'",
+          testData.filter(_._2 < "20180520"))
 
         assert(runQuery(
           "explain select city, `date`, name, cnt from deltaPartitionTbl where `date` <= '20180520'")
           .mkString(" ").contains("filterExpr: (date <= '20180520')"))
-        assert(runQuery(
-          "select city, `date`, name, cnt from deltaPartitionTbl where `date` <= '20180520'")
-          .toList.sorted === testData.filter(_._2 <= "20180520")
-          .map(r => s"${r._1}\t${r._2}\t${r._3}\t${r._4}").sorted)
+        checkAnswer(
+          "select city, `date`, name, cnt from deltaPartitionTbl where `date` <= '20180520'",
+          testData.filter(_._2 <= "20180520"))
 
         // expr(like) pushed down
         assert(runQuery(
           "explain select * from deltaPartitionTbl where `date` like '201805%'")
           .mkString(" ").contains("filterExpr: (date like '201805%')"))
-        assert(runQuery(
-          "select * from deltaPartitionTbl where `date` like '201805%'").toList.sorted === testData
-          .filter(_._2.contains("201805")).map(r => s"${r._3}\t${r._4}\t${r._1}\t${r._2}").sorted)
+        checkAnswer(
+          "select * from deltaPartitionTbl where `date` like '201805%'",
+          testData.filter(_._2.contains("201805")))
 
         // expr(in) pushed down
         assert(runQuery(
           "explain select name, `date`, cnt from deltaPartitionTbl where `city` in ('hz', 'sz')")
           .mkString(" ").contains("filterExpr: (city) IN ('hz', 'sz')"))
-        assert(runQuery(
-          "select name, `date`, cnt from deltaPartitionTbl where `city` in ('hz', 'sz')")
-          .toList.sorted === testData.filter(c => Seq("hz", "sz").contains(c._1))
-          .map(r => s"${r._3}\t${r._2}\t${r._4}").sorted)
+        checkAnswer(
+          "select name, `date`, cnt from deltaPartitionTbl where `city` in ('hz', 'sz')",
+          testData.filter(c => Seq("hz", "sz").contains(c._1)).map(r => (r._3, r._2, r._4)))
 
         // two partition column pushed down
         assert(runQuery(
           "explain select * from deltaPartitionTbl where `date` = '20181212' and `city` in ('hz', 'sz')")
           .mkString(" ").contains("filterExpr: ((city) IN ('hz', 'sz') and (date = '20181212'))"))
-        assert(runQuery(
-          "select * from deltaPartitionTbl where `date` = '20181212' and `city` in ('hz', 'sz')")
-          .toList.sorted === testData
-          .filter(c => Seq("hz", "sz").contains(c._1) && c._2 == "20181212")
-          .map(r => s"${r._3}\t${r._4}\t${r._1}\t${r._2}").sorted)
+        checkAnswer(
+          "select * from deltaPartitionTbl where `date` = '20181212' and `city` in ('hz', 'sz')",
+          testData.filter(c => Seq("hz", "sz").contains(c._1) && c._2 == "20181212"))
 
         // data column not be pushed down
         assert(runQuery(
           "explain select * from deltaPartitionTbl where city = 'hz' and name = 'Jim'")
           .mkString(" ").contains("filterExpr: (city = 'hz'"))
-        assert(runQuery(
-          "select * from deltaPartitionTbl where city = 'hz' and name = 'Jim'")
-          .toList.sorted === testData
-          .filter(c => c._1 == "hz" && c._3 == "Jim")
-          .map(r => s"${r._3}\t${r._4}\t${r._1}\t${r._2}").sorted)
+        checkAnswer(
+          "select * from deltaPartitionTbl where city = 'hz' and name = 'Jim'",
+          testData.filter(c => c._1 == "hz" && c._3 == "Jim"))
       }
     }
   }
@@ -380,30 +351,24 @@ class HiveConnectorSuite extends HiveTest with BeforeAndAfterEach {
 
           runQuery(
             s"""
-               |create external table deltaPartitionTbl(name string, cnt int, city string, `date` string)
+               |create external table deltaPartitionTbl(city string, `date` string, name string, cnt int)
                |stored by 'io.delta.hive.DeltaStorageHandler' location '${dir.getCanonicalPath}'
          """.stripMargin
           )
 
-          assert(runQuery(
-            "select * from deltaPartitionTbl").toList.sorted === testData1
-            .map(r => s"${r._3}\t${r._4}\t${r._1}\t${r._2}").sorted)
+          checkAnswer("select * from deltaPartitionTbl", testData1)
 
           // insert another partition data
           val testData2 = Seq(("bj", "20180520", "Trump", 1))
           testData2.toDS.toDF("city", "date", "name", "cnt").write.mode("append").format("delta")
             .partitionBy("date", "city").save(dir.getCanonicalPath)
           val testData = testData1 ++ testData2
-          assert(runQuery(
-            "select * from deltaPartitionTbl").toList.sorted === testData
-            .map(r => s"${r._3}\t${r._4}\t${r._1}\t${r._2}").sorted)
+          checkAnswer("select * from deltaPartitionTbl", testData)
 
           // delete one partition
           val deltaTable = DeltaTable.forPath(spark, dir.getCanonicalPath)
           deltaTable.delete("city='hz'")
-          assert(runQuery(
-            "select * from deltaPartitionTbl").toList.sorted === testData
-            .filterNot(_._1 == "hz").map(r => s"${r._3}\t${r._4}\t${r._1}\t${r._2}").sorted)
+          checkAnswer("select * from deltaPartitionTbl", testData.filterNot(_._1 == "hz"))
         }
       }
     }
@@ -427,10 +392,89 @@ class HiveConnectorSuite extends HiveTest with BeforeAndAfterEach {
          """.stripMargin
         )
 
-        // TODO Read partition values from `AddFile.partitionValues` to fix incorrect escaped
-        // partition values.
-        runQuery("select * from deltaPartitionTbl")
+        checkAnswer("select * from deltaPartitionTbl", testData)
+      }
+    }
+  }
+
+  test("map Spark types to Hive types correctly") {
+    withTable("deltaTbl") {
+      withTempDir { dir =>
+        val testData = Seq(
+          TestClass(
+            97.toByte,
+            Array(98.toByte, 99.toByte),
+            true,
+            4,
+            5L,
+            "foo",
+            6.0f,
+            7.0,
+            8.toShort,
+            new java.sql.Date(60000000L),
+            new java.sql.Timestamp(60000000L),
+            new java.math.BigDecimal(12345.6789),
+            Array("foo", "bar"),
+            Map("foo" -> 123L),
+            TestStruct("foo", 456L)
+          )
+        )
+
+        withSparkSession { spark =>
+          import spark.implicits._
+          testData.toDF.write.format("delta").save(dir.getCanonicalPath)
+        }
+
+        runQuery(
+          s"""
+             |create external table deltaTbl(
+             |c1 tinyint, c2 binary, c3 boolean, c4 int, c5 bigint, c6 string, c7 float, c8 double,
+             |c9 smallint, c10 date, c11 timestamp, c12 decimal(38, 18), c13 array<string>,
+             |c14 map<string, bigint>, c15 struct<f1: string, f2: bigint>)
+             |stored by 'io.delta.hive.DeltaStorageHandler' location '${dir.getCanonicalPath}'
+         """.stripMargin
+        )
+
+        val expected = (
+          "97",
+          "bc",
+          "true",
+          "4",
+          "5",
+          "foo",
+          "6.0",
+          "7.0",
+          "8",
+          "1970-01-01",
+          "1970-01-01 08:40:00",
+          "12345.678900000000794535",
+          """["foo","bar"]""",
+          """{"foo":123}""",
+          """{"f1":"foo","f2":456}"""
+        )
+        checkAnswer("select * from deltaTbl", Seq(expected))
       }
     }
   }
 }
+
+case class TestStruct(f1: String, f2: Long)
+
+/** A special test class that covers all Spark types we support in the Hive connector. */
+case class TestClass(
+  c1: Byte,
+  c2: Array[Byte],
+  c3: Boolean,
+  c4: Int,
+  c5: Long,
+  c6: String,
+  c7: Float,
+  c8: Double,
+  c9: Short,
+  c10: java.sql.Date,
+  c11: java.sql.Timestamp,
+  c12: BigDecimal,
+  c13: Array[String],
+  c14: Map[String, Long],
+  c15: TestStruct
+)


### PR DESCRIPTION
Right now we require the partition columns should be after the data columns.

This PR adds a new DeltaInputSplit to remove the above limitation and also adds validation to ensure Hive's schema is always consistent with Delta's metadata regarding column types and order.