### PR TITLE
Hadoop 3.2.1 compatibility on EMR

### DIFF
--- a/standalone/src/main/scala/io/delta/standalone/internal/MetadataCleanup.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/MetadataCleanup.scala
@@ -20,7 +20,7 @@ import java.util.{Calendar, TimeZone}
 
 import scala.collection.JavaConverters._
 
-import org.apache.commons.lang.time.DateUtils
+import org.apache.commons.lang3.time.DateUtils
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 import io.delta.standalone.internal.util.FileNames.{checkpointPrefix, checkpointVersion, deltaVersion, isCheckpointFile, isDeltaFile}


### PR DESCRIPTION
Updates 1 import for Hadoop 3.2.1 compatibility on EMR