### PR TITLE
Add getJson method to DataType.java 

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/types/DataType.java
+++ b/standalone/src/main/java/io/delta/standalone/types/DataType.java
@@ -79,7 +79,7 @@ public abstract class DataType {
     /**
      * @return a JSON (@code String} representation of the type
      */
-    public String toJson() { return DataTypeParser.toJson(this); }
+    public String getJson() { return DataTypeParser.toJson(this); }
 
     /**
      * Builds a readable {@code String} representation of the {@code ArrayType}

--- a/standalone/src/main/java/io/delta/standalone/types/DataType.java
+++ b/standalone/src/main/java/io/delta/standalone/types/DataType.java
@@ -41,6 +41,8 @@ package io.delta.standalone.types;
 import java.util.Locale;
 import java.util.Objects;
 
+import io.delta.standalone.internal.util.DataTypeParser;
+
 /**
  * The base type of all {@code io.delta.standalone} data types.
  * Represents a bare-bones Java implementation of the Spark SQL
@@ -73,6 +75,11 @@ public abstract class DataType {
     public String getCatalogString() {
         return getSimpleString();
     }
+
+    /**
+     * @return a JSON (@code String} representation of the type
+     */
+    public String toJson() { return DataTypeParser.toJson(this); }
 
     /**
      * Builds a readable {@code String} representation of the {@code ArrayType}

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/DataTypeParser.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/DataTypeParser.scala
@@ -42,9 +42,10 @@ import io.delta.standalone.types._
 
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
+import org.json4s.JsonDSL._
 import org.json4s.JsonAST.JValue
 
-private[internal] object DataTypeParser {
+object DataTypeParser {
 
   private val FIXED_DECIMAL = """decimal\(\s*(\d+)\s*,\s*(\-?\d+)\s*\)""".r
 
@@ -81,6 +82,39 @@ private[internal] object DataTypeParser {
     case other =>
       throw new IllegalArgumentException(
         s"Failed to convert the JSON string '${compact(render(other))}' to a data type.")
+  }
+
+  def toJson(value : DataType): String = {
+    compact(render(dataTypeToJValue(value)))
+  }
+
+  def dataTypeToJValue(dataType: DataType): JValue = dataType match {
+    case array: ArrayType =>
+      ("type" -> "array") ~
+        ("elementType" -> dataTypeToJValue(array.getElementType)) ~
+        ("containsNull" -> array.containsNull())
+    case map: MapType =>
+      ("type" -> "map") ~
+        ("keyType" -> dataTypeToJValue(map.getKeyType())) ~
+        ("valueType" -> dataTypeToJValue(map.getValueType())) ~
+        ("valueContainsNull" -> map.valueContainsNull())
+    case struct: StructType =>
+      ("type" -> "struct") ~
+        ("fields" -> struct.getFields().map(structFieldToJValue).toList)
+    case decimal: DecimalType =>
+      s"decimal(${decimal.getPrecision()},${decimal.getScale()})"
+    case _: DataType =>
+      dataType.getTypeName()
+  }
+
+  def structFieldToJValue(field: StructField): JValue = {
+    val name = field.getName()
+    val dataType = field.getDataType()
+    val nullable = field.isNullable()
+
+    ("name" -> name) ~
+      ("type" -> dataTypeToJValue(dataType)) ~
+      ("nullable" -> nullable)
   }
 
   /** Given the string representation of a type, return its DataType */

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
@@ -26,8 +26,9 @@ import scala.collection.JavaConverters._
 import io.delta.standalone.data.{RowRecord => JRowRecord}
 import io.delta.standalone.DeltaLog
 import io.delta.standalone.internal.sources.StandaloneHadoopConf
+import io.delta.standalone.internal.util.DataTypeParser
 import io.delta.standalone.internal.util.GoldenTableUtils._
-import io.delta.standalone.types.{DateType, StructField, StructType, TimestampType}
+import io.delta.standalone.types._
 import org.apache.hadoop.conf.Configuration
 // scalastyle:off funsuite
 import org.scalatest.FunSuite
@@ -300,4 +301,39 @@ class DeltaDataReaderSuite extends FunSuite {
       assert(row.getSchema == expectedSchema)
     }
   }
+
+  def checkDataTypeToJsonFromJson(dataType: DataType): Unit = {
+    test(s"DataType to Json and from Json - $dataType") {
+      assert(DataTypeParser.fromJson(dataType.toJson()) === dataType)
+    }
+
+    test(s"DataType inside StructType to Json and from Json - $dataType") {
+      val field1 = new StructField("foo", dataType, true)
+      val field2 = new StructField("bar", dataType, true)
+      val struct = new StructType(Array(field1, field2))
+      assert(DataTypeParser.fromJson(DataTypeParser.toJson(struct)) === struct)
+    }
+  }
+
+  checkDataTypeToJsonFromJson(new BooleanType)
+  checkDataTypeToJsonFromJson(new ByteType)
+  checkDataTypeToJsonFromJson(new ShortType)
+  checkDataTypeToJsonFromJson(new IntegerType)
+  checkDataTypeToJsonFromJson(new LongType)
+  checkDataTypeToJsonFromJson(new FloatType)
+  checkDataTypeToJsonFromJson(new DoubleType)
+  checkDataTypeToJsonFromJson(new DecimalType(10, 5))
+  checkDataTypeToJsonFromJson(DecimalType.USER_DEFAULT)
+  checkDataTypeToJsonFromJson(new DateType)
+  checkDataTypeToJsonFromJson(new TimestampType)
+  checkDataTypeToJsonFromJson(new StringType)
+  checkDataTypeToJsonFromJson(new BinaryType)
+  checkDataTypeToJsonFromJson(new ArrayType(new DoubleType, true))
+  checkDataTypeToJsonFromJson(new ArrayType(new StringType, false))
+  checkDataTypeToJsonFromJson(new MapType(new IntegerType, new StringType, true))
+  checkDataTypeToJsonFromJson(
+    new MapType(
+      new IntegerType,
+      new ArrayType(new DoubleType, true),
+      false))
 }


### PR DESCRIPTION
This PR adds support for conversion to json strings in `DataTypeParser.scala` and exposure via a `String getJson()` method in `DataType.java.` Includes added tests in `DeltaDataReaderSuite.scala.`