### PR TITLE
Expose column metadata in table schema

### DIFF
--- a/hive/src/main/scala/io/delta/hive/DeltaHelper.scala
+++ b/hive/src/main/scala/io/delta/hive/DeltaHelper.scala
@@ -80,8 +80,12 @@ object DeltaHelper {
         snapshotToUse.getAllFiles.asScala
       ).map { addF =>
         // Drop unused potential huge fields
-        val f = new AddFile(addF.getPath, addF.getPartitionValues, addF.getSize,
-          addF.getModificationTime, addF.isDataChange, null, null)
+        val f = new AddFile.AddFileBuilder(
+          addF.getPath,
+          addF.getPartitionValues,
+          addF.getSize,
+          addF.getModificationTime,
+          addF.isDataChange).build()
 
         val status = toFileStatus(fs, rootPath, f, blockSize)
         localFileToPartition +=

--- a/hive/src/main/scala/io/delta/hive/DeltaHelper.scala
+++ b/hive/src/main/scala/io/delta/hive/DeltaHelper.scala
@@ -80,7 +80,7 @@ object DeltaHelper {
         snapshotToUse.getAllFiles.asScala
       ).map { addF =>
         // Drop unused potential huge fields
-        val f = new AddFile.AddFileBuilder(
+        val f = AddFile.builder(
           addF.getPath,
           addF.getPartitionValues,
           addF.getSize,

--- a/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
@@ -170,6 +170,9 @@ public final class AddFile implements FileAction {
             return this;
         }
 
+        /**
+         * @return a new {@code AddFile} with the same properties as {@code this}
+         */
         public AddFile build() {
             AddFile addFile = new AddFile(this);
             return addFile;

--- a/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
@@ -49,6 +49,16 @@ public final class AddFile implements FileAction {
         this.tags = tags;
     }
 
+    private AddFile(AddFileBuilder builder) {
+        this.path = builder.path;
+        this.partitionValues = builder.partitionValues;
+        this.size = builder.size;
+        this.modificationTime = builder.modificationTime;
+        this.dataChange = builder.dataChange;
+        this.stats = builder.stats;
+        this.tags = builder.tags;
+    }
+
     /**
      * @return the relative path or the absolute path that should be added to the table. If it's a
      *         relative path, it's relative to the root of the table. Note: the path is encoded and
@@ -126,5 +136,40 @@ public final class AddFile implements FileAction {
     @Override
     public int hashCode() {
         return Objects.hash(path, partitionValues, size, modificationTime, dataChange, stats, tags);
+    }
+
+    public static class AddFileBuilder {
+        // add default values here, or in the constructor (values besides null)
+        private final String path;
+        private final Map<String, String> partitionValues;
+        private final long size;
+        private final long modificationTime;
+        private final boolean dataChange;
+        private String stats;
+        private Map<String, String> tags;
+
+        public AddFileBuilder(String path, Map<String, String> partitionValues, long size,
+                              long modificationTime, boolean dataChange) {
+            this.path = path;
+            this.partitionValues = partitionValues;
+            this.size = size;
+            this.modificationTime = modificationTime;
+            this.dataChange = dataChange;
+        }
+
+        public AddFileBuilder stats(String stats) {
+            this.stats = stats;
+            return this;
+        }
+
+        public AddFileBuilder tags(Map<String, String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        public AddFile build() {
+            AddFile addFile = new AddFile(this);
+            return addFile;
+        }
     }
 }

--- a/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
@@ -49,16 +49,6 @@ public final class AddFile implements FileAction {
         this.tags = tags;
     }
 
-    private AddFile(AddFileBuilder builder) {
-        this.path = builder.path;
-        this.partitionValues = builder.partitionValues;
-        this.size = builder.size;
-        this.modificationTime = builder.modificationTime;
-        this.dataChange = builder.dataChange;
-        this.stats = builder.stats;
-        this.tags = builder.tags;
-    }
-
     /**
      * @return the relative path or the absolute path that should be added to the table. If it's a
      *         relative path, it's relative to the root of the table. Note: the path is encoded and
@@ -139,19 +129,28 @@ public final class AddFile implements FileAction {
     }
 
     /**
+     * @return a new {@code AddFile.Builder}
+     */
+    public static Builder builder(String path, Map<String, String> partitionValues, long size,
+                                  long modificationTime, boolean dataChange) {
+        return new Builder(path, partitionValues, size, modificationTime, dataChange);
+    }
+
+    /**
      * Builder class for AddFile. Enables construction of AddFile object with default values.
      */
-    public static class AddFileBuilder {
-        // add default values here, or in the constructor (values besides null)
+    public static class Builder {
+        // required AddFile fields
         private final String path;
         private final Map<String, String> partitionValues;
         private final long size;
         private final long modificationTime;
         private final boolean dataChange;
+        //  optional AddFile fields
         private String stats;
         private Map<String, String> tags;
 
-        public AddFileBuilder(String path, Map<String, String> partitionValues, long size,
+        public Builder(String path, Map<String, String> partitionValues, long size,
                               long modificationTime, boolean dataChange) {
             this.path = path;
             this.partitionValues = partitionValues;
@@ -160,12 +159,12 @@ public final class AddFile implements FileAction {
             this.dataChange = dataChange;
         }
 
-        public AddFileBuilder stats(String stats) {
+        public Builder stats(String stats) {
             this.stats = stats;
             return this;
         }
 
-        public AddFileBuilder tags(Map<String, String> tags) {
+        public Builder tags(Map<String, String> tags) {
             this.tags = tags;
             return this;
         }
@@ -174,7 +173,8 @@ public final class AddFile implements FileAction {
          * @return a new {@code AddFile} with the same properties as {@code this}
          */
         public AddFile build() {
-            AddFile addFile = new AddFile(this);
+            AddFile addFile = new AddFile(this.path, this.partitionValues, this.size,
+                    this.modificationTime, this.dataChange, this.stats, this.tags);
             return addFile;
         }
     }

--- a/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
@@ -138,6 +138,9 @@ public final class AddFile implements FileAction {
         return Objects.hash(path, partitionValues, size, modificationTime, dataChange, stats, tags);
     }
 
+    /**
+     * Builder class for AddFile. Enables construction of AddFile object with default values.
+     */
     public static class AddFileBuilder {
         // add default values here, or in the constructor (values besides null)
         private final String path;

--- a/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
@@ -233,8 +233,8 @@ public class CommitInfo implements Action {
         private Optional<Map<String, String>> operationMetrics = Optional.empty();
         private Optional<String> userMetadata = Optional.empty();
 
-        public CommitInfoBuilder version(Optional<Long> version) {
-            this.version = version;
+        public CommitInfoBuilder version(Long version) {
+            this.version = Optional.of(version);
             return this;
         }
 
@@ -243,13 +243,13 @@ public class CommitInfo implements Action {
             return this;
         }
 
-        public CommitInfoBuilder userId(Optional<String> userId) {
-            this.userId = userId;
+        public CommitInfoBuilder userId(String userId) {
+            this.userId = Optional.of(userId);
             return this;
         }
 
-        public CommitInfoBuilder userName(Optional<String> userName) {
-            this.userName = userName;
+        public CommitInfoBuilder userName(String userName) {
+            this.userName = Optional.of(userName);
             return this;
         }
 
@@ -263,43 +263,43 @@ public class CommitInfo implements Action {
             return this;
         }
 
-        public CommitInfoBuilder jobInfo(Optional<JobInfo> jobInfo) {
-            this.jobInfo = jobInfo;
+        public CommitInfoBuilder jobInfo(JobInfo jobInfo) {
+            this.jobInfo = Optional.of(jobInfo);
             return this;
         }
 
-        public CommitInfoBuilder notebookInfo(Optional<NotebookInfo> notebookInfo ) {
-            this.notebookInfo = notebookInfo;
+        public CommitInfoBuilder notebookInfo(NotebookInfo notebookInfo ) {
+            this.notebookInfo = Optional.of(notebookInfo);
             return this;
         }
 
-        public CommitInfoBuilder clusterId(Optional<String> clusterId) {
-            this.clusterId = clusterId;
+        public CommitInfoBuilder clusterId(String clusterId) {
+            this.clusterId = Optional.of(clusterId);
             return this;
         }
 
-        public CommitInfoBuilder readVersion(Optional<Long> readVersion) {
-            this.readVersion = readVersion;
+        public CommitInfoBuilder readVersion(Long readVersion) {
+            this.readVersion = Optional.of(readVersion);
             return this;
         }
 
-        public CommitInfoBuilder isolationLevel(Optional<String> isolationLevel) {
-            this.isolationLevel = isolationLevel;
+        public CommitInfoBuilder isolationLevel(String isolationLevel) {
+            this.isolationLevel = Optional.of(isolationLevel);
             return this;
         }
 
-        public CommitInfoBuilder isBlindAppend(Optional<Boolean> isBlindAppend) {
-            this.isBlindAppend = isBlindAppend;
+        public CommitInfoBuilder isBlindAppend(Boolean isBlindAppend) {
+            this.isBlindAppend = Optional.of(isBlindAppend);
             return this;
         }
 
-        public CommitInfoBuilder operationMetrics(Optional<Map<String, String>> operationMetrics) {
-            this.operationMetrics = operationMetrics;
+        public CommitInfoBuilder operationMetrics(Map<String, String> operationMetrics) {
+            this.operationMetrics = Optional.of(operationMetrics);
             return this;
         }
 
-        public CommitInfoBuilder userMetadata(Optional<String> userMetadata) {
-            this.userMetadata = userMetadata;
+        public CommitInfoBuilder userMetadata(String userMetadata) {
+            this.userMetadata = Optional.of(userMetadata);
             return this;
         }
 

--- a/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
@@ -218,44 +218,89 @@ public class CommitInfo implements Action {
      * Builder class for CommitInfo. Enables construction of RemoveFile object with default values.
      */
     public static class CommitInfoBuilder {
-        // TODO
-        private final Optional<Long> version;
-        private final Timestamp timestamp;
-        private final Optional<String> userId;
-        private final Optional<String> userName;
-        private final String operation;
-        private final Map<String, String> operationParameters;
-        private final Optional<JobInfo> jobInfo;
-        private final Optional<NotebookInfo> notebookInfo;
-        private final Optional<String> clusterId;
-        private final Optional<Long> readVersion;
-        private final Optional<String> isolationLevel;
-        private final Optional<Boolean> isBlindAppend;
-        private final Optional<Map<String, String>> operationMetrics;
-        private final Optional<String> userMetadata;
+        private Optional<Long> version = Optional.empty();
+        private Timestamp timestamp;
+        private Optional<String> userId = Optional.empty();
+        private Optional<String> userName = Optional.empty();
+        private String operation;
+        private Map<String, String> operationParameters;
+        private Optional<JobInfo> jobInfo = Optional.empty();
+        private Optional<NotebookInfo> notebookInfo = Optional.empty();
+        private Optional<String> clusterId = Optional.empty();
+        private Optional<Long> readVersion = Optional.empty();
+        private Optional<String> isolationLevel = Optional.empty();
+        private Optional<Boolean> isBlindAppend = Optional.empty();
+        private Optional<Map<String, String>> operationMetrics = Optional.empty();
+        private Optional<String> userMetadata = Optional.empty();
 
-        public CommitInfoBuilder(Optional<Long> version, Timestamp timestamp, Optional<String> userId,
-                                 Optional<String> userName, String operation,
-                                 Map<String, String> operationParameters, Optional<JobInfo> jobInfo,
-                                 Optional<NotebookInfo> notebookInfo, Optional<String> clusterId,
-                                 Optional<Long> readVersion, Optional<String> isolationLevel,
-                                 Optional<Boolean> isBlindAppend,
-                                 Optional<Map<String, String>> operationMetrics,
-                                 Optional<String> userMetadata) {
+        public CommitInfoBuilder version(Optional<Long> version) {
             this.version = version;
+            return this;
+        }
+
+        public CommitInfoBuilder timestamp(Timestamp timestamp) {
             this.timestamp = timestamp;
+            return this;
+        }
+
+        public CommitInfoBuilder userId(Optional<String> userId) {
             this.userId = userId;
+            return this;
+        }
+
+        public CommitInfoBuilder userName(Optional<String> userName) {
             this.userName = userName;
+            return this;
+        }
+
+        public CommitInfoBuilder operation(String operation) {
             this.operation = operation;
+            return this;
+        }
+
+        public CommitInfoBuilder operationParameters(Map<String, String> operationParameters) {
             this.operationParameters = operationParameters;
+            return this;
+        }
+
+        public CommitInfoBuilder jobInfo(Optional<JobInfo> jobInfo) {
             this.jobInfo = jobInfo;
+            return this;
+        }
+
+        public CommitInfoBuilder notebookInfo(Optional<NotebookInfo> notebookInfo ) {
             this.notebookInfo = notebookInfo;
+            return this;
+        }
+
+        public CommitInfoBuilder clusterId(Optional<String> clusterId) {
             this.clusterId = clusterId;
+            return this;
+        }
+
+        public CommitInfoBuilder readVersion(Optional<Long> readVersion) {
             this.readVersion = readVersion;
+            return this;
+        }
+
+        public CommitInfoBuilder isolationLevel(Optional<String> isolationLevel) {
             this.isolationLevel = isolationLevel;
+            return this;
+        }
+
+        public CommitInfoBuilder isBlindAppend(Optional<Boolean> isBlindAppend) {
             this.isBlindAppend = isBlindAppend;
+            return this;
+        }
+
+        public CommitInfoBuilder operationMetrics(Optional<Map<String, String>> operationMetrics) {
             this.operationMetrics = operationMetrics;
+            return this;
+        }
+
+        public CommitInfoBuilder userMetadata(Optional<String> userMetadata) {
             this.userMetadata = userMetadata;
+            return this;
         }
 
         /**

--- a/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
@@ -68,23 +68,6 @@ public class CommitInfo implements Action {
         this.userMetadata = userMetadata;
     }
 
-    public CommitInfo(CommitInfoBuilder builder) {
-        this.version = builder.version;
-        this.timestamp = builder.timestamp;
-        this.userId = builder.userId;
-        this.userName = builder.userName;
-        this.operation = builder.operation;
-        this.operationParameters = builder.operationParameters;
-        this.jobInfo = builder.jobInfo;
-        this.notebookInfo = builder.notebookInfo;
-        this.clusterId = builder.clusterId;
-        this.readVersion = builder.readVersion;
-        this.isolationLevel = builder.isolationLevel;
-        this.isBlindAppend = builder.isBlindAppend;
-        this.operationMetrics = builder.operationMetrics;
-        this.userMetadata = builder.userMetadata;
-    }
-
     /**
      * @return the log version for this commit
      */
@@ -215,9 +198,17 @@ public class CommitInfo implements Action {
     }
 
     /**
-     * Builder class for CommitInfo. Enables construction of RemoveFile object with default values.
+     * @return a new {@code CommitInfo.Builder}
      */
-    public static class CommitInfoBuilder {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+
+    /**
+     * Builder class for CommitInfo. Enables construction of CommitInfo object with default values.
+     */
+    public static class Builder {
         private Optional<Long> version = Optional.empty();
         private Timestamp timestamp;
         private Optional<String> userId = Optional.empty();
@@ -233,72 +224,72 @@ public class CommitInfo implements Action {
         private Optional<Map<String, String>> operationMetrics = Optional.empty();
         private Optional<String> userMetadata = Optional.empty();
 
-        public CommitInfoBuilder version(Long version) {
+        public Builder version(Long version) {
             this.version = Optional.of(version);
             return this;
         }
 
-        public CommitInfoBuilder timestamp(Timestamp timestamp) {
+        public Builder timestamp(Timestamp timestamp) {
             this.timestamp = timestamp;
             return this;
         }
 
-        public CommitInfoBuilder userId(String userId) {
+        public Builder userId(String userId) {
             this.userId = Optional.of(userId);
             return this;
         }
 
-        public CommitInfoBuilder userName(String userName) {
+        public Builder userName(String userName) {
             this.userName = Optional.of(userName);
             return this;
         }
 
-        public CommitInfoBuilder operation(String operation) {
+        public Builder operation(String operation) {
             this.operation = operation;
             return this;
         }
 
-        public CommitInfoBuilder operationParameters(Map<String, String> operationParameters) {
+        public Builder operationParameters(Map<String, String> operationParameters) {
             this.operationParameters = operationParameters;
             return this;
         }
 
-        public CommitInfoBuilder jobInfo(JobInfo jobInfo) {
+        public Builder jobInfo(JobInfo jobInfo) {
             this.jobInfo = Optional.of(jobInfo);
             return this;
         }
 
-        public CommitInfoBuilder notebookInfo(NotebookInfo notebookInfo ) {
+        public Builder notebookInfo(NotebookInfo notebookInfo ) {
             this.notebookInfo = Optional.of(notebookInfo);
             return this;
         }
 
-        public CommitInfoBuilder clusterId(String clusterId) {
+        public Builder clusterId(String clusterId) {
             this.clusterId = Optional.of(clusterId);
             return this;
         }
 
-        public CommitInfoBuilder readVersion(Long readVersion) {
+        public Builder readVersion(Long readVersion) {
             this.readVersion = Optional.of(readVersion);
             return this;
         }
 
-        public CommitInfoBuilder isolationLevel(String isolationLevel) {
+        public Builder isolationLevel(String isolationLevel) {
             this.isolationLevel = Optional.of(isolationLevel);
             return this;
         }
 
-        public CommitInfoBuilder isBlindAppend(Boolean isBlindAppend) {
+        public Builder isBlindAppend(Boolean isBlindAppend) {
             this.isBlindAppend = Optional.of(isBlindAppend);
             return this;
         }
 
-        public CommitInfoBuilder operationMetrics(Map<String, String> operationMetrics) {
+        public Builder operationMetrics(Map<String, String> operationMetrics) {
             this.operationMetrics = Optional.of(operationMetrics);
             return this;
         }
 
-        public CommitInfoBuilder userMetadata(String userMetadata) {
+        public Builder userMetadata(String userMetadata) {
             this.userMetadata = Optional.of(userMetadata);
             return this;
         }
@@ -307,7 +298,10 @@ public class CommitInfo implements Action {
          * @return a new {@code CommitInfo} with the same properties as {@code this}
          */
         public CommitInfo build() {
-            CommitInfo commitInfo = new CommitInfo(this);
+            CommitInfo commitInfo = new CommitInfo(this.version, this.timestamp, this.userId,
+                    this.userName, this.operation, this.operationParameters, this.jobInfo,
+                    this.notebookInfo, this.clusterId, this.readVersion, this.isolationLevel,
+                    this.isBlindAppend, this.operationMetrics, this.userMetadata);
             return commitInfo;
         }
     }

--- a/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
@@ -68,6 +68,23 @@ public class CommitInfo implements Action {
         this.userMetadata = userMetadata;
     }
 
+    public CommitInfo(CommitInfoBuilder builder) {
+        this.version = builder.version;
+        this.timestamp = builder.timestamp;
+        this.userId = builder.userId;
+        this.userName = builder.userName;
+        this.operation = builder.operation;
+        this.operationParameters = builder.operationParameters;
+        this.jobInfo = builder.jobInfo;
+        this.notebookInfo = builder.notebookInfo;
+        this.clusterId = builder.clusterId;
+        this.readVersion = builder.readVersion;
+        this.isolationLevel = builder.isolationLevel;
+        this.isBlindAppend = builder.isBlindAppend;
+        this.operationMetrics = builder.operationMetrics;
+        this.userMetadata = builder.userMetadata;
+    }
+
     /**
      * @return the log version for this commit
      */
@@ -195,5 +212,58 @@ public class CommitInfo implements Action {
         return Objects.hash(version, timestamp, userId, userName, operation, operationParameters,
                 jobInfo, notebookInfo, clusterId, readVersion, isolationLevel, isBlindAppend,
                 operationMetrics, userMetadata);
+    }
+
+    /**
+     * Builder class for CommitInfo. Enables construction of RemoveFile object with default values.
+     */
+    public static class CommitInfoBuilder {
+        // TODO
+        private final Optional<Long> version;
+        private final Timestamp timestamp;
+        private final Optional<String> userId;
+        private final Optional<String> userName;
+        private final String operation;
+        private final Map<String, String> operationParameters;
+        private final Optional<JobInfo> jobInfo;
+        private final Optional<NotebookInfo> notebookInfo;
+        private final Optional<String> clusterId;
+        private final Optional<Long> readVersion;
+        private final Optional<String> isolationLevel;
+        private final Optional<Boolean> isBlindAppend;
+        private final Optional<Map<String, String>> operationMetrics;
+        private final Optional<String> userMetadata;
+
+        public CommitInfoBuilder(Optional<Long> version, Timestamp timestamp, Optional<String> userId,
+                                 Optional<String> userName, String operation,
+                                 Map<String, String> operationParameters, Optional<JobInfo> jobInfo,
+                                 Optional<NotebookInfo> notebookInfo, Optional<String> clusterId,
+                                 Optional<Long> readVersion, Optional<String> isolationLevel,
+                                 Optional<Boolean> isBlindAppend,
+                                 Optional<Map<String, String>> operationMetrics,
+                                 Optional<String> userMetadata) {
+            this.version = version;
+            this.timestamp = timestamp;
+            this.userId = userId;
+            this.userName = userName;
+            this.operation = operation;
+            this.operationParameters = operationParameters;
+            this.jobInfo = jobInfo;
+            this.notebookInfo = notebookInfo;
+            this.clusterId = clusterId;
+            this.readVersion = readVersion;
+            this.isolationLevel = isolationLevel;
+            this.isBlindAppend = isBlindAppend;
+            this.operationMetrics = operationMetrics;
+            this.userMetadata = userMetadata;
+        }
+
+        /**
+         * @return a new {@code CommitInfo} with the same properties as {@code this}
+         */
+        public CommitInfo build() {
+            CommitInfo commitInfo = new CommitInfo(this);
+            return commitInfo;
+        }
     }
 }

--- a/standalone/src/main/java/io/delta/standalone/actions/JobInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/JobInfo.java
@@ -33,14 +33,6 @@ public class JobInfo implements Action {
         this.triggerType = triggerType;
     }
 
-    public JobInfo(JobInfoBuilder builder) {
-        this.jobId = builder.jobId;
-        this.jobName = builder.jobName;
-        this.runId = builder.runId;
-        this.jobOwnerId = builder.jobOwnerId;
-        this.triggerType = builder.triggerType;
-    }
-
     public String getJobId() {
         return jobId;
     }
@@ -79,35 +71,44 @@ public class JobInfo implements Action {
     }
 
     /**
-     * Builder class for JobInfo. Enables construction of RemoveFile object with default values.
+     * @return a new {@code JobInfo.Builder}
      */
-    public static class JobInfoBuilder {
+    public static Builder builder(String jobId) {
+        return new Builder(jobId);
+    }
+
+    /**
+     * Builder class for JobInfo. Enables construction of JobInfo object with default values.
+     */
+    public static class Builder {
+        // required JobInfo fields
         private final String jobId;
+        // optional JobInfo fields
         private String jobName;
         private String runId;
         private String jobOwnerId;
         private String triggerType;
 
-        public JobInfoBuilder(String jobId) {
+        public Builder(String jobId) {
             this.jobId = jobId;
         }
 
-        public JobInfoBuilder jobName(String jobName) {
+        public Builder jobName(String jobName) {
             this.jobName = jobName;
             return this;
         }
 
-        public JobInfoBuilder runId(String runId) {
+        public Builder runId(String runId) {
             this.runId = runId;
             return this;
         }
 
-        public JobInfoBuilder jobOwnerId(String jobOwnerId) {
+        public Builder jobOwnerId(String jobOwnerId) {
             this.jobOwnerId = jobOwnerId;
             return this;
         }
 
-        public JobInfoBuilder triggerType(String triggerType) {
+        public Builder triggerType(String triggerType) {
             this.triggerType = triggerType;
             return this;
         }
@@ -116,7 +117,8 @@ public class JobInfo implements Action {
          * @return a new {@code JobInfo} with the same properties as {@code this}
          */
         public JobInfo build() {
-            JobInfo jobInfo = new JobInfo(this);
+            JobInfo jobInfo = new JobInfo(this.jobId, this.jobName, this.runId, this.jobOwnerId,
+                    this.triggerType);
             return jobInfo;
         }
     }

--- a/standalone/src/main/java/io/delta/standalone/actions/JobInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/JobInfo.java
@@ -33,6 +33,14 @@ public class JobInfo implements Action {
         this.triggerType = triggerType;
     }
 
+    public JobInfo(JobInfoBuilder builder) {
+        this.jobId = builder.jobId;
+        this.jobName = builder.jobName;
+        this.runId = builder.runId;
+        this.jobOwnerId = builder.jobOwnerId;
+        this.triggerType = builder.triggerType;
+    }
+
     public String getJobId() {
         return jobId;
     }
@@ -68,5 +76,48 @@ public class JobInfo implements Action {
     @Override
     public int hashCode() {
         return Objects.hash(jobId, jobName, runId, jobOwnerId, triggerType);
+    }
+
+    /**
+     * Builder class for JobInfo. Enables construction of RemoveFile object with default values.
+     */
+    public static class JobInfoBuilder {
+        private final String jobId;
+        private String jobName;
+        private String runId;
+        private String jobOwnerId;
+        private String triggerType;
+
+        public JobInfoBuilder(String jobId) {
+            this.jobId = jobId;
+        }
+
+        public JobInfoBuilder jobName(String jobName) {
+            this.jobName = jobName;
+            return this;
+        }
+
+        public JobInfoBuilder runId(String runId) {
+            this.runId = runId;
+            return this;
+        }
+
+        public JobInfoBuilder jobOwnerId(String jobOwnerId) {
+            this.jobOwnerId = jobOwnerId;
+            return this;
+        }
+
+        public JobInfoBuilder triggerType(String triggerType) {
+            this.triggerType = triggerType;
+            return this;
+        }
+
+        /**
+         * @return a new {@code JobInfo} with the same properties as {@code this}
+         */
+        public JobInfo build() {
+            JobInfo jobInfo = new JobInfo(this);
+            return jobInfo;
+        }
     }
 }

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -187,8 +187,8 @@ public final class Metadata implements Action {
             return this;
         }
 
-        public MetadataBuilder createdTime(Optional<Long> createdTime) {
-            this.createdTime = createdTime;
+        public MetadataBuilder createdTime(Long createdTime) {
+            this.createdTime = Optional.of(createdTime);
             return this;
         }
 

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -52,18 +52,6 @@ public final class Metadata implements Action {
         this.schema = schema;
     }
 
-    public Metadata(MetadataBuilder builder) {
-        this.id = builder.id;
-        this.name = builder.name;
-        this.description = builder.description;
-        this.format = builder.format;
-        this.partitionColumns = builder.partitionColumns;
-        this.configuration = builder.configuration;
-        this.createdTime = builder.createdTime;
-        this.schema = builder.schema;
-    }
-
-
     /**
      * @return the unique identifier for this table
      */
@@ -145,9 +133,16 @@ public final class Metadata implements Action {
     }
 
     /**
+     * @return a new {@code Metadata.Builder}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
      * Builder class for Metadata. Enables construction of Metadata object with default values.
      */
-    public static class MetadataBuilder {
+    public static class Builder {
         private String id = java.util.UUID.randomUUID().toString();
         private String name;
         private String description;
@@ -157,42 +152,42 @@ public final class Metadata implements Action {
         private Optional<Long> createdTime = Optional.of(System.currentTimeMillis());
         private StructType schema;
 
-        public MetadataBuilder id(String id) {
+        public Builder id(String id) {
             this.id = id;
             return this;
         }
 
-        public MetadataBuilder name(String name) {
+        public Builder name(String name) {
             this.name = name;
             return this;
         }
 
-        public MetadataBuilder description(String description) {
+        public Builder description(String description) {
             this.description = description;
             return this;
         }
 
-        public MetadataBuilder format(Format format) {
+        public Builder format(Format format) {
             this.format = format;
             return this;
         }
 
-        public MetadataBuilder partitionColumns(List<String> partitionColumns) {
+        public Builder partitionColumns(List<String> partitionColumns) {
             this.partitionColumns = partitionColumns;
             return this;
         }
 
-        public MetadataBuilder configuration(Map<String, String> configuration) {
+        public Builder configuration(Map<String, String> configuration) {
             this.configuration = configuration;
             return this;
         }
 
-        public MetadataBuilder createdTime(Long createdTime) {
+        public Builder createdTime(Long createdTime) {
             this.createdTime = Optional.of(createdTime);
             return this;
         }
 
-        public MetadataBuilder schema(StructType schema) {
+        public Builder schema(StructType schema) {
             this.schema = schema;
             return this;
         }
@@ -201,7 +196,15 @@ public final class Metadata implements Action {
          * @return a new {@code Metadata} with the same properties as {@code this}
          */
         public Metadata build() {
-            Metadata metadata = new Metadata(this);
+            Metadata metadata = new Metadata(
+                    this.id,
+                    this.name,
+                    this.description,
+                    this.format,
+                    this.partitionColumns,
+                    this.configuration,
+                    this.createdTime,
+                    this.schema);
             return metadata;
         }
     }

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -197,6 +197,9 @@ public final class Metadata implements Action {
             return this;
         }
 
+        /**
+         * @return a new {@code Metadata} with the same properties as {@code this}
+         */
         public Metadata build() {
             Metadata metadata = new Metadata(this);
             return metadata;

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -52,6 +52,18 @@ public final class Metadata implements Action {
         this.schema = schema;
     }
 
+    public Metadata(MetadataBuilder builder) {
+        this.id = builder.id;
+        this.name = builder.name;
+        this.description = builder.description;
+        this.format = builder.format;
+        this.partitionColumns = builder.partitionColumns;
+        this.configuration = builder.configuration;
+        this.createdTime = builder.createdTime;
+        this.schema = builder.schema;
+    }
+
+
     /**
      * @return the unique identifier for this table
      */
@@ -130,5 +142,64 @@ public final class Metadata implements Action {
     public int hashCode() {
         return Objects.hash(id, name, description, format, partitionColumns,
                 configuration, createdTime, schema);
+    }
+
+    /**
+     * Builder class for Metadata. Enables construction of Metadata object with default values.
+     */
+    public static class MetadataBuilder {
+        private String id = java.util.UUID.randomUUID().toString();
+        private String name;
+        private String description;
+        private Format format = new Format("parquet", Collections.emptyMap());
+        private List<String> partitionColumns = Collections.emptyList();
+        private Map<String, String> configuration = Collections.emptyMap();
+        private Optional<Long> createdTime = Optional.of(System.currentTimeMillis());
+        private StructType schema;
+
+        public MetadataBuilder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public MetadataBuilder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public MetadataBuilder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public MetadataBuilder format(Format format) {
+            this.format = format;
+            return this;
+        }
+
+        public MetadataBuilder partitionColumns(List<String> partitionColumns) {
+            this.partitionColumns = partitionColumns;
+            return this;
+        }
+
+        public MetadataBuilder configuration(Map<String, String> configuration) {
+            this.configuration = configuration;
+            return this;
+        }
+
+        public MetadataBuilder createdTime(Optional<Long> createdTime) {
+            this.createdTime = createdTime;
+            return this;
+        }
+
+        public MetadataBuilder schema(StructType schema) {
+            this.schema = schema;
+            return this;
+        }
+
+        public Metadata build() {
+            Metadata metadata = new Metadata(this);
+            return metadata;
+        }
     }
 }

--- a/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
@@ -107,6 +107,9 @@ public class RemoveFile implements FileAction {
             return this;
         }
 
+        /**
+         * @return a new {@code RemoveFile} with the same properties as {@code this}
+         */
         public RemoveFile build() {
             RemoveFile removeFile = new RemoveFile(this);
             return removeFile;

--- a/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
@@ -25,16 +25,6 @@ public class RemoveFile implements FileAction {
         this.tags = tags;
     }
 
-    public RemoveFile(RemoveFileBuilder builder) {
-        this.path = builder.path;
-        this.deletionTimestamp = builder.deletionTimestamp;
-        this.dataChange = builder.dataChange;
-        this.extendedFileMetadata = builder.extendedFileMetadata;
-        this.partitionValues = builder.partitionValues;
-        this.size = builder.size;
-        this.tags = builder.tags;
-    }
-
     @Override
     public String getPath() {
         return path;
@@ -66,10 +56,19 @@ public class RemoveFile implements FileAction {
     }
 
     /**
+     * @return a new {@code RemoveFile.Builder}
+     */
+    public static Builder builder(String path) {
+        return new Builder(path);
+    }
+
+    /**
      * Builder class for RemoveFile. Enables construction of RemoveFile object with default values.
      */
-    public static class RemoveFileBuilder {
+    public static class Builder {
+        // required RemoveFile fields
         private final String path;
+        // optional RemoveFile fields
         private Optional<Long> deletionTimestamp = Optional.empty();
         private boolean dataChange = true;
         private boolean extendedFileMetadata = false;
@@ -77,36 +76,36 @@ public class RemoveFile implements FileAction {
         private long size = 0;
         private Map<String, String> tags;
 
-        public RemoveFileBuilder(String path) {
+        public Builder(String path) {
             this.path = path;
         }
 
-        public RemoveFileBuilder deletionTimestamp(Long deletionTimestamp) {
+        public Builder deletionTimestamp(Long deletionTimestamp) {
             this.deletionTimestamp = Optional.of(deletionTimestamp);
             return this;
         }
 
-        public RemoveFileBuilder dataChange(boolean dataChange) {
+        public Builder dataChange(boolean dataChange) {
             this.dataChange = dataChange;
             return this;
         }
 
-        public RemoveFileBuilder extendedFileMetadata(boolean extendedFileMetadata) {
+        public Builder extendedFileMetadata(boolean extendedFileMetadata) {
             this.extendedFileMetadata = extendedFileMetadata;
             return this;
         }
 
-        public RemoveFileBuilder partitionValues(Map<String, String> partitionValues) {
+        public Builder partitionValues(Map<String, String> partitionValues) {
             this.partitionValues = partitionValues;
             return this;
         }
 
-        public RemoveFileBuilder size(long size) {
+        public Builder size(long size) {
             this.size = size;
             return this;
         }
 
-        public RemoveFileBuilder tags(Map<String, String> tags) {
+        public Builder tags(Map<String, String> tags) {
             this.tags = tags;
             return this;
         }
@@ -115,7 +114,14 @@ public class RemoveFile implements FileAction {
          * @return a new {@code RemoveFile} with the same properties as {@code this}
          */
         public RemoveFile build() {
-            RemoveFile removeFile = new RemoveFile(this);
+            RemoveFile removeFile = new RemoveFile(
+                    this.path,
+                    this.deletionTimestamp,
+                    this.dataChange,
+                    this.extendedFileMetadata,
+                    this.partitionValues,
+                    this.size,
+                    this.tags);
             return removeFile;
         }
     }

--- a/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
@@ -70,16 +70,20 @@ public class RemoveFile implements FileAction {
      */
     public static class RemoveFileBuilder {
         private final String path;
-        private final Optional<Long> deletionTimestamp;
+        private Optional<Long> deletionTimestamp = Optional.empty();
         private boolean dataChange = true;
         private boolean extendedFileMetadata = false;
         private Map<String, String> partitionValues;
         private long size = 0;
         private Map<String, String> tags;
 
-        public RemoveFileBuilder(String path, Optional<Long> deletionTimestamp) {
+        public RemoveFileBuilder(String path) {
             this.path = path;
-            this.deletionTimestamp = deletionTimestamp;
+        }
+
+        public RemoveFileBuilder deletionTimestamp(Long deletionTimestamp) {
+            this.deletionTimestamp = Optional.of(deletionTimestamp);
+            return this;
         }
 
         public RemoveFileBuilder dataChange(boolean dataChange) {

--- a/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
@@ -25,6 +25,16 @@ public class RemoveFile implements FileAction {
         this.tags = tags;
     }
 
+    public RemoveFile(RemoveFileBuilder builder) {
+        this.path = builder.path;
+        this.deletionTimestamp = builder.deletionTimestamp;
+        this.dataChange = builder.dataChange;
+        this.extendedFileMetadata = builder.extendedFileMetadata;
+        this.partitionValues = builder.partitionValues;
+        this.size = builder.size;
+        this.tags = builder.tags;
+    }
+
     @Override
     public String getPath() {
         return path;
@@ -53,5 +63,53 @@ public class RemoveFile implements FileAction {
 
     public Map<String, String> getTags() {
         return Collections.unmodifiableMap(tags);
+    }
+
+    /**
+     * Builder class for RemoveFile. Enables construction of RemoveFile object with default values.
+     */
+    public static class RemoveFileBuilder {
+        private final String path;
+        private final Optional<Long> deletionTimestamp;
+        private boolean dataChange = true;
+        private boolean extendedFileMetadata = false;
+        private Map<String, String> partitionValues;
+        private long size = 0;
+        private Map<String, String> tags;
+
+        public RemoveFileBuilder(String path, Optional<Long> deletionTimestamp) {
+            this.path = path;
+            this.deletionTimestamp = deletionTimestamp;
+        }
+
+        public RemoveFileBuilder dataChange(boolean dataChange) {
+            this.dataChange = dataChange;
+            return this;
+        }
+
+        public RemoveFileBuilder extendedFileMetadata(boolean extendedFileMetadata) {
+            this.extendedFileMetadata = extendedFileMetadata;
+            return this;
+        }
+
+        public RemoveFileBuilder partitionValues(Map<String, String> partitionValues) {
+            this.partitionValues = partitionValues;
+            return this;
+        }
+
+        public RemoveFileBuilder size(long size) {
+            this.size = size;
+            return this;
+        }
+
+        public RemoveFileBuilder tags(Map<String, String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        public RemoveFile build() {
+            RemoveFile removeFile = new RemoveFile(this);
+            return removeFile;
+        }
     }
 }

--- a/standalone/src/main/java/io/delta/standalone/types/StructField.java
+++ b/standalone/src/main/java/io/delta/standalone/types/StructField.java
@@ -38,7 +38,10 @@
 
 package io.delta.standalone.types;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * A field inside a {@link StructType}.
@@ -47,6 +50,7 @@ public final class StructField {
     private final String name;
     private final DataType dataType;
     private final boolean nullable;
+    private final Map<String, Object> metadata;
 
     /**
      * @param name  the name of this field
@@ -57,6 +61,20 @@ public final class StructField {
         this.name = name;
         this.dataType = dataType;
         this.nullable = nullable;
+        this.metadata = Collections.emptyMap();
+    }
+
+    /**
+     * @param name  the name of this field
+     * @param dataType  the data type of this field
+     * @param nullable  indicates if values of this field can be {@code null} values
+     * @param metadata metadata for this field
+     */
+    public StructField(String name, DataType dataType, boolean nullable, Map<String, Object> metadata) {
+        this.name = name;
+        this.dataType = dataType;
+        this.nullable = nullable;
+        this.metadata = metadata;
     }
 
     /**
@@ -91,11 +109,21 @@ public final class StructField {
     }
 
     /**
+     * @return the metadata for this field
+     */
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    /**
      * Builds a readable {@code String} representation of this {@code StructField}.
      */
     protected void buildFormattedString(String prefix, StringBuilder builder) {
         final String nextPrefix = prefix + "    |";
-        builder.append(String.format("%s-- %s: %s (nullable = %b)\n", prefix, name, dataType.getTypeName(), nullable));
+        builder.append(String.format("%s-- %s: %s (nullable = %b) (metadata =%s)\n",
+                prefix, name, dataType.getTypeName(), nullable,
+                metadata.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue())
+                        .collect(Collectors.joining(", ", "{", "}"))));
         DataType.buildFormattedString(dataType, nextPrefix, builder);
     }
 
@@ -104,11 +132,12 @@ public final class StructField {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         StructField that = (StructField) o;
-        return name.equals(that.name) && dataType.equals(that.dataType) && nullable == that.nullable;
+        return name.equals(that.name) && dataType.equals(that.dataType) && nullable == that.nullable
+                && metadata.equals(that.metadata);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, dataType, nullable);
+        return Objects.hash(name, dataType, nullable, metadata);
     }
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
@@ -336,4 +336,15 @@ class DeltaDataReaderSuite extends FunSuite {
       new IntegerType,
       new ArrayType(new DoubleType, true),
       false))
+
+  test("toJson fromJson with metadata") {
+    val schema_str =
+      """{"type":"struct",
+        |"fields":[
+        |{"name":"a","type":"integer","nullable":true,"metadata":{"test":"foo"}},
+        |{"name":"b","type":"timestamp","nullable":true,"metadata":{"test1":1, "test2":2.0}},
+        |{"name":"c","type":"string","nullable":true,"metadata":{"test3":true,"test4":[1,2,3,4]}}
+        |]}""".stripMargin.replaceAll("\\s", "")
+    assert(DataTypeParser.toJson(DataTypeParser.fromJson(schema_str)) == schema_str)
+  }
 }


### PR DESCRIPTION
Currently the DSR ignores column metadata when reading the schema. This PR adds column metadata to `DataTypeParser` and provides access to the user through `StructField`.
Changes:
• Add metadata field to `StructField`
• Include column metadata in `toJson` and `fromJson`
• Tests for schemas with column metadata