### PR TITLE
Add FieldMetadata to StructField

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
+++ b/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
@@ -106,13 +106,13 @@ public final class FieldMetadata {
 
     @Override
     public int hashCode() {
-            return metadata.entrySet()
-                    .stream()
-                    .mapToInt( entry -> (entry.getValue().getClass().isArray() ?
-                            (entry.getKey() == null ? 0 : entry.getKey().hashCode())^
-                            Arrays.hashCode((Object[]) entry.getValue()) :
-                            entry.hashCode()
-                    )).sum();
+        return metadata.entrySet()
+                .stream()
+                .mapToInt( entry -> (entry.getValue().getClass().isArray() ?
+                        (entry.getKey() == null ? 0 : entry.getKey().hashCode())^
+                                Arrays.hashCode((Object[]) entry.getValue()) :
+                        entry.hashCode())
+                ).sum();
         }
 
     /**

--- a/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
+++ b/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
@@ -108,11 +108,11 @@ public final class FieldMetadata {
     public int hashCode() {
             return metadata.entrySet()
                     .stream()
-                    .map( entry -> (entry.getValue().getClass().isArray() ?
+                    .mapToInt( entry -> (entry.getValue().getClass().isArray() ?
                             (entry.getKey() == null ? 0 : entry.getKey().hashCode())^
                             Arrays.hashCode((Object[]) entry.getValue()) :
                             entry.hashCode()
-                    )).mapToInt(i -> i.intValue()).sum();
+                    )).sum();
         }
 
     /**

--- a/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
+++ b/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
@@ -65,7 +65,7 @@ public final class FieldMetadata {
      * @param key  the key to check for
      * @return True if {@code this} contains a mapping for the given key, False otherwise
      */
-    public Boolean contains(String key) {
+    public boolean contains(String key) {
         return metadata.containsKey(key);
     }
 
@@ -80,7 +80,9 @@ public final class FieldMetadata {
 
     @Override
     public String toString() {
-        return metadata.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.toString())
+        return metadata.entrySet()
+                .stream()
+                .map(entry -> entry.getKey() + "=" + entry.toString())
                 .collect(Collectors.joining(", ", "{", "}"));
     }
 
@@ -113,24 +115,24 @@ public final class FieldMetadata {
      * Builder class for FieldMetadata.
      */
     public static class Builder {
-        private Map<String, Object> metadata =new HashMap<String, Object>();
+        private Map<String, Object> metadata = new HashMap<String, Object>();
 
         public Builder putNull(String key) {
             metadata.put(key, null);
             return this;
         }
 
-        public Builder putLong(String key, Long value) {
+        public Builder putLong(String key, long value) {
             metadata.put(key, value);
             return this;
         }
 
-        public Builder putDouble(String key, Double value) {
+        public Builder putDouble(String key, double value) {
             metadata.put(key, value);
             return this;
         }
 
-        public Builder putBoolean(String key, Boolean value) {
+        public Builder putBoolean(String key, boolean value) {
             metadata.put(key, value);
             return this;
         }

--- a/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
+++ b/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
@@ -79,7 +79,7 @@ public final class FieldMetadata {
     }
 
     @Override
-    public String toString(){
+    public String toString() {
         return metadata.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.toString())
                 .collect(Collectors.joining(", ", "{", "}"));
     }

--- a/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
+++ b/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
@@ -44,12 +44,10 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.stream.Collectors;
 
-
 /**
  * The metadata for a given {@link StructField}.
  */
 public final class FieldMetadata {
-    // TODO: should this be an immutable map created via the builder?
     private final Map<String, Object> metadata;
 
     private FieldMetadata(Map<String, Object> metadata) {
@@ -64,7 +62,7 @@ public final class FieldMetadata {
     }
 
     /**
-     * @param key the key to check for
+     * @param key  the key to check for
      * @return True if {@code this} contains a mapping for the given key, False otherwise
      */
     public Boolean contains(String key) {
@@ -72,7 +70,7 @@ public final class FieldMetadata {
     }
 
     /**
-     * @param key the key to check for
+     * @param key  the key to check for
      * @return the value to which the specified key is mapped, or null if there is no mapping for
      * the given key
      */
@@ -80,7 +78,8 @@ public final class FieldMetadata {
         return metadata.get(key);
     }
 
-    public String formattedString(){
+    @Override
+    public String toString(){
         return metadata.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.toString())
                 .collect(Collectors.joining(", ", "{", "}"));
     }
@@ -95,7 +94,8 @@ public final class FieldMetadata {
                 e.getValue().equals(that.metadata.get(e.getKey())) ||
                         (e.getValue().getClass().isArray() &&
                                 that.metadata.get(e.getKey()).getClass().isArray() &&
-                                Arrays.equals((Object[]) e.getValue(),
+                                Arrays.equals(
+                                        (Object[]) e.getValue(),
                                         (Object[]) that.metadata.get(e.getKey()))));
     }
 

--- a/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
+++ b/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
@@ -38,39 +38,53 @@
 
 package io.delta.standalone.types;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.stream.Collectors;
 
+
 /**
- * todo
+ * The metadata for a given {@link StructField}.
  */
 public final class FieldMetadata {
+    // TODO: should this be an immutable map created via the builder?
     private final Map<String, Object> metadata;
 
-
-    /**
-     * todo
-     * @param metadata
-     */
     private FieldMetadata(Map<String, Object> metadata) {
         this.metadata = metadata;
     }
 
-    // getters
+    /**
+     * @return list of the key-value pairs in {@code this}.
+     */
+    public ArrayList<Map.Entry<String, Object>> getEntries() {
+        return new ArrayList<Map.Entry<String, Object>>(metadata.entrySet());
+    }
 
-    // TODO is this acceptable to do? it's more of a "pretty" string?
-    @Override
-    public String toString(){
+    /**
+     * @param key the key to check for
+     * @return True if {@code this} contains a mapping for the given key, False otherwise
+     */
+    public Boolean contains(String key) {
+        return metadata.containsKey(key);
+    }
+
+    /**
+     * @param key the key to check for
+     * @return the value to which the specified key is mapped, or null if there is no mapping for
+     * the given key
+     */
+    public Object get(String key) {
+        return metadata.get(key);
+    }
+
+    public String formattedString(){
         return metadata.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.toString())
                 .collect(Collectors.joining(", ", "{", "}"));
     }
 
-    private static Boolean valueEquals(Object v1, Object v2) {
-    }
-
-    // TODO test this!!
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -79,26 +93,26 @@ public final class FieldMetadata {
         if (this.metadata.size() != that.metadata.size()) return false;
         return this.metadata.entrySet().stream().allMatch(e ->
                 e.getValue().equals(that.metadata.get(e.getKey())) ||
-                        (// TODO array equals????);
+                        (e.getValue().getClass().isArray() &&
+                                that.metadata.get(e.getKey()).getClass().isArray() &&
+                                Arrays.equals((Object[]) e.getValue(),
+                                        (Object[]) that.metadata.get(e.getKey()))));
     }
 
+    @Override
+    public int hashCode() { return metadata.hashCode(); }
 
-
-//    @Override
-//    public boolean equals(Object o){
-//        // todo
-//    }
-
-    // contains
-    // getters!
-    //  hashcode
-    // toJsonValue??
-
+    /**
+     * @return a new {@code FieldMetadata.Builder}
+     */
     public static Builder builder() {
         return new Builder();
     }
 
-    private static class Builder {
+    /**
+     * Builder class for FieldMetadata.
+     */
+    public static class Builder {
         private Map<String, Object> metadata =new HashMap<String, Object>();
 
         public Builder putNull(String key) {
@@ -156,6 +170,9 @@ public final class FieldMetadata {
             return this;
         }
 
+        /**
+         * @return a new {@code FieldMetadata} with the same mappings as {@code this}
+         */
         public FieldMetadata build() {
             return new FieldMetadata(this.metadata);
         }

--- a/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
+++ b/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file contains code from the Apache Spark project (original license above).
+ * It contains modifications, which are licensed as follows:
+ */
+
+/*
+ * Copyright (2020) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.standalone.types;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.stream.Collectors;
+
+/**
+ * todo
+ */
+public final class FieldMetadata {
+    private final Map<String, Object> metadata;
+
+
+    /**
+     * todo
+     * @param metadata
+     */
+    private FieldMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+
+    // getters
+
+    // TODO is this acceptable to do? it's more of a "pretty" string?
+    @Override
+    public String toString(){
+        return metadata.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.toString())
+                .collect(Collectors.joining(", ", "{", "}"));
+    }
+
+    private static Boolean valueEquals(Object v1, Object v2) {
+    }
+
+    // TODO test this!!
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FieldMetadata that = (FieldMetadata) o;
+        if (this.metadata.size() != that.metadata.size()) return false;
+        return this.metadata.entrySet().stream().allMatch(e ->
+                e.getValue().equals(that.metadata.get(e.getKey())) ||
+                        (// TODO array equals????);
+    }
+
+
+
+//    @Override
+//    public boolean equals(Object o){
+//        // todo
+//    }
+
+    // contains
+    // getters!
+    //  hashcode
+    // toJsonValue??
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private static class Builder {
+        private Map<String, Object> metadata =new HashMap<String, Object>();
+
+        public Builder putNull(String key) {
+            metadata.put(key, null);
+            return this;
+        }
+
+        public Builder putLong(String key, Long value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putDouble(String key, Double value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putBoolean(String key, Boolean value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putString(String key, String value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putMetadata(String key, FieldMetadata value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putLongArray(String key, Long[] value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putDoubleArray(String key, Double[] value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putBooleanArray(String key, Boolean[] value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putStringArray(String key, String[] value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putMetadataArray(String key, FieldMetadata[] value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public FieldMetadata build() {
+            return new FieldMetadata(this.metadata);
+        }
+    }
+}

--- a/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
+++ b/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
@@ -109,7 +109,7 @@ public final class FieldMetadata {
             return metadata.entrySet()
                     .stream()
                     .map( entry -> (entry.getValue().getClass().isArray() ?
-                            (entry.getKey()==null   ? 0 : entry.getKey().hashCode())^
+                            (entry.getKey() == null ? 0 : entry.getKey().hashCode())^
                             Arrays.hashCode((Object[]) entry.getValue()) :
                             entry.hashCode()
                     )).mapToInt(i -> i.intValue()).sum();

--- a/standalone/src/main/java/io/delta/standalone/types/StructField.java
+++ b/standalone/src/main/java/io/delta/standalone/types/StructField.java
@@ -50,7 +50,7 @@ public final class StructField {
     private final String name;
     private final DataType dataType;
     private final boolean nullable;
-    private final Map<String, Object> metadata;
+    private final FieldMetadata metadata;
 
     /**
      * @param name  the name of this field
@@ -61,7 +61,7 @@ public final class StructField {
         this.name = name;
         this.dataType = dataType;
         this.nullable = nullable;
-        this.metadata = Collections.emptyMap();
+        this.metadata = FieldMetadata.builder().build();
     }
 
     /**
@@ -70,7 +70,7 @@ public final class StructField {
      * @param nullable  indicates if values of this field can be {@code null} values
      * @param metadata  metadata for this field
      */
-    public StructField(String name, DataType dataType, boolean nullable, Map<String, Object> metadata) {
+    public StructField(String name, DataType dataType, boolean nullable, FieldMetadata metadata) {
         this.name = name;
         this.dataType = dataType;
         this.nullable = nullable;
@@ -111,7 +111,7 @@ public final class StructField {
     /**
      * @return the metadata for this field
      */
-    public Map<String, Object> getMetadata() {
+    public FieldMetadata getMetadata() {
         return metadata;
     }
 
@@ -121,9 +121,7 @@ public final class StructField {
     protected void buildFormattedString(String prefix, StringBuilder builder) {
         final String nextPrefix = prefix + "    |";
         builder.append(String.format("%s-- %s: %s (nullable = %b) (metadata =%s)\n",
-                prefix, name, dataType.getTypeName(), nullable,
-                metadata.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue())
-                        .collect(Collectors.joining(", ", "{", "}"))));
+                prefix, name, dataType.getTypeName(), nullable, metadata.toString()));
         DataType.buildFormattedString(dataType, nextPrefix, builder);
     }
 

--- a/standalone/src/main/java/io/delta/standalone/types/StructField.java
+++ b/standalone/src/main/java/io/delta/standalone/types/StructField.java
@@ -38,7 +38,10 @@
 
 package io.delta.standalone.types;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * A field inside a {@link StructType}.
@@ -47,6 +50,7 @@ public final class StructField {
     private final String name;
     private final DataType dataType;
     private final boolean nullable;
+    private final Map<String, Object> metadata;
 
     /**
      * @param name  the name of this field
@@ -57,6 +61,20 @@ public final class StructField {
         this.name = name;
         this.dataType = dataType;
         this.nullable = nullable;
+        this.metadata = Collections.emptyMap();
+    }
+
+    /**
+     * @param name  the name of this field
+     * @param dataType  the data type of this field
+     * @param nullable  indicates if values of this field can be {@code null} values
+     * @param metadata metadata for this field
+     */
+    public StructField(String name, DataType dataType, boolean nullable, Map<String, Object> metadata) {
+        this.name = name;
+        this.dataType = dataType;
+        this.nullable = nullable;
+        this.metadata = metadata;
     }
 
     /**
@@ -91,11 +109,21 @@ public final class StructField {
     }
 
     /**
+     * @return the metadata for this field
+     */
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    /**
      * Builds a readable {@code String} representation of this {@code StructField}.
      */
     protected void buildFormattedString(String prefix, StringBuilder builder) {
         final String nextPrefix = prefix + "    |";
-        builder.append(String.format("%s-- %s: %s (nullable = %b)\n", prefix, name, dataType.getTypeName(), nullable));
+        builder.append(String.format("%s-- %s: %s (nullable = %b) (metadata =%s)\n",
+                prefix, name, dataType.getTypeName(), nullable,
+                metadata.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue())
+                        .collect(Collectors.joining(", ", "{", "}"))));
         DataType.buildFormattedString(dataType, nextPrefix, builder);
     }
 
@@ -104,11 +132,12 @@ public final class StructField {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         StructField that = (StructField) o;
-        return name.equals(that.name) && dataType.equals(that.dataType) && nullable == that.nullable;
+        return name.equals(that.name) && dataType.equals(that.dataType) && nullable == that.nullable
+                && metadata.equals(that.metadata);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, dataType, nullable);
+        return Objects.hash(name, dataType, nullable, metadata);
     }
 }

--- a/standalone/src/main/java/io/delta/standalone/types/StructField.java
+++ b/standalone/src/main/java/io/delta/standalone/types/StructField.java
@@ -121,7 +121,7 @@ public final class StructField {
     protected void buildFormattedString(String prefix, StringBuilder builder) {
         final String nextPrefix = prefix + "    |";
         builder.append(String.format("%s-- %s: %s (nullable = %b) (metadata =%s)\n",
-                prefix, name, dataType.getTypeName(), nullable, metadata.formattedString()));
+                prefix, name, dataType.getTypeName(), nullable, metadata.toString()));
         DataType.buildFormattedString(dataType, nextPrefix, builder);
     }
 

--- a/standalone/src/main/java/io/delta/standalone/types/StructField.java
+++ b/standalone/src/main/java/io/delta/standalone/types/StructField.java
@@ -68,7 +68,7 @@ public final class StructField {
      * @param name  the name of this field
      * @param dataType  the data type of this field
      * @param nullable  indicates if values of this field can be {@code null} values
-     * @param metadata metadata for this field
+     * @param metadata  metadata for this field
      */
     public StructField(String name, DataType dataType, boolean nullable, Map<String, Object> metadata) {
         this.name = name;

--- a/standalone/src/main/java/io/delta/standalone/types/StructField.java
+++ b/standalone/src/main/java/io/delta/standalone/types/StructField.java
@@ -121,7 +121,7 @@ public final class StructField {
     protected void buildFormattedString(String prefix, StringBuilder builder) {
         final String nextPrefix = prefix + "    |";
         builder.append(String.format("%s-- %s: %s (nullable = %b) (metadata =%s)\n",
-                prefix, name, dataType.getTypeName(), nullable, metadata.toString()));
+                prefix, name, dataType.getTypeName(), nullable, metadata.formattedString()));
         DataType.buildFormattedString(dataType, nextPrefix, builder);
     }
 

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/DataTypeParser.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/DataTypeParser.scala
@@ -122,7 +122,7 @@ private[standalone] object DataTypeParser {
   private def metadataValueToJValue(value: Any): JValue = {
     value match {
       case metadata: FieldMetadata =>
-        JObject(metadata.getEntries().asScala.map(e =>
+        JObject(metadata.getEntries().entrySet().asScala.map(e =>
           (e.getKey(), metadataValueToJValue(e.getValue()))).toList)
       case arr: Array[Object] =>
         JArray(arr.toList.map(metadataValueToJValue))

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/DataTypeParser.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/DataTypeParser.scala
@@ -57,7 +57,7 @@ private[standalone] object DataTypeParser {
 
   def fromJson(json: String): DataType = parseDataType(parse(json))
 
-  def parseDataType(json: JValue): DataType = json match {
+  private def parseDataType(json: JValue): DataType = json match {
     case JString(name) =>
       nameToType(name)
 
@@ -88,7 +88,7 @@ private[standalone] object DataTypeParser {
     compact(render(dataTypeToJValue(value)))
   }
 
-  def dataTypeToJValue(dataType: DataType): JValue = dataType match {
+  private def dataTypeToJValue(dataType: DataType): JValue = dataType match {
     case array: ArrayType =>
       ("type" -> "array") ~
         ("elementType" -> dataTypeToJValue(array.getElementType)) ~
@@ -107,7 +107,7 @@ private[standalone] object DataTypeParser {
       dataType.getTypeName()
   }
 
-  def structFieldToJValue(field: StructField): JValue = {
+  private def structFieldToJValue(field: StructField): JValue = {
     val name = field.getName()
     val dataType = field.getDataType()
     val nullable = field.isNullable()
@@ -119,7 +119,7 @@ private[standalone] object DataTypeParser {
       ("metadata" -> metadataValueToJValue(metadata))
   }
 
-  def metadataValueToJValue(value: Any): JValue = {
+  private def metadataValueToJValue(value: Any): JValue = {
     value match {
       case metadata: FieldMetadata =>
         JObject(metadata.getEntries().asScala.map(e =>

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/DataTypeParser.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/DataTypeParser.scala
@@ -191,8 +191,8 @@ private[standalone] object DataTypeParser {
         } else {
           value.head match {
             case _: JInt =>
-              builder.putLongArray(key, value.map(_.asInstanceOf[JInt].num.toLong
-                .asInstanceOf[java.lang.Long]).toArray)
+              builder.putLongArray(key,
+                value.map(_.asInstanceOf[JInt].num.toLong.asInstanceOf[java.lang.Long]).toArray)
             case _: JDouble =>
               builder.putDoubleArray(key,
                 value.asInstanceOf[List[JDouble]].map(_.num.asInstanceOf[java.lang.Double]).toArray)
@@ -203,8 +203,8 @@ private[standalone] object DataTypeParser {
             case _: JString =>
               builder.putStringArray(key, value.asInstanceOf[List[JString]].map(_.s).toArray)
             case _: JObject =>
-              builder.putMetadataArray(
-                key, value.asInstanceOf[List[JObject]].map(parseFieldMetadata).toArray)
+              builder.putMetadataArray(key,
+                value.asInstanceOf[List[JObject]].map(parseFieldMetadata).toArray)
             case other =>
               throw new IllegalArgumentException(
                 s"Unsupported ${value.head.getClass()} Array as metadata value.")

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
@@ -337,15 +337,29 @@ class DeltaDataReaderSuite extends FunSuite {
       new ArrayType(new DoubleType, true),
       false))
 
-  test("toJson fromJson with metadata") {
-    val schemaStr =
-      """{"type":"struct",
-        |"fields":[
-        |{"name":"a","type":"integer","nullable":true,"metadata":{"test":"foo"}},
-        |{"name":"b","type":"timestamp","nullable":true,"metadata":{"test1":1, "test2":2.0}},
-        |{"name":"c","type":"string","nullable":true,"metadata":{"test3":true,"test4":[1,2,3,4]}},
-        |{"name":"d","type":"string","nullable":false,"metadata":{}}
-        |]}""".stripMargin.replaceAll("\\s", "")
-    assert(DataTypeParser.toJson(DataTypeParser.fromJson(schemaStr)) == schemaStr)
+  test("toJson fromJson for field metadata") {
+    val emptyMetadata = FieldMetadata.builder().build()
+    val singleStringMetadata = FieldMetadata.builder().putString("test", "test_value").build()
+    val singleBooleanMetadata = FieldMetadata.builder().putBoolean("test", true).build()
+    val singleIntegerMetadata = FieldMetadata.builder().putLong("test", 2L).build()
+    val singleDoubleMetadata = FieldMetadata.builder().putDouble("test", 2.0).build()
+    val singleMapMetadata = FieldMetadata.builder().putMetadata("test_outside",
+      FieldMetadata.builder().putString("test_inside", "test_inside_value").build()).build()
+    val singleListMetadata = FieldMetadata.builder().putLongArray("test", Array(0L, 1L, 2L)).build()
+    val multipleEntriesMetadata = FieldMetadata.builder().putString("test", "test_value")
+      .putDouble("test", 2.0).putLongArray("test", Array(0L, 1L, 2L)).build()
+
+    val field_array = Array(
+      new StructField("emptyMetadata", new BooleanType, true, emptyMetadata),
+      new StructField("singleStringMetadata", new BooleanType, true, singleStringMetadata),
+      new StructField("singleBooleanMetadata", new BooleanType, true, singleBooleanMetadata),
+      new StructField("singleIntegerMetadata", new BooleanType, true, singleIntegerMetadata),
+      new StructField("singleDoubleMetadata", new BooleanType, true, singleDoubleMetadata),
+      new StructField("singleMapMetadata", new BooleanType, true, singleMapMetadata),
+      new StructField("singleListMetadata", new BooleanType, true, singleListMetadata),
+      new StructField("multipleEntriesMetadata", new BooleanType, true, multipleEntriesMetadata))
+    val struct = new StructType(field_array)
+    assert(struct == DataTypeParser.fromJson(struct.toJson()))
   }
 }
+

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
@@ -338,13 +338,14 @@ class DeltaDataReaderSuite extends FunSuite {
       false))
 
   test("toJson fromJson with metadata") {
-    val schema_str =
+    val schemaStr =
       """{"type":"struct",
         |"fields":[
         |{"name":"a","type":"integer","nullable":true,"metadata":{"test":"foo"}},
         |{"name":"b","type":"timestamp","nullable":true,"metadata":{"test1":1, "test2":2.0}},
-        |{"name":"c","type":"string","nullable":true,"metadata":{"test3":true,"test4":[1,2,3,4]}}
+        |{"name":"c","type":"string","nullable":true,"metadata":{"test3":true,"test4":[1,2,3,4]}},
+        |{"name":"d","type":"string","nullable":false,"metadata":{}}
         |]}""".stripMargin.replaceAll("\\s", "")
-    assert(DataTypeParser.toJson(DataTypeParser.fromJson(schema_str)) == schema_str)
+    assert(DataTypeParser.toJson(DataTypeParser.fromJson(schemaStr)) == schemaStr)
   }
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
@@ -336,4 +336,15 @@ class DeltaDataReaderSuite extends FunSuite {
       new IntegerType,
       new ArrayType(new DoubleType, true),
       false))
+
+  test("toJson fromJson with metadata") {
+    val schema_str =
+      """{"type":"struct",
+        |"fields":[
+        |{"name":"a","type":"integer","nullable":true,"metadata":{"test":"foo"}},
+        |{"name":"b","type":"timestamp","nullable":true,"metadata":{"test1":1, "test2":2.0}},
+        |{"name":"c","type":"string","nullable":true,"metadata":{"test3":true,"test4":[1,2,3,4]}}
+        |]}""".stripMargin.replaceAll("\\s", "")
+    assert(DataTypeParser.toJson(DataTypeParser.fromJson(schema_str)) == schema_str)
+  }
 }


### PR DESCRIPTION
Currently the DSR ignores column metadata when reading the schema. This PR introduces a new type `FieldMetadata` which stores the metadata for a given field within the schema.
Changes:
• Add metadata attribute to `StructField`
• Adds a `FieldMetadata` class
• Includes column metadata in `DataTypeParser` `toJson` and `fromJson`
• New tests for schemas with column metadata