### PR TITLE
EngineInfo: replace spaces with '-' for engineVersion and deltaVersion

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
+++ b/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
@@ -40,7 +40,8 @@ public interface OptimisticTransaction {
      * @param actions  Set of actions to commit.
      * @param op  Details of operation that is performing this transactional commit.
      * @param engineInfo  String used to identify the writer engine. It should resemble
-     *                 "{engineName}/{engineVersion}".
+     *                    "{engineName}/{engineVersion}", with dashes in place of whitespace.
+     *                    For example, {@code "Flink-Connector/1.1.0"}.
      * @return a {@link CommitResult}, wrapping the table version that was committed.
      */
     <T extends Action> CommitResult commit(Iterable<T> actions, Operation op, String engineInfo);

--- a/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
@@ -201,7 +201,7 @@ public class CommitInfo implements Action {
 
     /**
      * @return the engineInfo of the operation that performed this commit. It should be of the form
-     *         "{engineName}-{engineVersion}-deltaStandalone-{deltaStandaloneVersion}"
+     *         "{engineName}/{engineVersion} Delta-Standalone/{deltaStandaloneVersion}"
      */
     public Optional<String> getEngineInfo() {
         return engineInfo;

--- a/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
@@ -129,7 +129,7 @@ private[internal] class OptimisticTransactionImpl(
       Some(isBlindAppend),
       Some(op.getMetrics.asScala.toMap),
       if (op.getUserMetadata.isPresent) Some(op.getUserMetadata.get()) else None,
-      Some(s"${engineInfo.replace(' ', '-')} ${NAME.replace(' ', '-')}/$VERSION")
+      Some(s"${engineInfo.replaceAll("\\s", "-")} ${NAME.replaceAll("\\s", "-")}/$VERSION")
     )
 
     preparedActions = commitInfo +: preparedActions

--- a/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
@@ -129,7 +129,7 @@ private[internal] class OptimisticTransactionImpl(
       Some(isBlindAppend),
       Some(op.getMetrics.asScala.toMap),
       if (op.getUserMetadata.isPresent) Some(op.getUserMetadata.get()) else None,
-      Some(s"$engineInfo $NAME/$VERSION")
+      Some(s"${engineInfo.replace(' ', '-')} ${NAME.replace(' ', '-')}/$VERSION")
     )
 
     preparedActions = commitInfo +: preparedActions

--- a/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionLegacySuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionLegacySuite.scala
@@ -507,17 +507,18 @@ class OptimisticTransactionLegacySuite extends FunSuite {
   // commit() tests
   ///////////////////////////////////////////////////////////////////////////
 
-  test("CommitInfo operation and engineInfo is persisted to the delta log") {
+  test("CommitInfo operation and engineInfo is persisted to the delta log correctly") {
     withTempDir { dir =>
       val opParams = Collections.singletonMap(Operation.Metrics.numAddedFiles, "0")
       val op = new Operation(Operation.Name.MANUAL_UPDATE, opParams)
       val log = DeltaLog.forTable(new Configuration(), dir.getCanonicalPath)
-      log.startTransaction().commit(Metadata() :: Nil, op, engineInfo)
+      log.startTransaction().commit(Metadata() :: Nil, op, "Foo Connector/1.1.0")
 
       val log2 = DeltaLog.forTable(new Configuration(), dir.getCanonicalPath)
       val commitInfo = log2.getCommitInfoAt(0)
       assert(commitInfo.getEngineInfo.isPresent)
-      assert(commitInfo.getEngineInfo.get() == s"$engineInfo $NAME/$VERSION")
+      assert(commitInfo.getEngineInfo.get() ==
+        s"Foo-Connector/1.1.0 ${NAME.replaceAll("\\s", "-")}/$VERSION")
       assert(commitInfo.getOperation == op.getName.toString)
       assert(commitInfo.getOperationParameters.asScala == Map("numAddedFiles" -> "0"))
     }
@@ -735,5 +736,4 @@ class OptimisticTransactionLegacySuite extends FunSuite {
       }
     }
   }
-
 }


### PR DESCRIPTION
Should we also ask the user to format this way? Or is it okay to just replace spaces with dashes before saving?