### PR TITLE
Wrap `lockInterruptibly` inside try-finally

### DIFF
--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -58,8 +58,8 @@ private[internal] class DeltaLogImpl private(
    * interrupted when waiting for the lock.
    */
   protected def lockInterruptibly[T](body: => T): T = {
-    deltaLogLock.lockInterruptibly()
     try {
+      deltaLogLock.lockInterruptibly()
       body
     } finally {
       deltaLogLock.unlock()


### PR DESCRIPTION
Hello,
Because `lockInterruptibly` can cause `InterruptException`, seems it will be good to wrap inside try-finally block.
Please review 🙏 

Also, some question:
- How can I try in stand-alone mode?
- Seems it will be good to add exception handler. What will be good to put inside `catch`?