### PR TITLE
[DSW] Memory optimized iterator

### DIFF
--- a/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
@@ -295,7 +295,7 @@ private class InitialSnapshotImpl(
 
   override lazy val metadataScala: Metadata = Metadata()
 
-  override def scan(): DeltaScan = new DeltaScanImpl(null)
+  override def scan(): DeltaScan = new DeltaScanImpl(memoryOptimizedLogReplay)
 
   override def scan(predicate: Expression): DeltaScan =
     new FilteredDeltaScanImpl(memoryOptimizedLogReplay, predicate, metadataScala.partitionSchema)

--- a/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
@@ -122,12 +122,11 @@ private[internal] class SnapshotImpl(
   private def loadTableProtocolAndMetadata(): (Protocol, Metadata) = {
     var protocol: Protocol = null
     var metadata: Metadata = null
-
     val iter = memoryOptimizedLogReplay.getReverseIterator
 
     try {
       // We replay logs from newest to oldest and will stop when we find the latest Protocol and
-      // metadata.
+      // Metadata.
       iter.asScala.foreach { case (action, _) =>
         action match {
           case p: Protocol =>
@@ -155,7 +154,6 @@ private[internal] class SnapshotImpl(
     } finally {
       iter.close()
     }
-
 
     // Sanity check. Should not happen in any valid Delta logs.
     if (protocol == null) {

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/MemoryOptimizedLogReplay.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/MemoryOptimizedLogReplay.scala
@@ -58,12 +58,7 @@ private[internal] class MemoryOptimizedLogReplay(
         parquetIter = None
 
         if (reverseFilesIter.hasNext) {
-          // TODO: what about empty JSON files?
           val nextFile = reverseFilesIter.next()
-
-          // scalastyle:off println
-          println(nextFile.getName)
-          // scalastyle:on println
 
           if (nextFile.getName.endsWith(".json")) {
             jsonIter = Some(logStore.read(nextFile, hadoopConf))

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/MemoryOptimizedLogReplay.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/MemoryOptimizedLogReplay.scala
@@ -88,7 +88,7 @@ private[internal] class MemoryOptimizedLogReplay(
       }
 
       override def next(): (Action, Boolean) = {
-        if (!hasNext) throw new NoSuchElementException
+        if (!hasNext()) throw new NoSuchElementException
 
         val result = if (jsonIter.isDefined) {
           val nextLine = jsonIter.get.next()

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/MemoryOptimizedLogReplay.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/MemoryOptimizedLogReplay.scala
@@ -30,7 +30,7 @@ import io.delta.standalone.internal.util.JsonUtils
 private[internal] class MemoryOptimizedLogReplay(
     files: Seq[Path],
     logStore: LogStore,
-    hadoopConf: Configuration,
+    val hadoopConf: Configuration,
     timeZone: TimeZone) {
 
   /**

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/MemoryOptimizedLogReplay.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/MemoryOptimizedLogReplay.scala
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-
-package io.delta.standalone.internal.util
+package io.delta.standalone.internal.actions
 
 import java.util.TimeZone
 
@@ -27,23 +26,19 @@ import org.apache.hadoop.fs.Path
 
 import io.delta.standalone.storage.LogStore
 
-import io.delta.standalone.internal.actions.{Action, Parquet4sSingleActionWrapper, SingleAction}
+import io.delta.standalone.internal.util.JsonUtils
 
-private[internal] object MemoryOptimizedLogReplayUtil {
+private[internal] class MemoryOptimizedLogReplay(
+    files: Seq[Path],
+    logStore: LogStore,
+    hadoopConf: Configuration,
+    timeZone: TimeZone) {
 
   /**
-   * Replay the transaction logs from the newest log file to the oldest log file.
-   *
    * @param actionListener a listener to receive all actions when we are reading logs. The second
    *                       `Boolean` parameter means whether an action is loaded from a checkpoint.
    */
-  def replayActionsReversely(
-      files: Seq[Path],
-      logStore: LogStore,
-      hadoopConf: Configuration,
-      timeZone: TimeZone)(
-      actionListener: (Action, Boolean) => Unit): Unit = {
-
+  def replayActionsReversely(actionListener: (Action, Boolean) => Unit) : Unit = {
     files.sortWith(_.getName > _.getName).foreach { path =>
       if (path.getName.endsWith(".json")) {
         val iter = logStore.read(path, hadoopConf)

--- a/standalone/src/main/scala/io/delta/standalone/internal/scan/DeltaScanImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/scan/DeltaScanImpl.scala
@@ -28,16 +28,11 @@ import io.delta.standalone.internal.util.ConversionUtils
 
 /**
  * Scala implementation of Java interface [[DeltaScan]].
- *
- * TODO this is currently a naive implementation, since
- * a) it takes in the in-memory AddFiles.
- * b) it uses the metadata.partitionColumns, but the metadata won't be known until the log files
- *    are scanned
  */
 private[internal] class DeltaScanImpl(files: Seq[AddFile]) extends DeltaScan {
 
   /**
-   * Whether or not the given [[addFile]] should be returned during iteration.
+   * Whether or not the given [[AddFile]] should be returned during iteration.
    */
   protected def accept(addFile: AddFile): Boolean = true
 
@@ -49,7 +44,6 @@ private[internal] class DeltaScanImpl(files: Seq[AddFile]) extends DeltaScan {
    */
   def getFilesScala: Seq[AddFile] = files.filter(accept)
 
-  // TODO: memory-optimized implementation
   override def getFiles: CloseableIterator[AddFileJ] = new CloseableIterator[AddFileJ] {
     private var nextValid: Option[AddFile] = None
     private val iter = files.iterator

--- a/standalone/src/main/scala/io/delta/standalone/internal/scan/DeltaScanImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/scan/DeltaScanImpl.scala
@@ -108,7 +108,7 @@ private[internal] class DeltaScanImpl(replay: MemoryOptimizedLogReplay) extends 
     }
 
     override def next(): AddFile = {
-      if (!hasNext) throw new NoSuchElementException()
+      if (!hasNext()) throw new NoSuchElementException()
       nextIsLoaded = false
       nextMatching.get
     }

--- a/standalone/src/main/scala/io/delta/standalone/internal/scan/DeltaScanImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/scan/DeltaScanImpl.scala
@@ -63,13 +63,10 @@ private[internal] class DeltaScanImpl(replay: MemoryOptimizedLogReplay) extends 
             val alreadyReturned = addFiles.contains(add.path)
             if (!alreadyDeleted && !alreadyReturned) {
               addFiles += add.path
-              // scalastyle:off
-              println(s"Found matched ${add.path}")
               return Some(add)
             } else if (!alreadyReturned) {
               addFiles += add.path
             }
-
           // Note: `RemoveFile` in a checkpoint is useless since when we generate a checkpoint, an
           // AddFile file must be removed if there is a `RemoveFile`
           case remove: RemoveFile if !isCheckpoint =>
@@ -83,7 +80,7 @@ private[internal] class DeltaScanImpl(replay: MemoryOptimizedLogReplay) extends 
     }
 
     /**
-     * Sets the [[nextMatching]] variable to the next valid AddFile that also passes the given
+     * Sets the [[nextMatching]] variable to the next "valid" AddFile that also passes the given
      * [[accept]] check, or None if no such AddFile file exists.
      */
     private def setNextMatching(): Unit = {

--- a/standalone/src/main/scala/io/delta/standalone/internal/scan/DeltaScanImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/scan/DeltaScanImpl.scala
@@ -103,11 +103,11 @@ private[internal] class DeltaScanImpl(replay: MemoryOptimizedLogReplay) extends 
           // Note: `RemoveFile` in a checkpoint is useless since when we generate a checkpoint, an
           // AddFile file must be removed if there is a `RemoveFile`
           case remove: RemoveFile if !isCheckpoint =>
-            val canonicaleRemove = remove.copy(
+            val canonicalizeRemove = remove.copy(
               dataChange = false,
               path = canonicalizePath(remove.path, replay.hadoopConf))
 
-            tombstones += canonicaleRemove.pathAsUri
+            tombstones += canonicalizeRemove.pathAsUri
           case _ => // do nothing
         }
       }
@@ -139,7 +139,7 @@ private[internal] class DeltaScanImpl(replay: MemoryOptimizedLogReplay) extends 
     override def hasNext: Boolean = {
       // nextMatching will be empty if
       // a) this is the first time hasNext has been called
-      // b) we've run out of files to iterate over. in this case, setNextMatching() and
+      // b) we've run out of actions to iterate over. in this case, setNextMatching() and
       //    findNextValid() will both short circuit and return immediately
       if (nextMatching.isEmpty) {
         setNextMatching()

--- a/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
@@ -21,7 +21,7 @@ import java.util.Optional
 import io.delta.standalone.expressions.Expression
 import io.delta.standalone.types.StructType
 
-import io.delta.standalone.internal.actions.AddFile
+import io.delta.standalone.internal.actions.{AddFile, MemoryOptimizedLogReplay}
 import io.delta.standalone.internal.data.PartitionRowRecord
 import io.delta.standalone.internal.util.PartitionUtils
 
@@ -32,9 +32,9 @@ import io.delta.standalone.internal.util.PartitionUtils
  * If the pushed predicate is empty, then all files are returned.
  */
 final private[internal] class FilteredDeltaScanImpl(
-    files: Seq[AddFile],
+    replay: MemoryOptimizedLogReplay,
     expr: Expression,
-    partitionSchema: StructType) extends DeltaScanImpl(files) {
+    partitionSchema: StructType) extends DeltaScanImpl(replay) {
 
   private val partitionColumns = partitionSchema.getFieldNames.toSeq
 

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/MemoryOptimizedLogReplayUtil.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/MemoryOptimizedLogReplayUtil.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (2020-present) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package io.delta.standalone.internal.util
 
 import java.util.TimeZone
@@ -24,8 +41,11 @@ private[internal] object MemoryOptimizedLogReplayUtil {
       files: Seq[Path],
       logStore: LogStore,
       hadoopConf: Configuration,
-      timeZone: TimeZone,
+      timeZone: TimeZone)(
       actionListener: (Action, Boolean) => Unit): Unit = {
+
+    // TODO: pass in an error wrapper? so we can catch FileNotFound exceptions?
+
     files.sortWith(_.getName > _.getName).foreach { path =>
       if (path.getName.endsWith(".json")) {
         val iter = logStore.read(path, hadoopConf)

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/MemoryOptimizedLogReplayUtil.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/MemoryOptimizedLogReplayUtil.scala
@@ -44,8 +44,6 @@ private[internal] object MemoryOptimizedLogReplayUtil {
       timeZone: TimeZone)(
       actionListener: (Action, Boolean) => Unit): Unit = {
 
-    // TODO: pass in an error wrapper? so we can catch FileNotFound exceptions?
-
     files.sortWith(_.getName > _.getName).foreach { path =>
       if (path.getName.endsWith(".json")) {
         val iter = logStore.read(path, hadoopConf)

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/MemoryOptimizedLogReplayUtil.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/MemoryOptimizedLogReplayUtil.scala
@@ -1,0 +1,62 @@
+package io.delta.standalone.internal.util
+
+import java.util.TimeZone
+
+import scala.collection.JavaConverters._
+
+import com.github.mjakubowski84.parquet4s.ParquetReader
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import io.delta.standalone.storage.LogStore
+
+import io.delta.standalone.internal.actions.{Action, Parquet4sSingleActionWrapper, SingleAction}
+
+private[internal] object MemoryOptimizedLogReplayUtil {
+
+  /**
+   * Replay the transaction logs from the newest log file to the oldest log file.
+   *
+   * @param actionListener a listener to receive all actions when we are reading logs. The second
+   *                       `Boolean` parameter means whether an action is loaded from a checkpoint.
+   */
+  def replayActionsReversely(
+      files: Seq[Path],
+      logStore: LogStore,
+      hadoopConf: Configuration,
+      timeZone: TimeZone,
+      actionListener: (Action, Boolean) => Unit): Unit = {
+    files.sortWith(_.getName > _.getName).foreach { path =>
+      if (path.getName.endsWith(".json")) {
+        val iter = logStore.read(path, hadoopConf)
+        try {
+          iter
+            .asScala
+            .map { line =>
+              JsonUtils.mapper.readValue[SingleAction](line).unwrap
+            }
+            .foreach { action =>
+              actionListener(action, false)
+            }
+        } finally {
+          iter.close()
+        }
+      } else if (path.getName.endsWith(".parquet")) {
+        val iter = ParquetReader.read[Parquet4sSingleActionWrapper](
+          path.toString,
+          ParquetReader.Options(timeZone, hadoopConf = hadoopConf)
+        )
+        try {
+          iter.iterator.map(_.unwrap.unwrap).foreach { action =>
+            actionListener(action, true)
+          }
+        } finally {
+          iter.close()
+        }
+      } else {
+        throw new IllegalStateException(s"unexpected log file path: $path")
+      }
+    }
+  }
+
+}

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -435,7 +435,7 @@ abstract class DeltaLogSuiteBase extends FunSuite {
 // Concrete Implementations
 ///////////////////////////////////////////////////////////////////////////
 
-class DeltaLogSuite extends DeltaLogSuiteBase {
+class StandardDeltaLogSuite extends DeltaLogSuiteBase {
   class StandardSnapshot(snapshot: Snapshot) extends CustomAddFilesAccessor(snapshot) {
     override def _getFiles(): java.util.List[AddFileJ] = snapshot.getAllFiles
   }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaScanSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaScanSuite.scala
@@ -148,8 +148,11 @@ class DeltaScanSuite extends FunSuite {
       val scan = log.update().scan(filter)
       val iter = scan.getFiles
       while (iter.hasNext) {
+        iter.hasNext // let's use another hasNext call to make sure it is idempotent
+
         set += iter.next()
       }
+
       assert(set == expectedSet)
 
       iter.close()


### PR DESCRIPTION
This PR adds a proper memory-optimized, lazy iterator implementation for `DeltaScan.getFiles`.

### SnapshotImpl
SnapshotImpl is changed to load the Protocol and Metadata actions efficiently, too (instead of replaying the log and keeping all actions in memory).

We never used `numOfMetadata` or `numOfProtocol`, so we can remove `protocol`, `metadata`, `numOfMetadata`, `numOfProtocol` from Snapshot.State

### MemoryOptimizedLogReplay
Provides a `CloseableIterator[(Action, isFromCheckpoint)]` API, using one iterator for files and another iterator for action-reading inside the current file.

We use this reverse, closeable iterator in two places, and it is important that we close it in both.
1. in `loadTableProtocolAndMetadata`, we use a try finally to close it
2. in `DeltaScanImpl` we expose both `getFilesScala`, which also uses try finally to close it, and `getFiles` which exposes a wrapper over this closeable iterator, and it is up to the user to close it.

### DeltaScanImpl
Now uses the MemoryOptimizedLogReplay and keeps track of seenAddFiles and tombstones to return valid AddFiles

### DeltaScanSuite
Adds tests for FilteredDeltaScanImpl

### DeltaLogSuite
We have now renamed `DeltaLogSuite` to `DeltaLogSuiteBase`, and basically provided an abstract "snapshot get all files" API that children test suites have to override.

So, we have `StandardDeltaLogSuite` which uses `snapshot.getAllFiles` (in memory).
And we have `MemoryOptimizedDeltaLogSuite` which uses `snapshot.scan.getFiles` (memory optimized)

