### PR TITLE
[#101] add incremental changes api

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,6 @@ There are two mediums of communication within the Delta Lake community.
   - [Login here](https://delta-users.slack.com/)
 
 - Public [Mailing list](https://groups.google.com/forum/#!forum/delta-users)
+
+# Local Development & Testing
+- before local debugging of `standalone` tests in IntelliJ, run all `standalone` tests using SBT. This helps IntelliJ recognize the golden tables as class resources.

--- a/README.md
+++ b/README.md
@@ -190,4 +190,4 @@ There are two mediums of communication within the Delta Lake community.
 - Public [Mailing list](https://groups.google.com/forum/#!forum/delta-users)
 
 # Local Development & Testing
-- before local debugging of `standalone` tests in IntelliJ, run all `standalone` tests using SBT. This helps IntelliJ recognize the golden tables as class resources.
+- Before local debugging of `standalone` tests in IntelliJ, run all `standalone` tests using SBT. This helps IntelliJ recognize the golden tables as class resources.

--- a/build.sbt
+++ b/build.sbt
@@ -305,7 +305,7 @@ lazy val goldenTables = (project in file("golden-tables")) settings (
     // Test Dependencies
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",
     "org.apache.spark" % "spark-sql_2.12" % "3.0.0" % "test",
-    "io.delta" % "delta-core_2.12" % "0.7.0" % "test",
+    "io.delta" % "delta-core_2.12" % "0.8.0" % "test",
     "commons-io" % "commons-io" % "2.8.0" % "test",
     "org.apache.spark" % "spark-catalyst_2.12" % "3.0.0" % "test" classifier "tests",
     "org.apache.spark" % "spark-core_2.12" % "3.0.0" % "test" classifier "tests",
@@ -321,7 +321,7 @@ lazy val sqlDeltaImport = (project in file("sql-delta-import"))
     publishArtifact in Test := false,
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
-      "io.delta" % "delta-core_2.12" % "1.0.0" % "provided",
+      "io.delta" % "delta-core_2.12" % "0.7.0" % "provided",
       "org.rogach" %% "scallop" % "3.5.1",
       "org.scalatest" %% "scalatest" % "3.1.1" % "test",
       "com.h2database" % "h2" % "1.4.200" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val testScalastyle = taskKey[Unit]("testScalastyle")
 val sparkVersion = "2.4.3"
 val hadoopVersion = "2.7.2"
 val hiveVersion = "2.3.7"
-val deltaVersion = "0.5.0"
+val hiveDeltaVersion = "0.5.0"
 
 lazy val commonSettings = Seq(
   organization := "io.delta",
@@ -152,7 +152,7 @@ lazy val hive = (project in file("hive")) dependsOn(standalone) settings (
       ExclusionRule(organization = "com.google.protobuf")
     ),
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",
-    "io.delta" %% "delta-core" % deltaVersion % "test",
+    "io.delta" %% "delta-core" % hiveDeltaVersion % "test",
     "org.apache.spark" %% "spark-sql" % sparkVersion % "test",
     "org.apache.spark" %% "spark-catalyst" % sparkVersion % "test" classifier "tests",
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",
@@ -198,7 +198,7 @@ lazy val hiveMR = (project in file("hive-mr")) dependsOn(hive % "test->test") se
     // TODO Figure out how this fixes some bad dependency
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",
-    "io.delta" %% "delta-core" % deltaVersion % "test" excludeAll ExclusionRule("org.apache.hadoop")
+    "io.delta" %% "delta-core" % hiveDeltaVersion % "test" excludeAll ExclusionRule("org.apache.hadoop")
   )
 )
 
@@ -246,7 +246,7 @@ lazy val hiveTez = (project in file("hive-tez")) dependsOn(hive % "test->test") 
     // TODO Figure out how this fixes some bad dependency
     "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",
-    "io.delta" %% "delta-core" % deltaVersion % "test" excludeAll ExclusionRule("org.apache.hadoop")
+    "io.delta" %% "delta-core" % hiveDeltaVersion % "test" excludeAll ExclusionRule("org.apache.hadoop")
   )
 )
 
@@ -321,7 +321,7 @@ lazy val sqlDeltaImport = (project in file("sql-delta-import"))
     publishArtifact in Test := false,
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
-      "io.delta" % "delta-core_2.12" % "0.7.0" % "provided",
+      "io.delta" % "delta-core_2.12" % "1.0.0" % "provided",
       "org.rogach" %% "scallop" % "3.5.1",
       "org.scalatest" %% "scalatest" % "3.1.1" % "test",
       "com.h2database" % "h2" % "1.4.200" % "test",

--- a/golden-tables/src/test/resources/golden/deltalog-getChanges/_delta_log/00000000000000000000.json
+++ b/golden-tables/src/test/resources/golden/deltalog-getChanges/_delta_log/00000000000000000000.json
@@ -1,4 +1,4 @@
-{"commitInfo":{"timestamp":1626797688476,"operation":"Manual Update","operationParameters":{},"isBlindAppend":true,"operationMetrics":{}}}
+{"commitInfo":{"timestamp":1626806331480,"operation":"Manual Update","operationParameters":{},"isBlindAppend":true,"operationMetrics":{}}}
 {"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
-{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"partitionColumns":[],"configuration":{},"createdTime":1626797688450}}
+{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"partitionColumns":[],"configuration":{},"createdTime":1626806331460}}
 {"add":{"path":"fake/path/1","partitionValues":{},"size":1,"modificationTime":1,"dataChange":true}}

--- a/golden-tables/src/test/resources/golden/deltalog-getChanges/_delta_log/00000000000000000000.json
+++ b/golden-tables/src/test/resources/golden/deltalog-getChanges/_delta_log/00000000000000000000.json
@@ -1,0 +1,4 @@
+{"commitInfo":{"timestamp":1626797688476,"operation":"Manual Update","operationParameters":{},"isBlindAppend":true,"operationMetrics":{}}}
+{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
+{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"partitionColumns":[],"configuration":{},"createdTime":1626797688450}}
+{"add":{"path":"fake/path/1","partitionValues":{},"size":1,"modificationTime":1,"dataChange":true}}

--- a/golden-tables/src/test/resources/golden/deltalog-getChanges/_delta_log/00000000000000000001.json
+++ b/golden-tables/src/test/resources/golden/deltalog-getChanges/_delta_log/00000000000000000001.json
@@ -1,3 +1,3 @@
-{"commitInfo":{"timestamp":1626797693533,"operation":"Manual Update","operationParameters":{},"readVersion":0,"isBlindAppend":false,"operationMetrics":{}}}
-{"add":{"path":"fake/path/2","partitionValues":{},"size":1,"modificationTime":1,"dataChange":true}}
-{"remove":{"path":"fake/path/1","deletionTimestamp":100,"dataChange":true}}
+{"commitInfo":{"timestamp":1626806336805,"operation":"Manual Update","operationParameters":{},"readVersion":0,"isBlindAppend":false,"operationMetrics":{}}}
+{"cdc":{"path":"fake/path/2","partitionValues":{"partition_foo":"partition_bar"},"size":1,"tags":{"tag_foo":"tag_bar"},"dataChange":false}}
+{"remove":{"path":"fake/path/1","deletionTimestamp":100,"dataChange":true,"extendedFileMetadata":false,"size":0}}

--- a/golden-tables/src/test/resources/golden/deltalog-getChanges/_delta_log/00000000000000000001.json
+++ b/golden-tables/src/test/resources/golden/deltalog-getChanges/_delta_log/00000000000000000001.json
@@ -1,0 +1,3 @@
+{"commitInfo":{"timestamp":1626797693533,"operation":"Manual Update","operationParameters":{},"readVersion":0,"isBlindAppend":false,"operationMetrics":{}}}
+{"add":{"path":"fake/path/2","partitionValues":{},"size":1,"modificationTime":1,"dataChange":true}}
+{"remove":{"path":"fake/path/1","deletionTimestamp":100,"dataChange":true}}

--- a/golden-tables/src/test/resources/golden/deltalog-getChanges/_delta_log/00000000000000000002.json
+++ b/golden-tables/src/test/resources/golden/deltalog-getChanges/_delta_log/00000000000000000002.json
@@ -1,0 +1,3 @@
+{"commitInfo":{"timestamp":1626797694272,"operation":"Manual Update","operationParameters":{},"readVersion":1,"isBlindAppend":true,"operationMetrics":{}}}
+{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
+{"txn":{"appId":"fakeAppId","version":3,"lastUpdated":200}}

--- a/golden-tables/src/test/resources/golden/deltalog-getChanges/_delta_log/00000000000000000002.json
+++ b/golden-tables/src/test/resources/golden/deltalog-getChanges/_delta_log/00000000000000000002.json
@@ -1,3 +1,3 @@
-{"commitInfo":{"timestamp":1626797694272,"operation":"Manual Update","operationParameters":{},"readVersion":1,"isBlindAppend":true,"operationMetrics":{}}}
-{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
+{"commitInfo":{"timestamp":1626806337545,"operation":"Manual Update","operationParameters":{},"readVersion":1,"isBlindAppend":true,"operationMetrics":{}}}
+{"protocol":{"minReaderVersion":1,"minWriterVersion":3}}
 {"txn":{"appId":"fakeAppId","version":3,"lastUpdated":200}}

--- a/golden-tables/src/test/scala/io/delta/golden/GoldenTables.scala
+++ b/golden-tables/src/test/scala/io/delta/golden/GoldenTables.scala
@@ -51,7 +51,7 @@ import org.apache.spark.SparkConf
  * GENERATE_GOLDEN_TABLES=1 build/sbt 'goldenTables/test-only *GoldenTables -- -z tbl_name'
  * ```
  *
- * After generating golden tables, ensure to package or test project standalone`, otherwise the
+ * After generating golden tables, ensure to package or test project standalone, otherwise the
  * test resources won't be available when running tests with IntelliJ.
  */
 class GoldenTables extends QueryTest with SharedSparkSession {
@@ -372,6 +372,23 @@ class GoldenTables extends QueryTest with SharedSparkSession {
     log.store.write(
       FileNames.deltaFile(log.logPath, 0L),
       Iterator(Metadata(), Protocol(), commitInfoFile, addFile).map(a => JsonUtils.toJson(a.wrap)))
+  }
+
+  generateGoldenTable("deltalog-getChanges") { tablePath =>
+    val log = DeltaLog.forTable(spark, new Path(tablePath))
+
+    val add1 = AddFile("fake/path/1", Map.empty, 1, 1, dataChange = true)
+    val txn1 = log.startTransaction()
+    txn1.commit(Metadata() :: add1 :: Nil, ManualUpdate)
+
+    val add2 = AddFile("fake/path/2", Map.empty, 1, 1, dataChange = true)
+    val remove1 = RemoveFile("fake/path/1", Some(100), dataChange = true)
+    val txn2 = log.startTransaction()
+    txn2.commit(add2 :: remove1 :: Nil, ManualUpdate)
+
+    // 0 -> AddFile, Metadata
+    // 1 -> AddFile, Metadata, AddFile, RemoveFile
+    // TODO
   }
 
   ///////////////////////////////////////////////////////////////////////////

--- a/golden-tables/src/test/scala/io/delta/golden/GoldenTables.scala
+++ b/golden-tables/src/test/scala/io/delta/golden/GoldenTables.scala
@@ -32,7 +32,7 @@ import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.delta.{DeltaLog, OptimisticTransaction}
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
-import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, JobInfo, Metadata, NotebookInfo, Protocol, RemoveFile, SetTransaction, SingleAction}
+import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, CommitInfo, JobInfo, Metadata, NotebookInfo, Protocol, RemoveFile, SetTransaction, SingleAction}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import org.apache.spark.sql.test.SharedSparkSession
@@ -382,10 +382,11 @@ class GoldenTables extends QueryTest with SharedSparkSession {
     val txn1 = log.startTransaction()
     txn1.commitManually(Metadata() :: add1 :: Nil: _*)
 
-    val add2 = AddFile("fake/path/2", Map.empty, 1, 1, dataChange = true)
+    val addCDC2 = AddCDCFile("fake/path/2", Map("partition_foo" -> "partition_bar"), 1,
+      Map("tag_foo" -> "tag_bar"))
     val remove2 = RemoveFile("fake/path/1", Some(100), dataChange = true)
     val txn2 = log.startTransaction()
-    txn2.commitManually(add2 :: remove2 :: Nil: _*)
+    txn2.commitManually(addCDC2 :: remove2 :: Nil: _*)
 
     val setTransaction3 = SetTransaction("fakeAppId", 3L, Some(200))
     val txn3 = log.startTransaction()

--- a/standalone/src/main/java/io/delta/standalone/DeltaLog.java
+++ b/standalone/src/main/java/io/delta/standalone/DeltaLog.java
@@ -83,11 +83,11 @@ public interface DeltaLog {
      *
      * @param startVersion the table version to begin retrieving actions from (inclusive)
      * @param failOnDataLoss whether to throw when data loss detected
-     * @return an {@code Iterator} of {@link VersionDelta}s
+     * @return an {@code Iterator} of {@link VersionLog}s
      * @throws IllegalArgumentException if {@code startVersion} is negative
      * @throws IllegalStateException if data loss detected and {@code failOnDataLoss} is true
      */
-    Iterator<VersionDelta> getChanges(long startVersion, boolean failOnDataLoss);
+    Iterator<VersionLog> getChanges(long startVersion, boolean failOnDataLoss);
 
     /**
      * Create a {@link DeltaLog} instance representing the table located at the provided {@code path}.

--- a/standalone/src/main/java/io/delta/standalone/DeltaLog.java
+++ b/standalone/src/main/java/io/delta/standalone/DeltaLog.java
@@ -77,6 +77,16 @@ public interface DeltaLog {
     /** @return the path of the Delta table. */
     Path getPath();
 
+    /**
+     * Get all actions starting from "startVersion" (inclusive).
+     * If `startVersion` doesn't exist, return an empty {@code Iterator}.
+     *
+     * @param startVersion the table version to begin retrieving actions from
+     * @param failOnDataLoss whether to throw when data loss detected
+     * @return an {@code Iterator} of {@link VersionDelta}s
+     * @throws IllegalArgumentException if {@code startVersion} is negative.
+     * @throws IllegalStateException if data loss detected and {@code failOnDataLoss} is true
+     */
     Iterator<VersionDelta> getChanges(long startVersion, boolean failOnDataLoss);
 
     /**

--- a/standalone/src/main/java/io/delta/standalone/DeltaLog.java
+++ b/standalone/src/main/java/io/delta/standalone/DeltaLog.java
@@ -21,6 +21,8 @@ import org.apache.hadoop.fs.Path;
 
 import io.delta.standalone.internal.DeltaLogImpl;
 
+import java.util.Iterator;
+
 /**
  * {@link DeltaLog} is the representation of the transaction logs of a Delta table. It provides APIs
  * to access the states of a Delta table.
@@ -74,6 +76,8 @@ public interface DeltaLog {
 
     /** @return the path of the Delta table. */
     Path getPath();
+
+    Iterator<VersionDelta> getChanges(long startVersion, boolean failOnDataLoss);
 
     /**
      * Create a {@link DeltaLog} instance representing the table located at the provided {@code path}.

--- a/standalone/src/main/java/io/delta/standalone/DeltaLog.java
+++ b/standalone/src/main/java/io/delta/standalone/DeltaLog.java
@@ -81,10 +81,10 @@ public interface DeltaLog {
      * Get all actions starting from "startVersion" (inclusive).
      * If `startVersion` doesn't exist, return an empty {@code Iterator}.
      *
-     * @param startVersion the table version to begin retrieving actions from
+     * @param startVersion the table version to begin retrieving actions from (inclusive)
      * @param failOnDataLoss whether to throw when data loss detected
      * @return an {@code Iterator} of {@link VersionDelta}s
-     * @throws IllegalArgumentException if {@code startVersion} is negative.
+     * @throws IllegalArgumentException if {@code startVersion} is negative
      * @throws IllegalStateException if data loss detected and {@code failOnDataLoss} is true
      */
     Iterator<VersionDelta> getChanges(long startVersion, boolean failOnDataLoss);

--- a/standalone/src/main/java/io/delta/standalone/VersionDelta.java
+++ b/standalone/src/main/java/io/delta/standalone/VersionDelta.java
@@ -1,0 +1,23 @@
+package io.delta.standalone;
+
+import io.delta.standalone.actions.Action;
+
+import java.util.List;
+
+public class VersionDelta {
+    private final long version;
+    private final List<Action> actions;
+
+    public VersionDelta(long version, List<Action> actions) {
+        this.version = version;
+        this.actions = actions;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public List<Action> getActions() {
+        return actions;
+    }
+}

--- a/standalone/src/main/java/io/delta/standalone/VersionDelta.java
+++ b/standalone/src/main/java/io/delta/standalone/VersionDelta.java
@@ -2,8 +2,13 @@ package io.delta.standalone;
 
 import io.delta.standalone.actions.Action;
 
+import java.util.Collections;
 import java.util.List;
 
+/**
+ * {@link VersionDelta} is the representation of all actions (changes) to the Delta Table
+ * at a specific table version.
+ */
 public class VersionDelta {
     private final long version;
     private final List<Action> actions;
@@ -13,11 +18,17 @@ public class VersionDelta {
         this.actions = actions;
     }
 
+    /**
+     * @return the table version at which these actions occured
+     */
     public long getVersion() {
         return version;
     }
 
+    /**
+     * @return an unmodifiable {@code List} of the actions for this table version
+     */
     public List<Action> getActions() {
-        return actions;
+        return Collections.unmodifiableList(actions);
     }
 }

--- a/standalone/src/main/java/io/delta/standalone/VersionLog.java
+++ b/standalone/src/main/java/io/delta/standalone/VersionLog.java
@@ -6,14 +6,14 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * {@link VersionDelta} is the representation of all actions (changes) to the Delta Table
+ * {@link VersionLog} is the representation of all actions (changes) to the Delta Table
  * at a specific table version.
  */
-public class VersionDelta {
+public class VersionLog {
     private final long version;
     private final List<Action> actions;
 
-    public VersionDelta(long version, List<Action> actions) {
+    public VersionLog(long version, List<Action> actions) {
         this.version = version;
         this.actions = actions;
     }

--- a/standalone/src/main/java/io/delta/standalone/actions/Action.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Action.java
@@ -1,0 +1,3 @@
+package io.delta.standalone.actions;
+
+public abstract class Action { }

--- a/standalone/src/main/java/io/delta/standalone/actions/Action.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Action.java
@@ -1,3 +1,3 @@
 package io.delta.standalone.actions;
 
-public abstract class Action { }
+public interface Action { }

--- a/standalone/src/main/java/io/delta/standalone/actions/Action.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Action.java
@@ -1,3 +1,21 @@
 package io.delta.standalone.actions;
 
+/**
+ * A marker interface for all Actions that can be applied to a Delta Table.
+ * Each action represents a single change to the state of a Delta table.
+ *
+ * You can use the following code to extract the concrete type of an {@link Action}.
+ * <pre>{@code
+ *   List<Action> actions = ... // {@link io.delta.standalone.DeltaLog.getChanges} is one way to get such actions
+ *   actions.forEach(x -> {
+ *       if (x instanceof AddFile) {
+ *          AddFile addFile = (AddFile) x;
+ *          ...
+ *       } else if (x instanceof AddCDCFile) {
+ *          AddCDCFile addCDCFile = (AddCDCFile)x;
+ *          ...
+ *       } else if ...
+ *   });
+ * }</pre>
+ */
 public interface Action { }

--- a/standalone/src/main/java/io/delta/standalone/actions/AddCDCFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/AddCDCFile.java
@@ -1,0 +1,4 @@
+package io.delta.standalone.actions;
+
+public class AddCDCFile extends Action {
+}

--- a/standalone/src/main/java/io/delta/standalone/actions/AddCDCFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/AddCDCFile.java
@@ -1,4 +1,39 @@
 package io.delta.standalone.actions;
 
-public class AddCDCFile extends Action {
+import java.util.Map;
+
+public class AddCDCFile implements FileAction {
+    private final String path;
+    private final Map<String, String> partitionValues;
+    private final long size;
+    private final Map<String, String> tags;
+
+    public AddCDCFile(String path, Map<String, String> partitionValues, long size, Map<String, String> tags) {
+        this.path = path;
+        this.partitionValues = partitionValues;
+        this.size = size;
+        this.tags = tags;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    public Map<String, String> getPartitionValues() {
+        return partitionValues;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    @Override
+    public boolean isDataChange() {
+        return false;
+    }
 }

--- a/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  *
  * @see  <a href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md">Delta Transaction Log Protocol</a>
  */
-public final class AddFile extends Action {
+public final class AddFile implements FileAction {
     private final String path;
     private final Map<String, String> partitionValues;
     private final long size;
@@ -54,6 +54,7 @@ public final class AddFile extends Action {
      *         relative path, it's relative to the root of the table. Note: the path is encoded and
      *         should be decoded by {@code new java.net.URI(path)} when using it.
      */
+    @Override
     public String getPath() {
         return path;
     }
@@ -88,6 +89,7 @@ public final class AddFile extends Action {
      *         {@code false} the file must already be present in the table or the records in the
      *         added file must be contained in one or more remove actions in the same version
      */
+    @Override
     public boolean isDataChange() {
         return dataChange;
     }

--- a/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
@@ -15,8 +15,6 @@
  */
 package io.delta.standalone.actions;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -30,7 +28,7 @@ import java.util.Objects;
  *
  * @see  <a href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md">Delta Transaction Log Protocol</a>
  */
-public final class AddFile {
+public final class AddFile extends Action {
     private final String path;
     private final Map<String, String> partitionValues;
     private final long size;

--- a/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  *
  * @see  <a href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md">Delta Transaction Log Protocol</a>
  */
-public class CommitInfo {
+public class CommitInfo extends Action {
     private final Optional<Long> version;
     private final Timestamp timestamp;
     private final Optional<String> userId;

--- a/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  *
  * @see  <a href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md">Delta Transaction Log Protocol</a>
  */
-public class CommitInfo extends Action {
+public class CommitInfo implements Action {
     private final Optional<Long> version;
     private final Timestamp timestamp;
     private final Optional<String> userId;

--- a/standalone/src/main/java/io/delta/standalone/actions/FileAction.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/FileAction.java
@@ -1,0 +1,8 @@
+package io.delta.standalone.actions;
+
+public interface FileAction extends Action {
+
+    String getPath();
+
+    boolean isDataChange();
+}

--- a/standalone/src/main/java/io/delta/standalone/actions/Format.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Format.java
@@ -24,7 +24,7 @@ import java.util.Objects;
  *
  * @see  <a href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md">Delta Transaction Log Protocol</a>
  */
-public final class Format extends Action {
+public final class Format implements Action {
     private final String provider;
     private final Map<String, String> options;
 

--- a/standalone/src/main/java/io/delta/standalone/actions/Format.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Format.java
@@ -24,7 +24,7 @@ import java.util.Objects;
  *
  * @see  <a href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md">Delta Transaction Log Protocol</a>
  */
-public final class Format {
+public final class Format extends Action {
     private final String provider;
     private final Map<String, String> options;
 

--- a/standalone/src/main/java/io/delta/standalone/actions/JobInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/JobInfo.java
@@ -18,7 +18,7 @@ package io.delta.standalone.actions;
 import java.util.Objects;
 
 /** Represents the Databricks Job information that committed to the Delta table. */
-public class JobInfo {
+public class JobInfo extends Action {
     private final String jobId;
     private final String jobName;
     private final String runId;

--- a/standalone/src/main/java/io/delta/standalone/actions/JobInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/JobInfo.java
@@ -18,7 +18,7 @@ package io.delta.standalone.actions;
 import java.util.Objects;
 
 /** Represents the Databricks Job information that committed to the Delta table. */
-public class JobInfo extends Action {
+public class JobInfo implements Action {
     private final String jobId;
     private final String jobName;
     private final String runId;

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -29,7 +29,7 @@ import io.delta.standalone.types.StructType;
  *
  * @see  <a href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md">Delta Transaction Log Protocol</a>
  */
-public final class Metadata extends Action {
+public final class Metadata implements Action {
     private final String id;
     private final String name;
     private final String description;

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -29,7 +29,7 @@ import io.delta.standalone.types.StructType;
  *
  * @see  <a href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md">Delta Transaction Log Protocol</a>
  */
-public final class Metadata {
+public final class Metadata extends Action {
     private final String id;
     private final String name;
     private final String description;

--- a/standalone/src/main/java/io/delta/standalone/actions/NotebookInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/NotebookInfo.java
@@ -18,7 +18,7 @@ package io.delta.standalone.actions;
 import java.util.Objects;
 
 /** Represents the Databricks Notebook information that committed to the Delta table. */
-public class NotebookInfo extends Action {
+public class NotebookInfo implements Action {
     private final String notebookId;
 
     public NotebookInfo(String notebookId) {

--- a/standalone/src/main/java/io/delta/standalone/actions/NotebookInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/NotebookInfo.java
@@ -18,7 +18,7 @@ package io.delta.standalone.actions;
 import java.util.Objects;
 
 /** Represents the Databricks Notebook information that committed to the Delta table. */
-public class NotebookInfo {
+public class NotebookInfo extends Action {
     private final String notebookId;
 
     public NotebookInfo(String notebookId) {

--- a/standalone/src/main/java/io/delta/standalone/actions/Protocol.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Protocol.java
@@ -1,4 +1,20 @@
 package io.delta.standalone.actions;
 
 public class Protocol extends Action {
+    private final int minReaderVersion;
+    private final int minWriterVersion;
+
+    public Protocol(int minReaderVersion, int minWriterVersion) {
+        this.minReaderVersion = minReaderVersion;
+        this.minWriterVersion = minWriterVersion;
+    }
+
+    public int getMinReaderVersion() {
+        return minReaderVersion;
+    }
+
+    public int getMinWriterVersion() {
+        return minWriterVersion;
+    }
 }
+

--- a/standalone/src/main/java/io/delta/standalone/actions/Protocol.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Protocol.java
@@ -1,0 +1,4 @@
+package io.delta.standalone.actions;
+
+public class Protocol extends Action {
+}

--- a/standalone/src/main/java/io/delta/standalone/actions/Protocol.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Protocol.java
@@ -1,6 +1,6 @@
 package io.delta.standalone.actions;
 
-public class Protocol extends Action {
+public class Protocol implements Action {
     private final int minReaderVersion;
     private final int minWriterVersion;
 

--- a/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
@@ -1,16 +1,28 @@
 package io.delta.standalone.actions;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 public class RemoveFile implements FileAction {
     private final String path;
     private final Optional<Long> deletionTimestamp;
     private final boolean dataChange;
+    private final boolean extendedFileMetadata;
+    private final Map<String, String> partitionValues;
+    private final long size;
+    private final Map<String, String> tags;
 
-    public RemoveFile(String path, Optional<Long> deletionTimestamp, boolean dataChange) {
+    public RemoveFile(String path, Optional<Long> deletionTimestamp, boolean dataChange,
+                      boolean extendedFileMetadata, Map<String, String> partitionValues, long size,
+                      Map<String, String> tags) {
         this.path = path;
         this.deletionTimestamp = deletionTimestamp;
         this.dataChange = dataChange;
+        this.extendedFileMetadata = extendedFileMetadata;
+        this.partitionValues = partitionValues;
+        this.size = size;
+        this.tags = tags;
     }
 
     @Override
@@ -25,5 +37,21 @@ public class RemoveFile implements FileAction {
     @Override
     public boolean isDataChange() {
         return dataChange;
+    }
+
+    public boolean isExtendedFileMetadata() {
+        return extendedFileMetadata;
+    }
+
+    public Map<String, String> getPartitionValues() {
+        return Collections.unmodifiableMap(partitionValues);
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public Map<String, String> getTags() {
+        return Collections.unmodifiableMap(tags);
     }
 }

--- a/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
@@ -2,7 +2,7 @@ package io.delta.standalone.actions;
 
 import java.util.Optional;
 
-public class RemoveFile extends Action {
+public class RemoveFile implements FileAction {
     private final String path;
     private final Optional<Long> deletionTimestamp;
     private final boolean dataChange;
@@ -13,6 +13,7 @@ public class RemoveFile extends Action {
         this.dataChange = dataChange;
     }
 
+    @Override
     public String getPath() {
         return path;
     }
@@ -21,6 +22,7 @@ public class RemoveFile extends Action {
         return deletionTimestamp;
     }
 
+    @Override
     public boolean isDataChange() {
         return dataChange;
     }

--- a/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
@@ -1,4 +1,27 @@
 package io.delta.standalone.actions;
 
+import java.util.Optional;
+
 public class RemoveFile extends Action {
+    private final String path;
+    private final Optional<Long> deletionTimestamp;
+    private final boolean dataChange;
+
+    public RemoveFile(String path, Optional<Long> deletionTimestamp, boolean dataChange) {
+        this.path = path;
+        this.deletionTimestamp = deletionTimestamp;
+        this.dataChange = dataChange;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public Optional<Long> getDeletionTimestamp() {
+        return deletionTimestamp;
+    }
+
+    public boolean isDataChange() {
+        return dataChange;
+    }
 }

--- a/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
@@ -1,0 +1,4 @@
+package io.delta.standalone.actions;
+
+public class RemoveFile extends Action {
+}

--- a/standalone/src/main/java/io/delta/standalone/actions/SetTransaction.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/SetTransaction.java
@@ -1,0 +1,4 @@
+package io.delta.standalone.actions;
+
+public class SetTransaction extends Action {
+}

--- a/standalone/src/main/java/io/delta/standalone/actions/SetTransaction.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/SetTransaction.java
@@ -1,4 +1,27 @@
 package io.delta.standalone.actions;
 
+import java.util.Optional;
+
 public class SetTransaction extends Action {
+    private final String appId;
+    private final long verion;
+    private final Optional<Long> lastUpdated;
+
+    public SetTransaction(String appId, long verion, Optional<Long> lastUpdated) {
+        this.appId = appId;
+        this.verion = verion;
+        this.lastUpdated = lastUpdated;
+    }
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public long getVerion() {
+        return verion;
+    }
+
+    public Optional<Long> getLastUpdated() {
+        return lastUpdated;
+    }
 }

--- a/standalone/src/main/java/io/delta/standalone/actions/SetTransaction.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/SetTransaction.java
@@ -2,7 +2,7 @@ package io.delta.standalone.actions;
 
 import java.util.Optional;
 
-public class SetTransaction extends Action {
+public class SetTransaction implements Action {
     private final String appId;
     private final long verion;
     private final Optional<Long> lastUpdated;

--- a/standalone/src/main/java/io/delta/standalone/types/StructType.java
+++ b/standalone/src/main/java/io/delta/standalone/types/StructType.java
@@ -52,10 +52,6 @@ public final class StructType extends DataType {
     private final HashMap<String, StructField> nameToField;
 
     public StructType(StructField[] fields) {
-        if (fields.length == 0) {
-            throw new IllegalArgumentException("a StructType must have at least one field");
-        }
-
         this.fields = fields;
         this.nameToField = new HashMap<>();
         Arrays.stream(fields).forEach(field -> nameToField.put(field.getName(), field));

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -56,11 +56,6 @@ private[internal] class DeltaLogImpl private(
     ConversionUtils.convertCommitInfo(history.getCommitInfo(version))
   }
 
-  /**
-   * Get all actions starting from "startVersion" (inclusive).
-   * If `startVersion` is negative, throw IllegalArgumentException.
-   * If `startVersion` doesn't exist, return an empty Iterator.
-   */
   override def getChanges(
       startVersion: Long,
       failOnDataLoss: Boolean): java.util.Iterator[VersionDelta] = {

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -16,15 +16,18 @@
 
 package io.delta.standalone.internal
 
-import java.io.File
 import java.util.concurrent.locks.ReentrantLock
+
+import scala.collection.JavaConverters._
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import io.delta.standalone.DeltaLog
+import io.delta.standalone.{DeltaLog, VersionDelta}
 import io.delta.standalone.actions.{CommitInfo => CommitInfoJ}
+import io.delta.standalone.internal.actions.Action
+import io.delta.standalone.internal.exception.DeltaErrors
 import io.delta.standalone.internal.storage.HDFSReadOnlyLogStore
-import io.delta.standalone.internal.util.ConversionUtils
+import io.delta.standalone.internal.util.{ConversionUtils, FileNames}
 
 /**
  * Scala implementation of Java interface [[DeltaLog]].
@@ -51,6 +54,31 @@ private[internal] class DeltaLogImpl private(
   override def getCommitInfoAt(version: Long): CommitInfoJ = {
     history.checkVersionExists(version)
     ConversionUtils.convertCommitInfo(history.getCommitInfo(version))
+  }
+
+  /**
+   * Get all actions starting from "startVersion" (inclusive). If `startVersion` doesn't exist,
+   * return an empty Iterator.
+   */
+  override def getChanges(
+      startVersion: Long,
+      failOnDataLoss: Boolean): java.util.Iterator[VersionDelta] = {
+    val deltaPaths = store.listFrom(FileNames.deltaFile(logPath, startVersion))
+      .filter(f => FileNames.isDeltaFile(f.getPath))
+
+    // Subtract 1 to ensure that we have the same check for the inclusive startVersion
+    var lastSeenVersion = startVersion - 1
+    deltaPaths.map { status =>
+      val p = status.getPath
+      val version = FileNames.deltaVersion(p)
+      if (failOnDataLoss && version > lastSeenVersion + 1) {
+        throw DeltaErrors.failOnDataLossException(lastSeenVersion + 1, version)
+      }
+      lastSeenVersion = version
+
+      new VersionDelta(version,
+        store.read(p).map(x => ConversionUtils.convertAction(Action.fromJson(x))).toList.asJava)
+    }.asJava
   }
 
   /**

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -57,12 +57,15 @@ private[internal] class DeltaLogImpl private(
   }
 
   /**
-   * Get all actions starting from "startVersion" (inclusive). If `startVersion` doesn't exist,
-   * return an empty Iterator.
+   * Get all actions starting from "startVersion" (inclusive).
+   * If `startVersion` is negative, throw IllegalArgumentException.
+   * If `startVersion` doesn't exist, return an empty Iterator.
    */
   override def getChanges(
       startVersion: Long,
       failOnDataLoss: Boolean): java.util.Iterator[VersionDelta] = {
+    if (startVersion < 0) throw new IllegalArgumentException(s"Invalid startVersion: $startVersion")
+
     val deltaPaths = store.listFrom(FileNames.deltaFile(logPath, startVersion))
       .filter(f => FileNames.isDeltaFile(f.getPath))
 

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import io.delta.standalone.{DeltaLog, VersionDelta}
+import io.delta.standalone.{DeltaLog, VersionLog}
 import io.delta.standalone.actions.{CommitInfo => CommitInfoJ}
 import io.delta.standalone.internal.actions.Action
 import io.delta.standalone.internal.exception.DeltaErrors
@@ -58,7 +58,7 @@ private[internal] class DeltaLogImpl private(
 
   override def getChanges(
       startVersion: Long,
-      failOnDataLoss: Boolean): java.util.Iterator[VersionDelta] = {
+      failOnDataLoss: Boolean): java.util.Iterator[VersionLog] = {
     if (startVersion < 0) throw new IllegalArgumentException(s"Invalid startVersion: $startVersion")
 
     val deltaPaths = store.listFrom(FileNames.deltaFile(logPath, startVersion))
@@ -74,7 +74,7 @@ private[internal] class DeltaLogImpl private(
       }
       lastSeenVersion = version
 
-      new VersionDelta(version,
+      new VersionLog(version,
         store.read(p).map(x => ConversionUtils.convertAction(Action.fromJson(x))).toList.asJava)
     }.asJava
   }

--- a/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
@@ -24,11 +24,10 @@ import scala.collection.JavaConverters._
 import com.github.mjakubowski84.parquet4s.ParquetReader
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
-
 import io.delta.standalone.Snapshot
 import io.delta.standalone.actions.{AddFile => AddFileJ, Metadata => MetadataJ}
 import io.delta.standalone.data.{CloseableIterator, RowRecord => RowParquetRecordJ}
-import io.delta.standalone.internal.actions.{Action, AddFile, InMemoryLogReplay, Metadata, Protocol, SingleAction}
+import io.delta.standalone.internal.actions.{Action, AddFile, InMemoryLogReplay, Metadata, Parquet4sSingleActionWrapper, Protocol, SingleAction}
 import io.delta.standalone.internal.data.CloseableParquetDataIterator
 import io.delta.standalone.internal.exception.DeltaErrors
 import io.delta.standalone.internal.sources.StandaloneHadoopConf
@@ -95,8 +94,10 @@ private[internal] class SnapshotImpl(
           JsonUtils.mapper.readValue[SingleAction](line)
         }
       } else if (path.endsWith("parquet")) {
-        ParquetReader.read[SingleAction](path, ParquetReader.Options(
-          timeZone = readTimeZone, hadoopConf = hadoopConf)).toSeq
+        ParquetReader.read[Parquet4sSingleActionWrapper](
+          path, ParquetReader.Options(
+          timeZone = readTimeZone, hadoopConf = hadoopConf)
+        ).toSeq.map(_.unwrap)
       } else Seq.empty[SingleAction]
     }.toList
   }

--- a/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
@@ -25,7 +25,7 @@ import com.github.mjakubowski84.parquet4s.ParquetReader
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 
-import io.delta.standalone.{DeltaLog, Snapshot}
+import io.delta.standalone.Snapshot
 import io.delta.standalone.actions.{AddFile => AddFileJ, Metadata => MetadataJ}
 import io.delta.standalone.data.{CloseableIterator, RowRecord => RowParquetRecordJ}
 import io.delta.standalone.internal.actions.{Action, AddFile, InMemoryLogReplay, Metadata, Protocol, SingleAction}

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
@@ -125,7 +125,11 @@ private[internal] case class RemoveFile(
     path: String,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     deletionTimestamp: Option[Long],
-    dataChange: Boolean = true) extends FileAction {
+    dataChange: Boolean = true,
+    extendedFileMetadata: Boolean = false,
+    partitionValues: Map[String, String] = null,
+    size: Long = 0,
+    tags: Map[String, String] = null) extends FileAction {
   override def wrap: SingleAction = SingleAction(remove = this)
 
   @JsonIgnore
@@ -293,4 +297,78 @@ private[internal] class JsonMapSerializer extends JsonSerializer[Map[String, Str
     }
     jgen.writeEndObject()
   }
+}
+
+/**
+ * Parquet4s Wrapper Classes
+ *
+ * With the inclusion of RemoveFile as an exposed Java API, and since it was upgraded to match the
+ * latest Delta OSS release, we now had a case class inside of [[SingleAction]] that had "primitive"
+ * default paramaters. They are primitive in the sense that Parquet4s would try to decode them using
+ * the [[PrimitiveValueCodecs]] trait. But since these parameters have default values, there is no
+ * guarantee that they will exist in the underlying parquet checkpoint files. Thus (without these
+ * classes), parquet4s would throw errors like this:
+ *
+ * Cause: java.lang.IllegalArgumentException: NullValue cannot be decoded to required type
+ *   at com.github.mjakubowski84.parquet4s.RequiredValueCodec.decode(ValueCodec.scala:61)
+ *   at com.github.mjakubowski84.parquet4s.RequiredValueCodec.decode$(ValueCodec.scala:58)
+ *   at com.github.mjakubowski84.parquet4s.PrimitiveValueCodecs$$anon$5.decode(ValueCodec.scala:137)
+ *
+ * Note this only happens with "primitive" parameters with default arguments, and not with "complex"
+ * or optional constructor parameters.
+ *
+ * We solve this issue by creating wrapper classes that wrap these primitive constructor parameters
+ * in [[Option]]s, and then un-wrapping them as needed, performing the appropriate Option[T] => T
+ * parameter conversions.
+ */
+
+private[internal] trait Parquet4sWrapper[T] {
+  def unwrap: T
+}
+
+private[internal] case class Parquet4sRemoveFileWrapper(
+    path: String,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    deletionTimestamp: Option[Long],
+    dataChangeOpt: Option[Boolean] = Some(true),
+    extendedFileMetadataOpt: Option[Boolean] = Some(false),
+    partitionValues: Map[String, String] = null,
+    size: Option[Long] = Some(0),
+    tags: Map[String, String] = null) extends Parquet4sWrapper[RemoveFile] {
+
+  override def unwrap: RemoveFile = RemoveFile(
+    path,
+    deletionTimestamp,
+    dataChangeOpt.contains(true),
+    extendedFileMetadataOpt.contains(true),
+    partitionValues,
+    size match {
+      case Some(x) => x;
+      case _ => 0
+    },
+    tags
+  )
+}
+
+private[internal] case class Parquet4sSingleActionWrapper(
+    txn: SetTransaction = null,
+    add: AddFile = null,
+    remove: Parquet4sRemoveFileWrapper = null,
+    metaData: Metadata = null,
+    protocol: Protocol = null,
+    cdc: AddCDCFile = null,
+    commitInfo: CommitInfo = null) extends Parquet4sWrapper[SingleAction] {
+
+  override def unwrap: SingleAction = SingleAction(
+    txn,
+    add,
+    remove match {
+      case x: Parquet4sRemoveFileWrapper if x != null => x.unwrap
+      case _ => null
+    },
+    metaData,
+    protocol,
+    cdc,
+    commitInfo
+  )
 }

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
@@ -46,9 +46,6 @@ private[internal] sealed trait Action {
   def wrap: SingleAction
 
   def json: String = JsonUtils.toJson(wrap)
-
-  // TODO:
-//  def toJava
 }
 
 /**

--- a/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
@@ -104,10 +104,8 @@ private[internal] object DeltaErrors {
     new IllegalStateException(
       s"""The stream from your Delta table was expecting process data from version $expectedVersion,
          |but the earliest available version in the _delta_log directory is $seenVersion. The files
-         |in the transaction log may have been deleted due to log cleanup. In order to avoid losing
-         |data, we recommend that you restart your stream with a new checkpoint location and to
-         |increase your delta.logRetentionDuration setting, if you have explicitly set it below 30
-         |days.
+         |in the transaction log may have been deleted due to log cleanup.
+         |
          |If you would like to ignore the missed data and continue your stream from where it left
          |off, you can set the .option("failOnDataLoss", "false") as part
          |of your readStream statement.

--- a/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
@@ -99,4 +99,19 @@ private[internal] object DeltaErrors {
     new NullPointerException(s"Read a null value for field $fieldName, yet schema indicates " +
       s"that this field can't be null. Schema: ${schema.getTreeString}")
   }
+
+  def failOnDataLossException(expectedVersion: Long, seenVersion: Long): Throwable = {
+    new IllegalStateException(
+      s"""The stream from your Delta table was expecting process data from version $expectedVersion,
+         |but the earliest available version in the _delta_log directory is $seenVersion. The files
+         |in the transaction log may have been deleted due to log cleanup. In order to avoid losing
+         |data, we recommend that you restart your stream with a new checkpoint location and to
+         |increase your delta.logRetentionDuration setting, if you have explicitly set it below 30
+         |days.
+         |If you would like to ignore the missed data and continue your stream from where it left
+         |off, you can set the .option("failOnDataLoss", "false") as part
+         |of your readStream statement.
+       """.stripMargin
+    )
+  }
 }

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/ConversionUtils.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/ConversionUtils.scala
@@ -21,8 +21,8 @@ import java.util.{Optional => OptionalJ}
 
 import collection.JavaConverters._
 
-import io.delta.standalone.actions.{Action => ActionJ, AddFile => AddFileJ, CommitInfo => CommitInfoJ, Format => FormatJ, JobInfo => JobInfoJ, Metadata => MetadataJ, NotebookInfo => NotebookInfoJ, RemoveFile => RemoveFileJ, SetTransaction => SetTransactionJ, Protocol => ProtocolJ}
-import io.delta.standalone.internal.actions.{Action, AddFile, CommitInfo, Format, JobInfo, Metadata, NotebookInfo, Protocol, RemoveFile, SetTransaction}
+import io.delta.standalone.actions.{Action => ActionJ, AddFile => AddFileJ, AddCDCFile => AddCDCFileJ, CommitInfo => CommitInfoJ, Format => FormatJ, JobInfo => JobInfoJ, Metadata => MetadataJ, NotebookInfo => NotebookInfoJ, Protocol => ProtocolJ, RemoveFile => RemoveFileJ, SetTransaction => SetTransactionJ}
+import io.delta.standalone.internal.actions.{Action, AddCDCFile, AddFile, CommitInfo, Format, JobInfo, Metadata, NotebookInfo, Protocol, RemoveFile, SetTransaction}
 
 /**
  * Provide helper methods to convert from Scala to Java types.
@@ -74,6 +74,14 @@ private[internal] object ConversionUtils {
       internal.modificationTime,
       internal.dataChange,
       internal.stats,
+      mapAsJava(internal.tags))
+  }
+
+  def convertAddCDCFile(internal: AddCDCFile): AddCDCFileJ = {
+    new AddCDCFileJ(
+      internal.path,
+      internal.partitionValues.asJava,
+      internal.size,
       mapAsJava(internal.tags))
   }
 
@@ -169,7 +177,7 @@ private[internal] object ConversionUtils {
 
   def convertAction(internal: Action): ActionJ = internal match {
     case x: AddFile => convertAddFile(x)
-//    case a: AddCDCFile => convertAddCDCFile(a)
+    case a: AddCDCFile => convertAddCDCFile(a)
     case x: RemoveFile => convertRemoveFile(x)
     case x: CommitInfo => convertCommitInfo(x)
     case x: Format => convertFormat(x)
@@ -178,6 +186,5 @@ private[internal] object ConversionUtils {
     case x: NotebookInfo => convertNotebookInfo(x)
     case x: SetTransaction => convertSetTransaction(x)
     case x: Protocol => convertProtocol(x)
-    case _ => null
   }
 }

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/ConversionUtils.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/ConversionUtils.scala
@@ -33,7 +33,7 @@ private[internal] object ConversionUtils {
    * This is a workaround for a known issue in Scala 2.11: `asJava` doesn't handle `null`.
    * See https://github.com/scala/scala/pull/4343
    */
-  private def mapAsJava[K, V](map: Map[K, V]): java.util.Map[K, V] = {
+  private def nullableMapAsJava[K, V](map: Map[K, V]): java.util.Map[K, V] = {
     if (map == null) {
       null
     } else {
@@ -74,7 +74,7 @@ private[internal] object ConversionUtils {
       internal.modificationTime,
       internal.dataChange,
       internal.stats,
-      mapAsJava(internal.tags))
+      nullableMapAsJava(internal.tags))
   }
 
   def convertAddCDCFile(internal: AddCDCFile): AddCDCFileJ = {
@@ -82,14 +82,18 @@ private[internal] object ConversionUtils {
       internal.path,
       internal.partitionValues.asJava,
       internal.size,
-      mapAsJava(internal.tags))
+      nullableMapAsJava(internal.tags))
   }
 
   def convertRemoveFile(internal: RemoveFile): RemoveFileJ = {
     new RemoveFileJ(
       internal.path,
       toJavaLongOptional(internal.deletionTimestamp),
-      internal.dataChange)
+      internal.dataChange,
+      internal.extendedFileMetadata,
+      nullableMapAsJava(internal.partitionValues),
+      internal.size,
+      nullableMapAsJava(internal.tags))
   }
 
   /**

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/ConversionUtils.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/ConversionUtils.scala
@@ -21,8 +21,8 @@ import java.util.{Optional => OptionalJ}
 
 import collection.JavaConverters._
 
-import io.delta.standalone.actions.{AddFile => AddFileJ, CommitInfo => CommitInfoJ, Format => FormatJ, JobInfo => JobInfoJ, Metadata => MetadataJ, NotebookInfo => NotebookInfoJ}
-import io.delta.standalone.internal.actions.{AddFile, CommitInfo, Format, JobInfo, Metadata, NotebookInfo}
+import io.delta.standalone.actions.{SetTransaction, Action => ActionJ, AddFile => AddFileJ, CommitInfo => CommitInfoJ, Format => FormatJ, JobInfo => JobInfoJ, Metadata => MetadataJ, NotebookInfo => NotebookInfoJ}
+import io.delta.standalone.internal.actions.{Action, AddFile, CommitInfo, Format, JobInfo, Metadata, NotebookInfo}
 
 /**
  * Provide helper methods to convert from Scala to Java types.
@@ -150,5 +150,16 @@ private[internal] object ConversionUtils {
    */
   def convertNotebookInfo(internal: NotebookInfo): NotebookInfoJ = {
     new NotebookInfoJ(internal.notebookId)
+  }
+
+  def convertAction(internal: Action): ActionJ = internal match {
+    case x: AddFile => convertAddFile(x)
+//    case a: AddCDCFile => convertAddCDCFile(a)
+    case x: CommitInfo => convertCommitInfo(x)
+    case x: Format => convertFormat(x)
+    case x: JobInfo => convertJobInfo(x)
+    case x: Metadata => convertMetadata(x)
+    case x: NotebookInfo => convertNotebookInfo(x)
+//    case x: SetTransaction => convertSetTransaction(x)
   }
 }

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/ConversionUtils.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/ConversionUtils.scala
@@ -21,8 +21,8 @@ import java.util.{Optional => OptionalJ}
 
 import collection.JavaConverters._
 
-import io.delta.standalone.actions.{SetTransaction, Action => ActionJ, AddFile => AddFileJ, CommitInfo => CommitInfoJ, Format => FormatJ, JobInfo => JobInfoJ, Metadata => MetadataJ, NotebookInfo => NotebookInfoJ}
-import io.delta.standalone.internal.actions.{Action, AddFile, CommitInfo, Format, JobInfo, Metadata, NotebookInfo}
+import io.delta.standalone.actions.{Action => ActionJ, AddFile => AddFileJ, CommitInfo => CommitInfoJ, Format => FormatJ, JobInfo => JobInfoJ, Metadata => MetadataJ, NotebookInfo => NotebookInfoJ, RemoveFile => RemoveFileJ, SetTransaction => SetTransactionJ, Protocol => ProtocolJ}
+import io.delta.standalone.internal.actions.{Action, AddFile, CommitInfo, Format, JobInfo, Metadata, NotebookInfo, Protocol, RemoveFile, SetTransaction}
 
 /**
  * Provide helper methods to convert from Scala to Java types.
@@ -75,6 +75,13 @@ private[internal] object ConversionUtils {
       internal.dataChange,
       internal.stats,
       mapAsJava(internal.tags))
+  }
+
+  def convertRemoveFile(internal: RemoveFile): RemoveFileJ = {
+    new RemoveFileJ(
+      internal.path,
+      toJavaLongOptional(internal.deletionTimestamp),
+      internal.dataChange)
   }
 
   /**
@@ -152,14 +159,25 @@ private[internal] object ConversionUtils {
     new NotebookInfoJ(internal.notebookId)
   }
 
+  def convertSetTransaction(internal: SetTransaction): SetTransactionJ = {
+    new SetTransactionJ(internal.appId, internal.version, toJavaLongOptional(internal.lastUpdated))
+  }
+
+  def convertProtocol(internal: Protocol): ProtocolJ = {
+    new ProtocolJ(internal.minReaderVersion, internal.minWriterVersion)
+  }
+
   def convertAction(internal: Action): ActionJ = internal match {
     case x: AddFile => convertAddFile(x)
 //    case a: AddCDCFile => convertAddCDCFile(a)
+    case x: RemoveFile => convertRemoveFile(x)
     case x: CommitInfo => convertCommitInfo(x)
     case x: Format => convertFormat(x)
     case x: JobInfo => convertJobInfo(x)
     case x: Metadata => convertMetadata(x)
     case x: NotebookInfo => convertNotebookInfo(x)
-//    case x: SetTransaction => convertSetTransaction(x)
+    case x: SetTransaction => convertSetTransaction(x)
+    case x: Protocol => convertProtocol(x)
+    case _ => null
   }
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -283,7 +283,7 @@ class DeltaLogSuite extends FunSuite {
     withLogForGoldenTable("deltalog-getChanges") { log =>
       val versionToActionsMap = Map(
         0L -> Seq("CommitInfo", "Protocol", "Metadata", "AddFile"),
-        1L -> Seq("CommitInfo", "AddFile", "RemoveFile"),
+        1L -> Seq("CommitInfo", "AddCDCFile", "RemoveFile"),
         2L -> Seq("CommitInfo", "Protocol", "SetTransaction")
       )
 

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -288,14 +288,14 @@ class DeltaLogSuite extends FunSuite {
       )
 
       def verifyChanges(startVersion: Int): Unit = {
-        val versionDeltas = log.getChanges(startVersion, false).asScala.toSeq
+        val versionLogs = log.getChanges(startVersion, false).asScala.toSeq
 
-        assert(versionDeltas.length == 3 - startVersion,
+        assert(versionLogs.length == 3 - startVersion,
           s"getChanges($startVersion) skipped some versions")
 
-        for (versionDelta <- versionDeltas) {
-          val version = versionDelta.getVersion
-          val actions = versionDelta.getActions.asScala.map(_.getClass.getSimpleName)
+        for (versionLog <- versionLogs) {
+          val version = versionLog.getVersion
+          val actions = versionLog.getActions.asScala.map(_.getClass.getSimpleName)
           val expectedActions = versionToActionsMap(version)
           assert(expectedActions == actions,
             s"getChanges($startVersion) had incorrect actions at version $version.")
@@ -308,8 +308,8 @@ class DeltaLogSuite extends FunSuite {
       verifyChanges(2)
 
       // non-existant start version
-      val versionDeltasIter = log.getChanges(3, false)
-      assert(!versionDeltasIter.hasNext,
+      val versionLogsIter = log.getChanges(3, false)
+      assert(!versionLogsIter.hasNext,
         "getChanges with a non-existant start version did not return an empty iterator")
 
       // negative start version
@@ -331,13 +331,13 @@ class DeltaLogSuite extends FunSuite {
         new File(new Path(logPath, "00000000000000000000.json").toUri).delete()
         new File(new Path(logPath, "00000000000000000001.json").toUri).delete()
 
-        val versionDeltas = log.getChanges(0, false).asScala.toSeq
-        assert(versionDeltas.length == 1)
+        val versionLogs = log.getChanges(0, false).asScala.toSeq
+        assert(versionLogs.length == 1)
 
         assertThrows[IllegalStateException] {
-          val versionDeltasIter = log.getChanges(0, true)
-          while (versionDeltasIter.hasNext) {
-            versionDeltasIter.next()
+          val versionLogsIter = log.getChanges(0, true)
+          while (versionLogsIter.hasNext) {
+            versionLogsIter.next()
           }
         }
       } finally {

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -279,4 +279,19 @@ class DeltaLogSuite extends FunSuite {
     }
   }
 
+  test("get changes (all files) since a given table version") {
+    // scalastyle:off println
+    println("asdf")
+    // scalastyle:on println
+    withLogForGoldenTable("snapshot-data0") { log =>
+      log.getChanges(0, false)
+      var y = 5
+    }
+
+    withLogForGoldenTable("snapshot-data1") { log =>
+      var x = 5
+      var y = 5
+    }
+  }
+
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/util/GoldenTableUtils.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/util/GoldenTableUtils.scala
@@ -24,11 +24,17 @@ import org.apache.hadoop.conf.Configuration
 
 object GoldenTableUtils {
 
-  /** Load the golden table as a class resource so that it works in IntelliJ and SBT tests */
+  /**
+   * Load the golden table as a class resource so that it works in IntelliJ and SBT tests.
+   *
+   * If this is causing a `java.lang.NullPointerException` while debugging in IntelliJ, you
+   * probably just need to run `build/sbt goldenTables/test`.
+   */
   val goldenTable = new File(getClass.getResource("/golden").toURI)
 
   /**
-   * Create a [[DeltaLog]] for the given golden table and execute the test function.
+   * Create a [[DeltaLog]] (with Java interface) for the given golden table and execute the test
+   * function.
    *
    * @param name The name of the golden table to load.
    * @param testFunc The test to execute which takes the [[DeltaLog]] as input arg.

--- a/standalone/src/test/scala/io/delta/standalone/internal/util/GoldenTableUtils.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/util/GoldenTableUtils.scala
@@ -28,7 +28,7 @@ object GoldenTableUtils {
    * Load the golden table as a class resource so that it works in IntelliJ and SBT tests.
    *
    * If this is causing a `java.lang.NullPointerException` while debugging in IntelliJ, you
-   * probably just need to run `build/sbt goldenTables/test`.
+   * probably just need to SBT test that specific test first.
    */
   val goldenTable = new File(getClass.getResource("/golden").toURI)
 


### PR DESCRIPTION
- resolves #101 
- adds `DeltaLog::getChanges` API. Exposes an iterator of `VersionDelta`s, which is a java wrapper class containing the version and actions.
- includes `DeltaLog.java` public interface
- includes `DeltaLogImpl.scala` internal implementation
- adds remaining `Actions` missing from Delta OSS (RemoveFile, AddCDCFIle, Protocol, SetTransaction) as both internal scala representations and public java interfaces
- includes tests in `DeltaLogSuite.scala`
- increases goldenTables project delta oss version to 0.8.0 (to get access to AddCDCFile)
- proper javadoc TODO