### PR TITLE
Fix the broken Tez tests due to incompatible parquet version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
             build/sbt "++ 2.12.8 standalone/test"
             build/sbt "++ 2.12.8 hive/test"
             build/sbt "++ 2.12.8 hiveMR/test"
+            build/sbt "++ 2.12.8 hiveTez/test"
             build/sbt "++ 2.11.12 standalone/test"
             build/sbt "++ 2.11.12 hive/test"
             build/sbt "++ 2.11.12 hiveMR/test"
+            build/sbt "++ 2.11.12 hiveTez/test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,4 @@ jobs:
       - run:
           name: Run tests 
           command: |
-            build/sbt "++ 2.12.8 standalone/test"
-            build/sbt "++ 2.12.8 hive/test"
-            build/sbt "++ 2.12.8 hiveMR/test"
             build/sbt "++ 2.12.8 hiveTez/test"
-            build/sbt "++ 2.11.12 standalone/test"
-            build/sbt "++ 2.11.12 hive/test"
-            build/sbt "++ 2.11.12 hiveMR/test"
-            build/sbt "++ 2.11.12 hiveTez/test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,3 +9,4 @@ jobs:
           name: Run tests 
           command: |
             build/sbt "++ 2.12.8 hiveTez/test"
+            build/sbt "++ 2.11.12 hiveTez/test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,5 +8,11 @@ jobs:
       - run:
           name: Run tests 
           command: |
+            build/sbt "++ 2.12.8 standalone/test"
+            build/sbt "++ 2.12.8 hive/test"
+            build/sbt "++ 2.12.8 hiveMR/test"
             build/sbt "++ 2.12.8 hiveTez/test"
+            build/sbt "++ 2.11.12 standalone/test"
+            build/sbt "++ 2.11.12 hive/test"
+            build/sbt "++ 2.11.12 hiveMR/test"
             build/sbt "++ 2.11.12 hiveTez/test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,4 +8,11 @@ jobs:
       - run:
           name: Run tests 
           command: |
+            build/sbt "++ 2.12.8 standalone/test"
+            build/sbt "++ 2.12.8 hive/test"
+            build/sbt "++ 2.12.8 hiveMR/test"
             build/sbt "++ 2.12.8 hiveTez/test"
+            build/sbt "++ 2.11.12 standalone/test"
+            build/sbt "++ 2.11.12 hive/test"
+            build/sbt "++ 2.11.12 hiveMR/test"
+            build/sbt "++ 2.11.12 hiveTez/test"

--- a/build.sbt
+++ b/build.sbt
@@ -133,7 +133,11 @@ lazy val hiveTez = (project in file("hive-tez")) dependsOn(hive % "test->test") 
       ExclusionRule(organization = "com.google.protobuf")
     ),
     "org.jodd" % "jodd-core" % "3.5.2",
-    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided",
+    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided" excludeAll(
+      ExclusionRule(organization = "org.apache.spark"),
+      ExclusionRule(organization = "org.apache.parquet"),
+      ExclusionRule("org.apache.hive", "hive-exec")
+    ),
     "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "test" classifier "tests",
     "org.apache.hadoop" % "hadoop-mapreduce-client-hs" % hadoopVersion % "test",
     "org.apache.hadoop" % "hadoop-mapreduce-client-jobclient" % hadoopVersion % "test" classifier "tests",

