### PR TITLE
Adding support in reading data in parallelism

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/Snapshot.java
+++ b/standalone/src/main/java/io/delta/standalone/Snapshot.java
@@ -53,4 +53,10 @@ public interface Snapshot {
      * @return a {@link CloseableIterator} to iterate over data
      */
     CloseableIterator<RowRecord> open();
+
+    /**
+     * @param parallelism The number of threads to use for reading the files
+     * @return All the data belonging to this snapshot
+     */
+    List<RowRecord> getAllData(int parallelism);
 }


### PR DESCRIPTION
For now, the only way to read data from the delta-standalone, is by open method of Snapshot - that return CloseableIterator which let us to iterate the data one-by-one.

I suggent new method getAllData(int parallelism) that will read in multithread the data and will return List with all the records of the table.
This way we can use all threads for I/O calls, instead go one-by-one.

I didn't Write UT yet, as i wanted to get feedback if you think this is the right way to implement this.

Thanks.