### PR TITLE
Optimize the connector memory usage

### DIFF
--- a/hive/src/main/scala/org/apache/spark/sql/delta/DeltaHelper.scala
+++ b/hive/src/main/scala/org/apache/spark/sql/delta/DeltaHelper.scala
@@ -268,11 +268,14 @@ object DeltaHelper extends Logging {
   /**
    * Start a special Spark cluster using local mode to process Delta's metadata. The Spark UI has
    * been disabled and `SparkListener`s have been removed to reduce the memory usage of Spark.
-   * `DeltaLog` cache size is also set to "1" to cache only the recent accessed `DeltaLog`.
+   * `DeltaLog` cache size is also set to "1" if the user doesn't specify it, to cache only the
+   * recent accessed `DeltaLog`.
    */
   def spark: SparkSession = {
     // TODO Configure `spark` to pick up the right Hadoop configuration.
-    System.setProperty("delta.log.cacheSize", "1")
+    if (System.getProperty("delta.log.cacheSize") == null) {
+      System.setProperty("delta.log.cacheSize", "1")
+    }
     val sparkSession = SparkSession.builder()
       .master("local[*]")
       .appName("Delta Connector")

--- a/hive/src/main/scala/org/apache/spark/sql/delta/DeltaHelper.scala
+++ b/hive/src/main/scala/org/apache/spark/sql/delta/DeltaHelper.scala
@@ -97,6 +97,8 @@ object DeltaHelper extends Logging {
     val files = DeltaLog.filterFileList(
       snapshotToUse.metadata.partitionColumns, snapshotToUse.allFiles.toDF(), convertedFilterExpr)
       .as[AddFile](SingleAction.addFileEncoder)
+      // Drop unused potential huge fields
+      .map(add => add.copy(stats = null, tags = null))(SingleAction.addFileEncoder)
       .collect().map { f =>
         logInfo(s"selected delta file ${f.path} under $rootPath")
         val status = toFileStatus(fs, rootPath, f, blockSize)
@@ -263,9 +265,24 @@ object DeltaHelper extends Logging {
          |${hiveSchemaString}""".stripMargin)
   }
 
-  // TODO Configure `spark` to pick up the right Hadoop configuration.
-  def spark: SparkSession = SparkSession.builder()
-    .master("local[*]")
-    .appName("HiveOnDelta Get Files")
-    .getOrCreate()
+  /**
+   * Start a special Spark cluster using local mode to process Delta's metadata. The Spark UI has
+   * been disabled and `SparkListener`s have been removed to reduce the memory usage of Spark.
+   * `DeltaLog` cache size is also set to "1" to cache only the recent accessed `DeltaLog`.
+   */
+  def spark: SparkSession = {
+    // TODO Configure `spark` to pick up the right Hadoop configuration.
+    System.setProperty("delta.log.cacheSize", "1")
+    val sparkSession = SparkSession.builder()
+      .master("local[*]")
+      .appName("Delta Connector")
+      .config("spark.ui.enabled", "false")
+      .getOrCreate()
+    // Trigger codes that add `SparkListener`s before stopping the listener bus. Otherwise, they
+    // would fail to add `SparkListener`s.
+    sparkSession.sharedState
+    sparkSession.sessionState
+    sparkSession.sparkContext.listenerBus.stop()
+    sparkSession
+  }
 }

--- a/hive/src/test/scala/io/delta/hive/HiveConnectorSuite.scala
+++ b/hive/src/test/scala/io/delta/hive/HiveConnectorSuite.scala
@@ -22,18 +22,9 @@ import io.delta.hive.test.HiveTest
 import io.delta.tables.DeltaTable
 
 import org.apache.spark.network.util.JavaUtils
-import org.apache.spark.sql.delta.DeltaLog
 import org.scalatest.BeforeAndAfterEach
 
 class HiveConnectorSuite extends HiveTest with BeforeAndAfterEach {
-
-  override def beforeEach(): Unit = {
-    DeltaLog.clearCache()
-  }
-
-  override def afterEach(): Unit = {
-    DeltaLog.clearCache()
-  }
 
   test("should not allow to create a non external Delta table") {
     val e = intercept[Exception] {

--- a/hive/src/test/scala/io/delta/hive/test/HiveTest.scala
+++ b/hive/src/test/scala/io/delta/hive/test/HiveTest.scala
@@ -31,10 +31,10 @@ import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hadoop.mapred.{JobConf, MiniMRCluster}
 import org.apache.hadoop.mapreduce.MRJobConfig
 import org.apache.hadoop.yarn.conf.YarnConfiguration
-import org.apache.spark.SparkConf
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.DeltaHelper
 // scalastyle:off funsuite
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
@@ -160,12 +160,7 @@ trait HiveTest extends FunSuite with BeforeAndAfterAll {
   }
 
   protected def withSparkSession(f: SparkSession => Unit): Unit = {
-    val conf = new SparkConf()
-    val spark = SparkSession.builder()
-      .appName("HiveConnectorSuite")
-      .master("local[2]")
-      .getOrCreate()
-
+    val spark = DeltaHelper.spark
     try f(spark) finally {
       // Clean up resources so that we can use new DeltaLog and SparkSession
       spark.stop()


### PR DESCRIPTION
- Disable Spark UI and remove `SparkListener`s to reduce the memory usage of Spark. They are unnecessary for the Spark cluster in connector.
- Set the `DeltaLog` cache size to 1 if the user doesn't specify it to avoid caching lots of `DeltaLog` objects.