### PR TITLE
Fix jackson incompatibility issue for Delta Hive 3 connector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -159,12 +159,23 @@ lazy val hive = (project in file("hive")) dependsOn(standalone) settings (
   // default merge strategy
   assemblyShadeRules in assembly := Seq(
     /**
-     * Hive 2.3.7 uses an old paranamer version that doesn't support Scala 2.12
+     * Hive uses an old paranamer version that doesn't support Scala 2.12
      * (https://issues.apache.org/jira/browse/SPARK-22128), so we need to shade our own paranamer
      * version to avoid conflicts.
      */
-    ShadeRule.rename("com.thoughtworks.paranamer.**" -> "shadedelta.@0").inAll
-    )
+    ShadeRule.rename("com.thoughtworks.paranamer.**" -> "shadedelta.@0").inAll,
+    // Hive 3 now has jackson-module-scala on the classpath. We need to shade it otherwise we may
+    // pick up Hive's jackson-module-scala and use the above old paranamer jar on Hive's classpath.
+    ShadeRule.rename("com.fasterxml.jackson.module.scala.**" -> "shadedelta.@0").inAll
+  ),
+  assemblyMergeStrategy in assembly := {
+    // Discard `module-info.class` to fix the `different file contents found` error.
+    // TODO Upgrade SBT to 1.5 which will do this automatically
+    case "module-info.class" => MergeStrategy.discard
+    case x =>
+      val oldStrategy = (assemblyMergeStrategy in assembly).value
+      oldStrategy(x)
+  }
 )
 
 lazy val hiveMR = (project in file("hive-mr")) dependsOn(hive % "test->test") settings (
@@ -260,8 +271,8 @@ lazy val standalone = (project in file("standalone"))
         ExclusionRule("org.slf4j", "slf4j-api"),
         ExclusionRule("org.apache.parquet", "parquet-hadoop")
       ),
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.8",
-      "org.json4s" %% "json4s-jackson" % "3.5.3" excludeAll (
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.10.0",
+      "org.json4s" %% "json4s-jackson" % "3.7.0-M5" excludeAll (
         ExclusionRule("com.fasterxml.jackson.core"),
         ExclusionRule("com.fasterxml.jackson.module")
       ),

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/JsonUtils.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/JsonUtils.scala
@@ -18,8 +18,7 @@ package io.delta.standalone.internal.util
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.fasterxml.jackson.module.scala.{DefaultScalaModule, ScalaObjectMapper}
 
 /** Useful json functions used around the Delta codebase. */
 private[internal] object JsonUtils {


### PR DESCRIPTION
Found some jackson incompatibility issue when testing on an Amazon EMR 6.4.0. This PR fixes it by 

- Upgrade jackson-module-scala version
- Upgrade json4s version
- Shade jackson-module-scala to fix the incompatibility issue