### PR TITLE
Fail incorrect format and throw an error rather then returning NULL values

### DIFF
--- a/hive/src/test/scala/io/delta/hive/test/HiveTest.scala
+++ b/hive/src/test/scala/io/delta/hive/test/HiveTest.scala
@@ -176,4 +176,21 @@ trait HiveTest extends FunSuite with BeforeAndAfterAll {
       DeltaLog.clearCache()
     }
   }
+
+  protected def withHiveConf(key: String, value: String)(body: => Unit): Unit = {
+    val hiveConfField = driver.getClass.getDeclaredField("conf")
+    hiveConfField.setAccessible(true)
+    val hiveConf = hiveConfField.get(driver).asInstanceOf[HiveConf]
+    val original = hiveConf.get(key)
+    try {
+      hiveConf.set(key, value)
+      body
+    } finally {
+      if (original == null) {
+        hiveConf.unset(key)
+      } else {
+        hiveConf.set(key, original)
+      }
+    }
+  }
 }


### PR DESCRIPTION
When a user doesn't set the input format to `io.delta.hive.HiveInputFormat`, we will return NULL values right now. This is pretty bad as the user may not notice it. It's better to throw an error when the input format is not set.