--- a/build.sbt
+++ b/build.sbt
@@ -189,18 +189,14 @@ lazy val standalone = (project in file("standalone")) settings (
   unmanagedResourceDirectories in Test += file("golden-tables/src/test/resources"),
   libraryDependencies ++= Seq(
     "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
-    "org.apache.parquet" % "parquet-hadoop" % "1.10.1" excludeAll(
-      ExclusionRule("org.apache.hadoop", "hadoop-client")
-      ),
-    "com.github.mjakubowski84" %% "parquet4s-core" % "1.2.1" excludeAll(
-      ExclusionRule("org.apache.parquet", "parquet-hadoop")
-      ),
+    "org.apache.parquet" % "parquet-hadoop" % "1.10.1" % "provided",
+    "com.github.mjakubowski84" %% "parquet4s-core" % "1.2.1",
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7.1",
     "org.json4s" %% "json4s-jackson" % "3.5.3" excludeAll (
       ExclusionRule("com.fasterxml.jackson.core"),
       ExclusionRule("com.fasterxml.jackson.module")
     ),
-    "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.5" % "test"
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -66,10 +66,7 @@ lazy val hive = (project in file("hive")) dependsOn(standalone) settings (
     "org.apache.hive" % "hive-metastore" % hiveVersion % "provided"  excludeAll(
       ExclusionRule(organization = "org.apache.spark"),
       ExclusionRule(organization = "org.apache.parquet"),
-      ExclusionRule("ch.qos.logback", "logback-classic"),
-      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
-      ExclusionRule("org.apache.hive", "hive-exec"),
-      ExclusionRule(organization = "com.google.protobuf")
+      ExclusionRule("org.apache.hive", "hive-exec")
     ),
     "org.apache.hive" % "hive-cli" % hiveVersion % "test" excludeAll(
       ExclusionRule(organization = "org.apache.spark"),

--- a/build.sbt
+++ b/build.sbt
@@ -81,14 +81,10 @@ lazy val hive = (project in file("hive")) dependsOn(standalone) settings (
     ),
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",
     "io.delta" %% "delta-core" % deltaVersion % "test",
-    "org.apache.spark" %% "spark-sql" % sparkVersion % "test" excludeAll(
-      ExclusionRule(organization = "org.apache.hive")
-    ),
+    "org.apache.spark" %% "spark-sql" % sparkVersion % "test",
     "org.apache.spark" %% "spark-catalyst" % sparkVersion % "test" classifier "tests",
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",
-    "org.apache.spark" %% "spark-sql" % sparkVersion % "test" classifier "tests" excludeAll (
-      ExclusionRule(organization = "org.apache.hive")
-      )
+    "org.apache.spark" %% "spark-sql" % sparkVersion % "test" classifier "tests"
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ crossScalaVersions := Seq("2.12.8", "2.11.12")
 
 val sparkVersion = "2.4.3"
 val hadoopVersion = "2.7.2"
-val hiveVersion = "2.3.6"
+val hiveVersion = "2.3.7"
 val deltaVersion = "0.5.0"
 
 lazy val commonSettings = Seq(
@@ -142,8 +142,16 @@ lazy val hiveTez = (project in file("hive-tez")) dependsOn(hive % "test->test") 
     "org.apache.hadoop" % "hadoop-yarn-common" % hadoopVersion % "test",
     "org.apache.hadoop" % "hadoop-yarn-api" % hadoopVersion % "test",
     "org.apache.tez" % "tez-mapreduce" % "0.8.4" % "test",
-    "org.apache.tez" % "tez-dag" % "0.8.4" % "test",
-    "org.apache.tez" % "tez-tests" % "0.8.4" % "test" classifier "tests",
+    "org.apache.tez" % "tez-dag" % "0.8.4" % "test" excludeAll(
+      ExclusionRule(organization = "org.apache.spark"),
+      ExclusionRule(organization = "org.apache.parquet"),
+      ExclusionRule(organization = "org.apache.hive")
+    ),
+    "org.apache.tez" % "tez-tests" % "0.8.4" % "test" classifier "tests" excludeAll(
+      ExclusionRule(organization = "org.apache.spark"),
+      ExclusionRule(organization = "org.apache.parquet"),
+      ExclusionRule(organization = "org.apache.hive")
+    ),
     // TODO Figure out how this fixes some bad dependency
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -63,14 +63,7 @@ lazy val hive = (project in file("hive")) dependsOn(standalone) settings (
       ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
       ExclusionRule(organization = "com.google.protobuf")
     ),
-    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided"  excludeAll(
-      ExclusionRule(organization = "org.apache.spark"),
-      ExclusionRule(organization = "org.apache.parquet"),
-      ExclusionRule("ch.qos.logback", "logback-classic"),
-      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
-      ExclusionRule("org.apache.hive", "hive-exec"),
-      ExclusionRule(organization = "com.google.protobuf")
-    ),
+    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided",
     "org.apache.hive" % "hive-cli" % hiveVersion % "test" excludeAll(
       ExclusionRule(organization = "org.apache.spark"),
       ExclusionRule(organization = "org.apache.parquet"),
@@ -81,14 +74,10 @@ lazy val hive = (project in file("hive")) dependsOn(standalone) settings (
     ),
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",
     "io.delta" %% "delta-core" % deltaVersion % "test",
-    "org.apache.spark" %% "spark-sql" % sparkVersion % "test" excludeAll(
-      ExclusionRule(organization = "org.apache.hive")
-    ),
+    "org.apache.spark" %% "spark-sql" % sparkVersion % "test",
     "org.apache.spark" %% "spark-catalyst" % sparkVersion % "test" classifier "tests",
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",
-    "org.apache.spark" %% "spark-sql" % sparkVersion % "test" classifier "tests" excludeAll (
-      ExclusionRule(organization = "org.apache.hive")
-      )
+    "org.apache.spark" %% "spark-sql" % sparkVersion % "test" classifier "tests"
   )
 )
 
@@ -137,14 +126,7 @@ lazy val hiveTez = (project in file("hive-tez")) dependsOn(hive % "test->test") 
       ExclusionRule(organization = "com.google.protobuf")
     ),
     "org.jodd" % "jodd-core" % "3.5.2",
-    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided" excludeAll(
-      ExclusionRule(organization = "org.apache.spark"),
-      ExclusionRule(organization = "org.apache.parquet"),
-      ExclusionRule("ch.qos.logback", "logback-classic"),
-      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
-      ExclusionRule("org.apache.hive", "hive-exec"),
-      ExclusionRule(organization = "com.google.protobuf")
-    ),
+    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided",
     "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "test" classifier "tests",
     "org.apache.hadoop" % "hadoop-mapreduce-client-hs" % hadoopVersion % "test",
     "org.apache.hadoop" % "hadoop-mapreduce-client-jobclient" % hadoopVersion % "test" classifier "tests",
@@ -159,22 +141,8 @@ lazy val hiveTez = (project in file("hive-tez")) dependsOn(hive % "test->test") 
     ),
     "org.apache.hadoop" % "hadoop-yarn-common" % hadoopVersion % "test",
     "org.apache.hadoop" % "hadoop-yarn-api" % hadoopVersion % "test",
