### PR TITLE
Added Support for spark3.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -262,7 +262,7 @@ lazy val standalone = (project in file("standalone"))
         ExclusionRule("org.slf4j", "slf4j-api"),
         ExclusionRule("org.apache.parquet", "parquet-hadoop")
       ),
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.7.1",
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.10.0",
       "org.json4s" %% "json4s-jackson" % "3.5.3" excludeAll (
         ExclusionRule("com.fasterxml.jackson.core"),
         ExclusionRule("com.fasterxml.jackson.module")

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/JsonUtils.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/JsonUtils.scala
@@ -19,7 +19,7 @@ package io.delta.standalone.internal.util
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.fasterxml.jackson.module.scala.ScalaObjectMapper
 
 /** Useful json functions used around the Delta codebase. */
 private[internal] object JsonUtils {


### PR DESCRIPTION
Using delta-standalone with spark3 is cannot be done right now.

The problem is spark3 using jackson-module with higher version of 2.6.7.1, where ScalaObjectMapper was moved from experimental package.