### PR TITLE
Snapshot getAllFilesIter dummy API

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/Snapshot.java
+++ b/standalone/src/main/java/io/delta/standalone/Snapshot.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.delta.standalone;
 
 import java.util.List;
@@ -35,6 +36,20 @@ public interface Snapshot {
      * @return all of the files present in this snapshot
      */
     List<AddFile> getAllFiles();
+
+    /**
+     * :: DeveloperApi ::
+     *
+     * Dummy API. Will be replaced in a later version with a proper implementation.
+     *
+     * Creates a {@link CloseableIterator} which can iterate over all of the files present in this
+     * snapshot.
+     *
+     * TODO: document ordering (i.e. forwards or reverse)
+     *
+     * @return a {@link CloseableIterator} to iterate over files
+     */
+    CloseableIterator<AddFile> getAllFilesIter();
 
     /**
      * @return the table metadata for this snapshot

--- a/standalone/src/main/scala/io/delta/standalone/internal/MemoryOptimizedAddFileReplayIterator.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/MemoryOptimizedAddFileReplayIterator.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.standalone.internal
+
+import io.delta.standalone.actions.{AddFile => AddFileJ}
+import io.delta.standalone.data.CloseableIterator
+
+/**
+ * Dummy class. Will be replaced in a later version with a proper implementation.
+ */
+private[internal] class MemoryOptimizedAddFileReplayIterator
+    (val addFilesIter: Iterator[AddFileJ]) extends CloseableIterator[AddFileJ] {
+
+  override def hasNext: Boolean = addFilesIter.hasNext
+
+  override def next(): AddFileJ = addFilesIter.next()
+
+  override def close(): Unit = { }
+}

--- a/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
@@ -65,6 +65,10 @@ private[internal] class SnapshotImpl(
 
   override def getAllFiles: java.util.List[AddFileJ] = activeFiles
 
+  /** Dummy API. Will be replaced in a later version with a proper implementation. */
+  override def getAllFilesIter: CloseableIterator[AddFileJ] =
+    new MemoryOptimizedAddFileReplayIterator(activeFiles.iterator().asScala)
+
   override def getMetadata: MetadataJ = ConversionUtils.convertMetadata(state.metadata)
 
   override def getVersion: Long = version


### PR DESCRIPTION
- implements dummy API to return all AddFiles in a Snapshot as a `CloseableIterator<AddFile>`
- we want it to be a `CloseableIterator<AddFile>`, instead of an iterator, since in the future it will internally use `logStore. readAsIterator` (which is a `CloseableIterator`) and it is possible for the user to stop half-way through iterating over all the files. If they do that, then it is on them to call `close` on the log store iterator, since otherwise we wouldn't be able to detect that they have finished iterating.