-    "org.apache.tez" % "tez-mapreduce" % "0.8.4" % "test"  excludeAll(
-      ExclusionRule(organization = "org.apache.spark"),
-      ExclusionRule(organization = "org.apache.parquet"),
-      ExclusionRule("ch.qos.logback", "logback-classic"),
-      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
-      ExclusionRule(organization = "org.apache.hive"),
-      ExclusionRule(organization = "com.google.protobuf")
-    ),
-    "org.apache.tez" % "tez-dag" % "0.8.4" % "test"  excludeAll(
-      ExclusionRule(organization = "org.apache.spark"),
-      ExclusionRule(organization = "org.apache.parquet"),
-      ExclusionRule("ch.qos.logback", "logback-classic"),
-      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
-      ExclusionRule(organization = "org.apache.hive"),
-      ExclusionRule(organization = "com.google.protobuf")
-    ),
+    "org.apache.tez" % "tez-mapreduce" % "0.8.4" % "test",
+    "org.apache.tez" % "tez-dag" % "0.8.4" % "test",
     "org.apache.tez" % "tez-tests" % "0.8.4" % "test" classifier "tests",
     // TODO Figure out how this fixes some bad dependency
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",
@@ -189,18 +157,14 @@ lazy val standalone = (project in file("standalone")) settings (
   unmanagedResourceDirectories in Test += file("golden-tables/src/test/resources"),
   libraryDependencies ++= Seq(
     "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
-    "org.apache.parquet" % "parquet-hadoop" % "1.10.1" excludeAll(
-      ExclusionRule("org.apache.hadoop", "hadoop-client")
-      ),
-    "com.github.mjakubowski84" %% "parquet4s-core" % "1.2.1" excludeAll(
-      ExclusionRule("org.apache.parquet", "parquet-hadoop")
-      ),
+    "org.apache.parquet" % "parquet-hadoop" % "1.10.1"% "provided",
+    "com.github.mjakubowski84" %% "parquet4s-core" % "1.2.1",
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7.1",
     "org.json4s" %% "json4s-jackson" % "3.5.3" excludeAll (
       ExclusionRule("com.fasterxml.jackson.core"),
       ExclusionRule("com.fasterxml.jackson.module")
     ),
-    "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.5" % "test"
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ crossScalaVersions := Seq("2.12.8", "2.11.12")
 
 val sparkVersion = "2.4.3"
 val hadoopVersion = "2.7.2"
-val hiveVersion = "2.3.3"
+val hiveVersion = "2.3.6"
 val deltaVersion = "0.5.0"
 
 lazy val commonSettings = Seq(
@@ -57,12 +57,13 @@ lazy val hive = (project in file("hive")) dependsOn(standalone) settings (
   // any runtime dependencies.
   libraryDependencies ++= Seq(
     "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
-    "org.apache.hive" % "hive-exec" % hiveVersion % "provided" excludeAll(
+    "org.apache.hive" % "hive-exec" % hiveVersion % "provided" classifier "core" excludeAll(
       ExclusionRule(organization = "org.apache.spark"),
       ExclusionRule(organization = "org.apache.parquet"),
       ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
       ExclusionRule(organization = "com.google.protobuf")
     ),
+    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided",
     "org.apache.hive" % "hive-cli" % hiveVersion % "test" excludeAll(
       ExclusionRule(organization = "org.apache.spark"),
       ExclusionRule(organization = "org.apache.parquet"),
@@ -110,19 +111,20 @@ lazy val hiveTez = (project in file("hive-tez")) dependsOn(hive % "test->test") 
   name := "hive-tez",
   commonSettings,
   libraryDependencies ++= Seq(
-    "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided"  excludeAll (
+    "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided" excludeAll (
       ExclusionRule(organization = "com.google.protobuf")
       ),
     "org.apache.parquet" % "parquet-hadoop" % "1.10.1" excludeAll(
       ExclusionRule("org.apache.hadoop", "hadoop-client")
       ),
     "com.google.protobuf" % "protobuf-java" % "2.5.0",
-    "org.apache.hive" % "hive-exec" % hiveVersion % "provided" excludeAll(
+    "org.apache.hive" % "hive-exec" % hiveVersion % "provided" classifier "core" excludeAll(
       ExclusionRule(organization = "org.apache.spark"),
       ExclusionRule(organization = "org.apache.parquet"),
       ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
       ExclusionRule(organization = "com.google.protobuf")
     ),
+    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided",
     "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "test" classifier "tests",
     "org.apache.hadoop" % "hadoop-mapreduce-client-hs" % hadoopVersion % "test",
     "org.apache.hadoop" % "hadoop-mapreduce-client-jobclient" % hadoopVersion % "test" classifier "tests",

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,14 @@ lazy val hive = (project in file("hive")) dependsOn(standalone) settings (
       ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
       ExclusionRule(organization = "com.google.protobuf")
     ),
-    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided",
+    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided"  excludeAll(
+      ExclusionRule(organization = "org.apache.spark"),
+      ExclusionRule(organization = "org.apache.parquet"),
+      ExclusionRule("ch.qos.logback", "logback-classic"),
+      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
+      ExclusionRule("org.apache.hive", "hive-exec"),
+      ExclusionRule(organization = "com.google.protobuf")
+    ),
     "org.apache.hive" % "hive-cli" % hiveVersion % "test" excludeAll(
       ExclusionRule(organization = "org.apache.spark"),
       ExclusionRule(organization = "org.apache.parquet"),
@@ -74,10 +81,14 @@ lazy val hive = (project in file("hive")) dependsOn(standalone) settings (
     ),
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",
     "io.delta" %% "delta-core" % deltaVersion % "test",
-    "org.apache.spark" %% "spark-sql" % sparkVersion % "test",
+    "org.apache.spark" %% "spark-sql" % sparkVersion % "test" excludeAll(
+      ExclusionRule(organization = "org.apache.hive")
+    ),
     "org.apache.spark" %% "spark-catalyst" % sparkVersion % "test" classifier "tests",
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",
-    "org.apache.spark" %% "spark-sql" % sparkVersion % "test" classifier "tests"
+    "org.apache.spark" %% "spark-sql" % sparkVersion % "test" classifier "tests" excludeAll (
+      ExclusionRule(organization = "org.apache.hive")
+      )
   )
 )
 
@@ -126,7 +137,14 @@ lazy val hiveTez = (project in file("hive-tez")) dependsOn(hive % "test->test") 
       ExclusionRule(organization = "com.google.protobuf")
     ),
     "org.jodd" % "jodd-core" % "3.5.2",
-    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided",
+    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided" excludeAll(
+      ExclusionRule(organization = "org.apache.spark"),
+      ExclusionRule(organization = "org.apache.parquet"),
+      ExclusionRule("ch.qos.logback", "logback-classic"),
+      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
+      ExclusionRule("org.apache.hive", "hive-exec"),
+      ExclusionRule(organization = "com.google.protobuf")
+    ),
     "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "test" classifier "tests",
     "org.apache.hadoop" % "hadoop-mapreduce-client-hs" % hadoopVersion % "test",
     "org.apache.hadoop" % "hadoop-mapreduce-client-jobclient" % hadoopVersion % "test" classifier "tests",
@@ -141,17 +159,23 @@ lazy val hiveTez = (project in file("hive-tez")) dependsOn(hive % "test->test") 
     ),
     "org.apache.hadoop" % "hadoop-yarn-common" % hadoopVersion % "test",
     "org.apache.hadoop" % "hadoop-yarn-api" % hadoopVersion % "test",
-    "org.apache.tez" % "tez-mapreduce" % "0.8.4" % "test",
-    "org.apache.tez" % "tez-dag" % "0.8.4" % "test" excludeAll(
+    "org.apache.tez" % "tez-mapreduce" % "0.8.4" % "test"  excludeAll(
       ExclusionRule(organization = "org.apache.spark"),
       ExclusionRule(organization = "org.apache.parquet"),
-      ExclusionRule(organization = "org.apache.hive")
+      ExclusionRule("ch.qos.logback", "logback-classic"),
+      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
+      ExclusionRule(organization = "org.apache.hive"),
+      ExclusionRule(organization = "com.google.protobuf")
     ),
-    "org.apache.tez" % "tez-tests" % "0.8.4" % "test" classifier "tests" excludeAll(
+    "org.apache.tez" % "tez-dag" % "0.8.4" % "test"  excludeAll(
       ExclusionRule(organization = "org.apache.spark"),
       ExclusionRule(organization = "org.apache.parquet"),
-      ExclusionRule(organization = "org.apache.hive")
+      ExclusionRule("ch.qos.logback", "logback-classic"),
+      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
+      ExclusionRule(organization = "org.apache.hive"),
+      ExclusionRule(organization = "com.google.protobuf")
     ),
+    "org.apache.tez" % "tez-tests" % "0.8.4" % "test" classifier "tests",
     // TODO Figure out how this fixes some bad dependency
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",
@@ -165,14 +189,18 @@ lazy val standalone = (project in file("standalone")) settings (
   unmanagedResourceDirectories in Test += file("golden-tables/src/test/resources"),
   libraryDependencies ++= Seq(
     "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
-    "org.apache.parquet" % "parquet-hadoop" % "1.10.1"% "provided",
-    "com.github.mjakubowski84" %% "parquet4s-core" % "1.2.1",
+    "org.apache.parquet" % "parquet-hadoop" % "1.10.1" excludeAll(
+      ExclusionRule("org.apache.hadoop", "hadoop-client")
+      ),
+    "com.github.mjakubowski84" %% "parquet4s-core" % "1.2.1" excludeAll(
+      ExclusionRule("org.apache.parquet", "parquet-hadoop")
+      ),
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7.1",
     "org.json4s" %% "json4s-jackson" % "3.5.3" excludeAll (
       ExclusionRule("com.fasterxml.jackson.core"),
       ExclusionRule("com.fasterxml.jackson.module")
     ),
-    "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.8" % "test"
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,7 @@ lazy val hive = (project in file("hive")) dependsOn(standalone) settings (
   // any runtime dependencies.
   libraryDependencies ++= Seq(
     "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
+    "org.apache.parquet" % "parquet-hadoop" % "1.10.1" % "provided",
     "org.apache.hive" % "hive-exec" % hiveVersion % "provided" classifier "core" excludeAll(
       ExclusionRule(organization = "org.apache.spark"),
       ExclusionRule(organization = "org.apache.parquet"),
@@ -166,7 +167,10 @@ lazy val standalone = (project in file("standalone")) settings (
   libraryDependencies ++= Seq(
     "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
     "org.apache.parquet" % "parquet-hadoop" % "1.10.1" % "provided",
-    "com.github.mjakubowski84" %% "parquet4s-core" % "1.2.1",
+    "com.github.mjakubowski84" %% "parquet4s-core" % "1.2.1" excludeAll (
+      ExclusionRule("org.slf4j", "slf4j-api"),
+      ExclusionRule("org.apache.parquet", "parquet-hadoop")
+    ),
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7.1",
     "org.json4s" %% "json4s-jackson" % "3.5.3" excludeAll (
       ExclusionRule("com.fasterxml.jackson.core"),

--- a/build.sbt
+++ b/build.sbt
@@ -136,6 +136,7 @@ lazy val hiveTez = (project in file("hive-tez")) dependsOn(hive % "test->test") 
       ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
       ExclusionRule(organization = "com.google.protobuf")
     ),
+    "org.jodd" % "jodd-core" % "3.5.2",
     "org.apache.hive" % "hive-metastore" % hiveVersion % "provided" excludeAll(
       ExclusionRule(organization = "org.apache.spark"),
       ExclusionRule(organization = "org.apache.parquet"),

--- a/build.sbt
+++ b/build.sbt
@@ -133,14 +133,7 @@ lazy val hiveTez = (project in file("hive-tez")) dependsOn(hive % "test->test") 
       ExclusionRule(organization = "com.google.protobuf")
     ),
     "org.jodd" % "jodd-core" % "3.5.2",
-    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided" excludeAll(
-      ExclusionRule(organization = "org.apache.spark"),
-      ExclusionRule(organization = "org.apache.parquet"),
-      ExclusionRule("ch.qos.logback", "logback-classic"),
-      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
-      ExclusionRule("org.apache.hive", "hive-exec"),
-      ExclusionRule(organization = "com.google.protobuf")
-    ),
+    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided",
     "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "test" classifier "tests",
     "org.apache.hadoop" % "hadoop-mapreduce-client-hs" % hadoopVersion % "test",
     "org.apache.hadoop" % "hadoop-mapreduce-client-jobclient" % hadoopVersion % "test" classifier "tests",

--- a/build.sbt
+++ b/build.sbt
@@ -63,20 +63,32 @@ lazy val hive = (project in file("hive")) dependsOn(standalone) settings (
       ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
       ExclusionRule(organization = "com.google.protobuf")
     ),
-    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided",
+    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided"  excludeAll(
+      ExclusionRule(organization = "org.apache.spark"),
+      ExclusionRule(organization = "org.apache.parquet"),
+      ExclusionRule("ch.qos.logback", "logback-classic"),
+      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
+      ExclusionRule("org.apache.hive", "hive-exec"),
+      ExclusionRule(organization = "com.google.protobuf")
+    ),
     "org.apache.hive" % "hive-cli" % hiveVersion % "test" excludeAll(
       ExclusionRule(organization = "org.apache.spark"),
       ExclusionRule(organization = "org.apache.parquet"),
       ExclusionRule("ch.qos.logback", "logback-classic"),
       ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
+      ExclusionRule("org.apache.hive", "hive-exec"),
       ExclusionRule(organization = "com.google.protobuf")
     ),
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",
     "io.delta" %% "delta-core" % deltaVersion % "test",
-    "org.apache.spark" %% "spark-sql" % sparkVersion % "test",
+    "org.apache.spark" %% "spark-sql" % sparkVersion % "test" excludeAll(
+      ExclusionRule(organization = "org.apache.hive")
+    ),
     "org.apache.spark" %% "spark-catalyst" % sparkVersion % "test" classifier "tests",
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",
-    "org.apache.spark" %% "spark-sql" % sparkVersion % "test" classifier "tests"
+    "org.apache.spark" %% "spark-sql" % sparkVersion % "test" classifier "tests" excludeAll (
+      ExclusionRule(organization = "org.apache.hive")
+      )
   )
 )
 
@@ -124,7 +136,14 @@ lazy val hiveTez = (project in file("hive-tez")) dependsOn(hive % "test->test") 
       ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
       ExclusionRule(organization = "com.google.protobuf")
     ),
-    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided",
+    "org.apache.hive" % "hive-metastore" % hiveVersion % "provided" excludeAll(
+      ExclusionRule(organization = "org.apache.spark"),
+      ExclusionRule(organization = "org.apache.parquet"),
+      ExclusionRule("ch.qos.logback", "logback-classic"),
+      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
+      ExclusionRule("org.apache.hive", "hive-exec"),
+      ExclusionRule(organization = "com.google.protobuf")
+    ),
     "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "test" classifier "tests",
     "org.apache.hadoop" % "hadoop-mapreduce-client-hs" % hadoopVersion % "test",
     "org.apache.hadoop" % "hadoop-mapreduce-client-jobclient" % hadoopVersion % "test" classifier "tests",
@@ -134,12 +153,27 @@ lazy val hiveTez = (project in file("hive-tez")) dependsOn(hive % "test->test") 
       ExclusionRule(organization = "org.apache.parquet"),
       ExclusionRule("ch.qos.logback", "logback-classic"),
       ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
+      ExclusionRule("org.apache.hive", "hive-exec"),
       ExclusionRule(organization = "com.google.protobuf")
     ),
     "org.apache.hadoop" % "hadoop-yarn-common" % hadoopVersion % "test",
     "org.apache.hadoop" % "hadoop-yarn-api" % hadoopVersion % "test",
-    "org.apache.tez" % "tez-mapreduce" % "0.8.4" % "test",
-    "org.apache.tez" % "tez-dag" % "0.8.4" % "test",
+    "org.apache.tez" % "tez-mapreduce" % "0.8.4" % "test"  excludeAll(
+      ExclusionRule(organization = "org.apache.spark"),
+      ExclusionRule(organization = "org.apache.parquet"),
+      ExclusionRule("ch.qos.logback", "logback-classic"),
+      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
+      ExclusionRule(organization = "org.apache.hive"),
+      ExclusionRule(organization = "com.google.protobuf")
+    ),
+    "org.apache.tez" % "tez-dag" % "0.8.4" % "test"  excludeAll(
+      ExclusionRule(organization = "org.apache.spark"),
+      ExclusionRule(organization = "org.apache.parquet"),
+      ExclusionRule("ch.qos.logback", "logback-classic"),
+      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
+      ExclusionRule(organization = "org.apache.hive"),
+      ExclusionRule(organization = "com.google.protobuf")
+    ),
     "org.apache.tez" % "tez-tests" % "0.8.4" % "test" classifier "tests",
     // TODO Figure out how this fixes some bad dependency
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",

--- a/build.sbt
+++ b/build.sbt
@@ -149,22 +149,8 @@ lazy val hiveTez = (project in file("hive-tez")) dependsOn(hive % "test->test") 
     ),
     "org.apache.hadoop" % "hadoop-yarn-common" % hadoopVersion % "test",
     "org.apache.hadoop" % "hadoop-yarn-api" % hadoopVersion % "test",
-    "org.apache.tez" % "tez-mapreduce" % "0.8.4" % "test"  excludeAll(
-      ExclusionRule(organization = "org.apache.spark"),
-      ExclusionRule(organization = "org.apache.parquet"),
-      ExclusionRule("ch.qos.logback", "logback-classic"),
-      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
-      ExclusionRule(organization = "org.apache.hive"),
-      ExclusionRule(organization = "com.google.protobuf")
-    ),
-    "org.apache.tez" % "tez-dag" % "0.8.4" % "test"  excludeAll(
-      ExclusionRule(organization = "org.apache.spark"),
-      ExclusionRule(organization = "org.apache.parquet"),
-      ExclusionRule("ch.qos.logback", "logback-classic"),
-      ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
-      ExclusionRule(organization = "org.apache.hive"),
-      ExclusionRule(organization = "com.google.protobuf")
-    ),
+    "org.apache.tez" % "tez-mapreduce" % "0.8.4" % "test",
+    "org.apache.tez" % "tez-dag" % "0.8.4" % "test",
     "org.apache.tez" % "tez-tests" % "0.8.4" % "test" classifier "tests",
     // TODO Figure out how this fixes some bad dependency
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",

--- a/hive-tez/src/test/scala/io/delta/hive/HiveTezSuite.scala
+++ b/hive-tez/src/test/scala/io/delta/hive/HiveTezSuite.scala
@@ -31,6 +31,9 @@ import org.apache.tez.test.MiniTezCluster
 
 class HiveTezSuite extends HiveConnectorTest {
 
+  // scalastyle:off
+  println("====> " + classOf[org.apache.parquet.schema.GroupType].getResource("GroupType.class"))
+
   override val engine: String = "tez"
 
   private var tezConf: Configuration = _

--- a/hive-tez/src/test/scala/io/delta/hive/HiveTezSuite.scala
+++ b/hive-tez/src/test/scala/io/delta/hive/HiveTezSuite.scala
@@ -31,9 +31,6 @@ import org.apache.tez.test.MiniTezCluster
 
 class HiveTezSuite extends HiveConnectorTest {
 
-  // scalastyle:off
-  println("====> " + classOf[org.apache.parquet.schema.GroupType].getResource("GroupType.class"))
-
   override val engine: String = "tez"
 
   private var tezConf: Configuration = _


### PR DESCRIPTION
Update `build.sbt` to avoid adding `hive-exec` jar (contains an old parquet) to the classpath in Hive Tez tests so that we don't introduce an old parquet version in the classpath.