### PR TITLE
Add `getRemoveFile` API to AddFile

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/actions/Action.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Action.java
@@ -19,7 +19,7 @@ package io.delta.standalone.actions;
 /**
  * A marker interface for all Actions that can be applied to a Delta Table.
  * Each action represents a single change to the state of a Delta table.
- *
+ * <p>
  * You can use the following code to extract the concrete type of an {@link Action}.
  * <pre>{@code
  *   // {@link io.delta.standalone.DeltaLog.getChanges} is one way to get such actions

--- a/standalone/src/main/java/io/delta/standalone/actions/AddCDCFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/AddCDCFile.java
@@ -38,8 +38,11 @@ public final class AddCDCFile implements FileAction {
     @Nullable
     private final Map<String, String> tags;
 
-    public AddCDCFile(@Nonnull String path, @Nonnull Map<String, String> partitionValues, long size,
-                      @Nullable Map<String, String> tags) {
+    public AddCDCFile(
+            @Nonnull String path,
+            @Nonnull Map<String, String> partitionValues,
+            long size,
+            @Nullable Map<String, String> tags) {
         this.path = path;
         this.partitionValues = partitionValues;
         this.size = size;

--- a/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
@@ -68,8 +68,7 @@ public final class AddFile implements FileAction {
      */
     @Nonnull
     public RemoveFile getRemoveFile() {
-        return new RemoveFile(path, Optional.of(System.currentTimeMillis()), dataChange, true,
-            partitionValues, size, tags);
+        return getRemoveFile(System.currentTimeMillis());
     }
 
     /**

--- a/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
@@ -90,8 +90,8 @@ public final class AddFile implements FileAction {
      *         {@code dataChange} flag
      */
     @Nonnull
-    public RemoveFile remove(boolean _dataChange) {
-        return remove(System.currentTimeMillis(), _dataChange);
+    public RemoveFile remove(boolean dataChange) {
+        return remove(System.currentTimeMillis(), dataChange);
     }
 
     /**
@@ -99,8 +99,8 @@ public final class AddFile implements FileAction {
      *         {@code deletionTimestamp} value and {@code dataChange} flag
      */
     @Nonnull
-    public RemoveFile remove(long deletionTimestamp, boolean _dataChange) {
-        return new RemoveFile(path, Optional.of(deletionTimestamp), _dataChange, true,
+    public RemoveFile remove(long deletionTimestamp, boolean dataChange) {
+        return new RemoveFile(path, Optional.of(deletionTimestamp), dataChange, true,
             partitionValues, size, tags);
     }
 

--- a/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
@@ -19,6 +19,7 @@ package io.delta.standalone.actions;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -60,6 +61,25 @@ public final class AddFile implements FileAction {
         this.dataChange = dataChange;
         this.stats = stats;
         this.tags = tags;
+    }
+
+    /**
+     * @return the corresponding {@link RemoveFile} for this file
+     */
+    @Nonnull
+    public RemoveFile getRemoveFile() {
+        return new RemoveFile(path, Optional.of(System.currentTimeMillis()), dataChange, true,
+            partitionValues, size, tags);
+    }
+
+    /**
+     * @return the corresponding {@link RemoveFile} for this file, instantiated with the given
+     *         {@code deletionTimestamp}
+     */
+    @Nonnull
+    public RemoveFile getRemoveFile(long deletionTimestamp) {
+        return new RemoveFile(path, Optional.of(deletionTimestamp), dataChange, true,
+            partitionValues, size, tags);
     }
 
     /**

--- a/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/AddFile.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 /**
  * Represents an action that adds a new file to the table. The path of a file acts as the primary
  * key for the entry in the set of files.
- *
+ * <p>
  * Note: since actions within a given Delta file are not guaranteed to be applied in order, it is
  * not valid for multiple file operations with the same path to exist in a single version.
  *
@@ -51,9 +51,14 @@ public final class AddFile implements FileAction {
     @Nullable
     private final Map<String, String> tags;
 
-    public AddFile(@Nonnull String path, @Nonnull Map<String, String> partitionValues, long size,
-                   long modificationTime, boolean dataChange, @Nullable String stats,
-                   @Nullable Map<String, String> tags) {
+    public AddFile(
+            @Nonnull String path,
+            @Nonnull Map<String, String> partitionValues,
+            long size,
+            long modificationTime,
+            boolean dataChange,
+            @Nullable String stats,
+            @Nullable Map<String, String> tags) {
         this.path = path;
         this.partitionValues = partitionValues;
         this.size = size;
@@ -67,8 +72,8 @@ public final class AddFile implements FileAction {
      * @return the corresponding {@link RemoveFile} for this file
      */
     @Nonnull
-    public RemoveFile getRemoveFile() {
-        return getRemoveFile(System.currentTimeMillis());
+    public RemoveFile remove() {
+        return remove(System.currentTimeMillis(), dataChange);
     }
 
     /**
@@ -76,8 +81,26 @@ public final class AddFile implements FileAction {
      *         {@code deletionTimestamp}
      */
     @Nonnull
-    public RemoveFile getRemoveFile(long deletionTimestamp) {
-        return new RemoveFile(path, Optional.of(deletionTimestamp), dataChange, true,
+    public RemoveFile remove(long deletionTimestamp) {
+        return remove(deletionTimestamp, dataChange);
+    }
+
+    /**
+     * @return the corresponding {@link RemoveFile} for this file, instantiated with the given
+     *         {@code dataChange} flag
+     */
+    @Nonnull
+    public RemoveFile remove(boolean _dataChange) {
+        return remove(System.currentTimeMillis(), _dataChange);
+    }
+
+    /**
+     * @return the corresponding {@link RemoveFile} for this file, instantiated with the given
+     *         {@code deletionTimestamp} value and {@code dataChange} flag
+     */
+    @Nonnull
+    public RemoveFile remove(long deletionTimestamp, boolean _dataChange) {
+        return new RemoveFile(path, Optional.of(deletionTimestamp), _dataChange, true,
             partitionValues, size, tags);
     }
 

--- a/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
@@ -21,6 +21,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Holds provenance information about changes to the table. This CommitInfo
@@ -30,38 +32,38 @@ import java.util.Optional;
  * @see  <a href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md">Delta Transaction Log Protocol</a>
  */
 public class CommitInfo implements Action {
-    private final Optional<Long> version;
-    private final Timestamp timestamp;
-    private final Optional<String> userId;
-    private final Optional<String> userName;
-    private final String operation;
-    private final Map<String, String> operationParameters;
-    private final Optional<JobInfo> jobInfo;
-    private final Optional<NotebookInfo> notebookInfo;
-    private final Optional<String> clusterId;
-    private final Optional<Long> readVersion;
-    private final Optional<String> isolationLevel;
-    private final Optional<Boolean> isBlindAppend;
-    private final Optional<Map<String, String>> operationMetrics;
-    private final Optional<String> userMetadata;
-    private final Optional<String> engineInfo;
+    @Nonnull private final Optional<Long> version;
+    @Nullable private final Timestamp timestamp;
+    @Nonnull private final Optional<String> userId;
+    @Nonnull private final Optional<String> userName;
+    @Nullable private final String operation;
+    @Nullable private final Map<String, String> operationParameters;
+    @Nonnull private final Optional<JobInfo> jobInfo;
+    @Nonnull private final Optional<NotebookInfo> notebookInfo;
+    @Nonnull private final Optional<String> clusterId;
+    @Nonnull private final Optional<Long> readVersion;
+    @Nonnull private final Optional<String> isolationLevel;
+    @Nonnull private final Optional<Boolean> isBlindAppend;
+    @Nonnull private final Optional<Map<String, String>> operationMetrics;
+    @Nonnull private final Optional<String> userMetadata;
+    @Nonnull private final Optional<String> engineInfo;
 
     // For binary compatibility with version 0.2.0
     public CommitInfo(
-            Optional<Long> version,
-            Timestamp timestamp,
-            Optional<String> userId,
-            Optional<String> userName,
-            String operation,
-            Map<String, String> operationParameters,
-            Optional<JobInfo> jobInfo,
-            Optional<NotebookInfo> notebookInfo,
-            Optional<String> clusterId,
-            Optional<Long> readVersion,
-            Optional<String> isolationLevel,
-            Optional<Boolean> isBlindAppend,
-            Optional<Map<String, String>> operationMetrics,
-            Optional<String> userMetadata) {
+            @Nonnull Optional<Long> version,
+            @Nullable Timestamp timestamp,
+            @Nonnull Optional<String> userId,
+            @Nonnull Optional<String> userName,
+            @Nullable String operation,
+            @Nullable Map<String, String> operationParameters,
+            @Nonnull Optional<JobInfo> jobInfo,
+            @Nonnull Optional<NotebookInfo> notebookInfo,
+            @Nonnull Optional<String> clusterId,
+            @Nonnull Optional<Long> readVersion,
+            @Nonnull Optional<String> isolationLevel,
+            @Nonnull Optional<Boolean> isBlindAppend,
+            @Nonnull Optional<Map<String, String>> operationMetrics,
+            @Nonnull Optional<String> userMetadata) {
         this.version = version;
         this.timestamp = timestamp;
         this.userId = userId;
@@ -80,21 +82,21 @@ public class CommitInfo implements Action {
     }
 
     public CommitInfo(
-            Optional<Long> version,
-            Timestamp timestamp,
-            Optional<String> userId,
-            Optional<String> userName,
-            String operation,
-            Map<String, String> operationParameters,
-            Optional<JobInfo> jobInfo,
-            Optional<NotebookInfo> notebookInfo,
-            Optional<String> clusterId,
-            Optional<Long> readVersion,
-            Optional<String> isolationLevel,
-            Optional<Boolean> isBlindAppend,
-            Optional<Map<String, String>> operationMetrics,
-            Optional<String> userMetadata,
-            Optional<String> engineInfo) {
+            @Nonnull Optional<Long> version,
+            @Nullable Timestamp timestamp,
+            @Nonnull Optional<String> userId,
+            @Nonnull Optional<String> userName,
+            @Nullable String operation,
+            @Nullable Map<String, String> operationParameters,
+            @Nonnull Optional<JobInfo> jobInfo,
+            @Nonnull Optional<NotebookInfo> notebookInfo,
+            @Nonnull Optional<String> clusterId,
+            @Nonnull Optional<Long> readVersion,
+            @Nonnull Optional<String> isolationLevel,
+            @Nonnull Optional<Boolean> isBlindAppend,
+            @Nonnull Optional<Map<String, String>> operationMetrics,
+            @Nonnull Optional<String> userMetadata,
+            @Nonnull Optional<String> engineInfo) {
         this.version = version;
         this.timestamp = timestamp;
         this.userId = userId;
@@ -115,6 +117,7 @@ public class CommitInfo implements Action {
     /**
      * @return the log version for this commit
      */
+    @Nonnull
     public Optional<Long> getVersion() {
         return version;
     }
@@ -122,6 +125,7 @@ public class CommitInfo implements Action {
     /**
      * @return the time the files in this commit were committed
      */
+    @Nullable
     public Timestamp getTimestamp() {
         return timestamp;
     }
@@ -129,6 +133,7 @@ public class CommitInfo implements Action {
     /**
      * @return the userId of the user who committed this file
      */
+    @Nonnull
     public Optional<String> getUserId() {
         return userId;
     }
@@ -136,6 +141,7 @@ public class CommitInfo implements Action {
     /**
      * @return the userName of the user who committed this file
      */
+    @Nonnull
     public Optional<String> getUserName() {
         return userName;
     }
@@ -143,6 +149,7 @@ public class CommitInfo implements Action {
     /**
      * @return the type of operation for this commit. e.g. "WRITE"
      */
+    @Nullable
     public String getOperation() {
         return operation;
     }
@@ -150,6 +157,7 @@ public class CommitInfo implements Action {
     /**
      * @return any relevant operation parameters. e.g. "mode", "partitionBy"
      */
+    @Nullable
     public Map<String, String> getOperationParameters() {
         if (operationParameters != null) return Collections.unmodifiableMap(operationParameters);
         return null;
@@ -158,6 +166,7 @@ public class CommitInfo implements Action {
     /**
      * @return the JobInfo for this commit
      */
+    @Nonnull
     public Optional<JobInfo> getJobInfo() {
         return jobInfo;
     }
@@ -165,6 +174,7 @@ public class CommitInfo implements Action {
     /**
      * @return the NotebookInfo for this commit
      */
+    @Nonnull
     public Optional<NotebookInfo> getNotebookInfo() {
         return notebookInfo;
     }
@@ -172,6 +182,7 @@ public class CommitInfo implements Action {
     /**
      * @return the ID of the cluster used to generate this commit
      */
+    @Nonnull
     public Optional<String> getClusterId() {
         return clusterId;
     }
@@ -179,6 +190,7 @@ public class CommitInfo implements Action {
     /**
      * @return the version that the transaction used to generate this commit is reading from
      */
+    @Nonnull
     public Optional<Long> getReadVersion() {
         return readVersion;
     }
@@ -186,6 +198,7 @@ public class CommitInfo implements Action {
     /**
      * @return the isolation level at which this commit was generated
      */
+    @Nonnull
     public Optional<String> getIsolationLevel() {
         return isolationLevel;
     }
@@ -193,6 +206,7 @@ public class CommitInfo implements Action {
     /**
      * @return whether this commit has blindly appended without caring about existing files
      */
+    @Nonnull
     public Optional<Boolean> getIsBlindAppend() {
         return isBlindAppend;
     }
@@ -200,16 +214,15 @@ public class CommitInfo implements Action {
     /**
      * @return any operation metrics calculated
      */
+    @Nonnull
     public Optional<Map<String, String>> getOperationMetrics() {
-        if (operationMetrics.isPresent()) {
-            return Optional.of(Collections.unmodifiableMap(operationMetrics.get()));
-        }
-        return operationMetrics;
+        return operationMetrics.map(Collections::unmodifiableMap);
     }
 
     /**
      * @return any additional user metadata
      */
+    @Nonnull
     public Optional<String> getUserMetadata() {
         return userMetadata;
     }
@@ -218,6 +231,7 @@ public class CommitInfo implements Action {
      * @return the engineInfo of the operation that performed this commit. It should be of the form
      *         "{engineName}/{engineVersion} Delta-Standalone/{deltaStandaloneVersion}"
      */
+    @Nonnull
     public Optional<String> getEngineInfo() {
         return engineInfo;
     }
@@ -262,33 +276,33 @@ public class CommitInfo implements Action {
      * Builder class for CommitInfo. Enables construction of CommitInfo object with default values.
      */
     public static class Builder {
-        private Optional<Long> version = Optional.empty();
-        private Timestamp timestamp;
-        private Optional<String> userId = Optional.empty();
-        private Optional<String> userName = Optional.empty();
-        private String operation;
-        private Map<String, String> operationParameters;
-        private Optional<JobInfo> jobInfo = Optional.empty();
-        private Optional<NotebookInfo> notebookInfo = Optional.empty();
-        private Optional<String> clusterId = Optional.empty();
-        private Optional<Long> readVersion = Optional.empty();
-        private Optional<String> isolationLevel = Optional.empty();
-        private Optional<Boolean> isBlindAppend = Optional.empty();
-        private Optional<Map<String, String>> operationMetrics = Optional.empty();
-        private Optional<String> userMetadata = Optional.empty();
-        private Optional<String> engineInfo = Optional.empty();
+        @Nonnull private Optional<Long> version = Optional.empty();
+        @Nullable private Timestamp timestamp;
+        @Nonnull private Optional<String> userId = Optional.empty();
+        @Nonnull private Optional<String> userName = Optional.empty();
+        @Nullable private String operation;
+        @Nullable private Map<String, String> operationParameters;
+        @Nonnull private Optional<JobInfo> jobInfo = Optional.empty();
+        @Nonnull private Optional<NotebookInfo> notebookInfo = Optional.empty();
+        @Nonnull private Optional<String> clusterId = Optional.empty();
+        @Nonnull private Optional<Long> readVersion = Optional.empty();
+        @Nonnull private Optional<String> isolationLevel = Optional.empty();
+        @Nonnull private Optional<Boolean> isBlindAppend = Optional.empty();
+        @Nonnull private Optional<Map<String, String>> operationMetrics = Optional.empty();
+        @Nonnull private Optional<String> userMetadata = Optional.empty();
+        @Nonnull private Optional<String> engineInfo = Optional.empty();
 
         public Builder version(Long version) {
             this.version = Optional.of(version);
             return this;
         }
 
-        public Builder timestamp(Timestamp timestamp) {
+        public Builder timestamp(@Nullable Timestamp timestamp) {
             this.timestamp = timestamp;
             return this;
         }
 
-        public Builder userId(String userId) {
+        public Builder userId(@Nullable String userId) {
             this.userId = Optional.of(userId);
             return this;
         }
@@ -303,7 +317,7 @@ public class CommitInfo implements Action {
             return this;
         }
 
-        public Builder operationParameters(Map<String, String> operationParameters) {
+        public Builder operationParameters(@Nullable Map<String, String> operationParameters) {
             this.operationParameters = operationParameters;
             return this;
         }

--- a/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/CommitInfo.java
@@ -47,14 +47,21 @@ public class CommitInfo implements Action {
     private final Optional<String> engineInfo;
 
     // For binary compatibility with version 0.2.0
-    public CommitInfo(Optional<Long> version, Timestamp timestamp, Optional<String> userId,
-                      Optional<String> userName, String operation,
-                      Map<String, String> operationParameters, Optional<JobInfo> jobInfo,
-                      Optional<NotebookInfo> notebookInfo, Optional<String> clusterId,
-                      Optional<Long> readVersion, Optional<String> isolationLevel,
-                      Optional<Boolean> isBlindAppend,
-                      Optional<Map<String, String>> operationMetrics,
-                      Optional<String> userMetadata) {
+    public CommitInfo(
+            Optional<Long> version,
+            Timestamp timestamp,
+            Optional<String> userId,
+            Optional<String> userName,
+            String operation,
+            Map<String, String> operationParameters,
+            Optional<JobInfo> jobInfo,
+            Optional<NotebookInfo> notebookInfo,
+            Optional<String> clusterId,
+            Optional<Long> readVersion,
+            Optional<String> isolationLevel,
+            Optional<Boolean> isBlindAppend,
+            Optional<Map<String, String>> operationMetrics,
+            Optional<String> userMetadata) {
         this.version = version;
         this.timestamp = timestamp;
         this.userId = userId;
@@ -72,14 +79,22 @@ public class CommitInfo implements Action {
         this.engineInfo = Optional.empty();
     }
 
-    public CommitInfo(Optional<Long> version, Timestamp timestamp, Optional<String> userId,
-                      Optional<String> userName, String operation,
-                      Map<String, String> operationParameters, Optional<JobInfo> jobInfo,
-                      Optional<NotebookInfo> notebookInfo, Optional<String> clusterId,
-                      Optional<Long> readVersion, Optional<String> isolationLevel,
-                      Optional<Boolean> isBlindAppend,
-                      Optional<Map<String, String>> operationMetrics,
-                      Optional<String> userMetadata, Optional<String> engineInfo) {
+    public CommitInfo(
+            Optional<Long> version,
+            Timestamp timestamp,
+            Optional<String> userId,
+            Optional<String> userName,
+            String operation,
+            Map<String, String> operationParameters,
+            Optional<JobInfo> jobInfo,
+            Optional<NotebookInfo> notebookInfo,
+            Optional<String> clusterId,
+            Optional<Long> readVersion,
+            Optional<String> isolationLevel,
+            Optional<Boolean> isBlindAppend,
+            Optional<Map<String, String>> operationMetrics,
+            Optional<String> userMetadata,
+            Optional<String> engineInfo) {
         this.version = version;
         this.timestamp = timestamp;
         this.userId = userId;

--- a/standalone/src/main/java/io/delta/standalone/actions/JobInfo.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/JobInfo.java
@@ -26,8 +26,12 @@ public class JobInfo {
     private final String jobOwnerId;
     private final String triggerType;
 
-    public JobInfo(String jobId, String jobName, String runId, String jobOwnerId,
-                   String triggerType) {
+    public JobInfo(
+            String jobId,
+            String jobName,
+            String runId,
+            String jobOwnerId,
+            String triggerType) {
         this.jobId = jobId;
         this.jobName = jobName;
         this.runId = runId;

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -44,9 +44,15 @@ public final class Metadata implements Action {
     private final Optional<Long> createdTime;
     private final StructType schema;
 
-    public Metadata(String id, String name, String description, Format format,
-                    List<String> partitionColumns, Map<String, String> configuration,
-                    Optional<Long> createdTime, StructType schema) {
+    public Metadata(
+            String id,
+            String name,
+            String description,
+            Format format,
+            List<String> partitionColumns,
+            Map<String, String> configuration,
+            Optional<Long> createdTime,
+            StructType schema) {
         this.id = id;
         this.name = name;
         this.description = description;

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -22,6 +22,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import io.delta.standalone.types.StructType;
 
 /**
@@ -35,24 +38,24 @@ import io.delta.standalone.types.StructType;
  * @see  <a href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md">Delta Transaction Log Protocol</a>
  */
 public final class Metadata implements Action {
-    private final String id;
-    private final String name;
-    private final String description;
-    private final Format format;
-    private final List<String> partitionColumns;
-    private final Map<String, String> configuration;
-    private final Optional<Long> createdTime;
-    private final StructType schema;
+    @Nonnull private final String id;
+    @Nullable private final String name;
+    @Nullable private final String description;
+    @Nonnull private final Format format;
+    @Nonnull private final List<String> partitionColumns;
+    @Nonnull private final Map<String, String> configuration;
+    @Nonnull private final Optional<Long> createdTime;
+    @Nullable private final StructType schema;
 
     public Metadata(
-            String id,
-            String name,
-            String description,
-            Format format,
-            List<String> partitionColumns,
-            Map<String, String> configuration,
-            Optional<Long> createdTime,
-            StructType schema) {
+            @Nonnull String id,
+            @Nullable String name,
+            @Nullable String description,
+            @Nonnull Format format,
+            @Nonnull List<String> partitionColumns,
+            @Nonnull Map<String, String> configuration,
+            @Nonnull Optional<Long> createdTime,
+            @Nullable StructType schema) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -66,6 +69,7 @@ public final class Metadata implements Action {
     /**
      * @return the unique identifier for this table
      */
+    @Nonnull
     public String getId() {
         return id;
     }
@@ -73,6 +77,7 @@ public final class Metadata implements Action {
     /**
      * @return the user-provided identifier for this table
      */
+    @Nullable
     public String getName() {
         return name;
     }
@@ -80,6 +85,7 @@ public final class Metadata implements Action {
     /**
      * @return the user-provided description for this table
      */
+    @Nullable
     public String getDescription() {
         return description;
     }
@@ -87,6 +93,7 @@ public final class Metadata implements Action {
     /**
      * @return the {@link Format} for this table
      */
+    @Nonnull
     public Format getFormat() {
         return format;
     }
@@ -95,22 +102,25 @@ public final class Metadata implements Action {
      * @return an unmodifiable {@code java.util.List} containing the names of
      *         columns by which the data should be partitioned
      */
+    @Nonnull
     public List<String> getPartitionColumns() {
-        return partitionColumns != null ? Collections.unmodifiableList(partitionColumns) : null;
+        return Collections.unmodifiableList(partitionColumns);
     }
 
     /**
      * @return an unmodifiable {@code java.util.Map} containing configuration
      *         options for this metadata
      */
+    @Nonnull
     public Map<String, String> getConfiguration() {
-        return configuration != null ? Collections.unmodifiableMap(configuration) : null;
+        return Collections.unmodifiableMap(configuration);
     }
 
     /**
      * @return the time when this metadata action was created, in milliseconds
      *         since the Unix epoch
      */
+    @Nonnull
     public Optional<Long> getCreatedTime() {
         return createdTime;
     }
@@ -118,6 +128,7 @@ public final class Metadata implements Action {
     /**
      * @return the schema of the table as a {@link StructType}
      */
+    @Nullable
     public StructType getSchema() {
         return schema;
     }
@@ -154,41 +165,41 @@ public final class Metadata implements Action {
      * Builder class for Metadata. Enables construction of Metadata object with default values.
      */
     public static class Builder {
-        private String id = java.util.UUID.randomUUID().toString();
-        private String name;
-        private String description;
-        private Format format = new Format("parquet", Collections.emptyMap());
-        private List<String> partitionColumns = Collections.emptyList();
-        private Map<String, String> configuration = Collections.emptyMap();
-        private Optional<Long> createdTime = Optional.of(System.currentTimeMillis());
-        private StructType schema;
+        @Nonnull private String id = java.util.UUID.randomUUID().toString();
+        @Nullable private String name;
+        @Nullable private String description;
+        @Nonnull private Format format = new Format("parquet", Collections.emptyMap());
+        @Nonnull private List<String> partitionColumns = Collections.emptyList();
+        @Nonnull private Map<String, String> configuration = Collections.emptyMap();
+        @Nonnull private Optional<Long> createdTime = Optional.of(System.currentTimeMillis());
+        @Nullable private StructType schema;
 
-        public Builder id(String id) {
+        public Builder id(@Nonnull String id) {
             this.id = id;
             return this;
         }
 
-        public Builder name(String name) {
+        public Builder name(@Nullable String name) {
             this.name = name;
             return this;
         }
 
-        public Builder description(String description) {
+        public Builder description(@Nullable String description) {
             this.description = description;
             return this;
         }
 
-        public Builder format(Format format) {
+        public Builder format(@Nonnull Format format) {
             this.format = format;
             return this;
         }
 
-        public Builder partitionColumns(List<String> partitionColumns) {
+        public Builder partitionColumns(@Nonnull List<String> partitionColumns) {
             this.partitionColumns = partitionColumns;
             return this;
         }
 
-        public Builder configuration(Map<String, String> configuration) {
+        public Builder configuration(@Nonnull Map<String, String> configuration) {
             this.configuration = configuration;
             return this;
         }
@@ -198,7 +209,7 @@ public final class Metadata implements Action {
             return this;
         }
 
-        public Builder schema(StructType schema) {
+        public Builder schema(@Nullable StructType schema) {
             this.schema = schema;
             return this;
         }

--- a/standalone/src/main/java/io/delta/standalone/actions/Protocol.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Protocol.java
@@ -23,7 +23,7 @@ import java.util.Objects;
  * incompatible changes are made to the protocol. Readers and writers are
  * responsible for checking that they meet the minimum versions before performing
  * any other operations.
- *
+ * <p>
  * Since this action allows us to explicitly block older clients in the case of a
  * breaking change to the protocol, clients should be tolerant of messages and
  * fields that they do not understand.

--- a/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
@@ -26,11 +26,14 @@ import javax.annotation.Nullable;
 /**
  * Logical removal of a given file from the reservoir. Acts as a tombstone before a file is
  * deleted permanently.
- *
- * Note that for protocol compatibility reasons, the fields {@code partitionValues}, {@code size},
- * and {@code tags} are only present when the extendedFileMetadata flag is true. New writers should
- * generally be setting this flag, but old writers (and FSCK) won't, so readers must check this flag
- * before attempting to consume those values.
+ * <p>
+ * Note that users should onlu instantiate {@link RemoveFile} instances using one of the various
+ * {@link AddFile#remove()} methods.
+ * <p>
+ * As well, note that for protocol compatibility reasons, the fields {@code partitionValues},
+ * {@code size}, and {@code tags} are only present when the extendedFileMetadata flag is true. New
+ * writers should generally be setting this flag, but old writers (and FSCK) won't, so readers must
+ * check this flag before attempting to consume those values.
  */
 public class RemoveFile implements FileAction {
     @Nonnull
@@ -51,10 +54,19 @@ public class RemoveFile implements FileAction {
     @Nullable
     private final Map<String, String> tags;
 
-    public RemoveFile(@Nonnull String path, @Nonnull Optional<Long> deletionTimestamp,
-                      boolean dataChange, boolean extendedFileMetadata,
-                      @Nullable Map<String, String> partitionValues, long size,
-                      @Nullable Map<String, String> tags) {
+    /**
+     * Users should <b>not</b> construct {@link RemoveFile}s themselves, and should instead use one
+     * of the various {@link AddFile#remove()} methods to instantiate the correct {@link RemoveFile}
+     * for a given {@link AddFile} instance.
+     */
+    public RemoveFile(
+            @Nonnull String path,
+            @Nonnull Optional<Long> deletionTimestamp,
+            boolean dataChange,
+            boolean extendedFileMetadata,
+            @Nullable Map<String, String> partitionValues,
+            long size,
+            @Nullable Map<String, String> tags) {
         this.path = path;
         this.deletionTimestamp = deletionTimestamp;
         this.dataChange = dataChange;
@@ -143,76 +155,5 @@ public class RemoveFile implements FileAction {
     public int hashCode() {
         return Objects.hash(path, deletionTimestamp, dataChange, extendedFileMetadata,
                 partitionValues, size, tags);
-    }
-
-    /**
-     * @return a new {@code RemoveFile.Builder}
-     */
-    public static Builder builder(String path) {
-        return new Builder(path);
-    }
-
-    /**
-     * Builder class for RemoveFile. Enables construction of RemoveFile object with default values.
-     */
-    public static class Builder {
-        // required RemoveFile fields
-        private final String path;
-        // optional RemoveFile fields
-        private Optional<Long> deletionTimestamp = Optional.empty();
-        private boolean dataChange = true;
-        private boolean extendedFileMetadata = false;
-        private Map<String, String> partitionValues;
-        private long size = 0;
-        private Map<String, String> tags;
-
-        public Builder(String path) {
-            this.path = path;
-        }
-
-        public Builder deletionTimestamp(Long deletionTimestamp) {
-            this.deletionTimestamp = Optional.of(deletionTimestamp);
-            return this;
-        }
-
-        public Builder dataChange(boolean dataChange) {
-            this.dataChange = dataChange;
-            return this;
-        }
-
-        public Builder extendedFileMetadata(boolean extendedFileMetadata) {
-            this.extendedFileMetadata = extendedFileMetadata;
-            return this;
-        }
-
-        public Builder partitionValues(Map<String, String> partitionValues) {
-            this.partitionValues = partitionValues;
-            return this;
-        }
-
-        public Builder size(long size) {
-            this.size = size;
-            return this;
-        }
-
-        public Builder tags(Map<String, String> tags) {
-            this.tags = tags;
-            return this;
-        }
-
-        /**
-         * @return a new {@code RemoveFile} with the same properties as {@code this}
-         */
-        public RemoveFile build() {
-            RemoveFile removeFile = new RemoveFile(
-                    this.path,
-                    this.deletionTimestamp,
-                    this.dataChange,
-                    this.extendedFileMetadata,
-                    this.partitionValues,
-                    this.size,
-                    this.tags);
-            return removeFile;
-        }
     }
 }

--- a/standalone/src/main/java/io/delta/standalone/actions/SetTransaction.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/SetTransaction.java
@@ -32,8 +32,10 @@ public final class SetTransaction implements Action {
     @Nonnull
     private final Optional<Long> lastUpdated;
 
-    public SetTransaction(@Nonnull String appId, long version,
-                          @Nonnull Optional<Long> lastUpdated) {
+    public SetTransaction(
+            @Nonnull String appId,
+            long version,
+            @Nonnull Optional<Long> lastUpdated) {
         this.appId = appId;
         this.version = version;
         this.lastUpdated = lastUpdated;

--- a/standalone/src/test/scala/io/delta/standalone/internal/ActionBuildersSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ActionBuildersSuite.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters._
 
 import org.scalatest.FunSuite
 
-import io.delta.standalone.actions.{AddFile => AddFileJ, CommitInfo => CommitInfoJ, Format => FormatJ, JobInfo => JobInfoJ, Metadata => MetadataJ, NotebookInfo => NotebookInfoJ, RemoveFile => RemoveFileJ}
+import io.delta.standalone.actions.{AddFile => AddFileJ, CommitInfo => CommitInfoJ, Format => FormatJ, JobInfo => JobInfoJ, Metadata => MetadataJ, NotebookInfo => NotebookInfoJ}
 import io.delta.standalone.types.{IntegerType, StructField => StructFieldJ, StructType => StructTypeJ}
 
 class ActionBuildersSuite extends FunSuite {
@@ -122,37 +122,6 @@ class ActionBuildersSuite extends FunSuite {
       "test_job_id",
       "test_trigger_type")
     assert(jobInfoFromBuilder == jobInfoFromConstructor)
-  }
-
-  test("builder action class constructor for RemoveFile") {
-    val removeFileJFromBuilderDefaults = RemoveFileJ.builder("/test").build()
-    val removeFileJFromConstructorDefaults = new RemoveFileJ(
-      "/test",
-      Optional.empty(),
-      true,
-      false,
-      null,
-      0L,
-      null)
-    assert(removeFileJFromBuilderDefaults == removeFileJFromConstructorDefaults)
-
-    val removeFileJFromBuilder = RemoveFileJ.builder("/test")
-      .deletionTimestamp(0L)
-      .dataChange(false)
-      .extendedFileMetadata(true)
-      .partitionValues(Map("test"->"foo").asJava)
-      .size(1L)
-      .tags(Map("tag"->"foo").asJava)
-      .build()
-    val removeFileJFromConstructor = new RemoveFileJ(
-      "/test",
-      Optional.of(0L),
-      false,
-      true,
-      Map("test"->"foo").asJava,
-      1L,
-      Map("tag"->"foo").asJava)
-    assert(removeFileJFromBuilder == removeFileJFromConstructor)
   }
 
   test("builder action class constructor for CommitInfo") {

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -255,11 +255,16 @@ abstract class DeltaLogSuiteBase extends FunSuite {
       assert(new File(log.logPath.toUri).mkdirs())
       val path = new File(dir, "a/b/c").getCanonicalPath
 
-      val removeFile = RemoveFileJ
-        .builder(path)
-        .deletionTimestamp(System.currentTimeMillis())
-        .dataChange(true)
-        .build()
+      val removeFile = new RemoveFileJ(
+        path,
+        java.util.Optional.of(System.currentTimeMillis()),
+        true, // dataChange
+        false, // extendedFileMetadata
+        null, // partitionValues
+        0L, // size
+        null // null
+      )
+
       val metadata = MetadataJ.builder().build()
       val actions = java.util.Arrays.asList(removeFile, metadata)
 

--- a/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionSuiteTestVals.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionSuiteTestVals.scala
@@ -20,7 +20,7 @@ import java.util.Collections
 
 import scala.collection.JavaConverters._
 
-import io.delta.standalone.actions.{AddFile => AddFileJ, Metadata => MetadataJ, RemoveFile => RemoveFileJ}
+import io.delta.standalone.actions.{AddFile => AddFileJ, Metadata => MetadataJ}
 import io.delta.standalone.expressions.{EqualTo, Literal}
 import io.delta.standalone.types.{IntegerType, StructField, StructType}
 
@@ -33,8 +33,8 @@ trait OptimisticTransactionSuiteTestVals {
   val addA = new AddFileJ("a", Collections.emptyMap(), 1, 1, true, null, null)
   val addB = new AddFileJ("b", Collections.emptyMap(), 1, 1, true, null, null)
 
-  val removeA = RemoveFileJ.builder("a").deletionTimestamp(4L).build()
-  val removeA_time5 = RemoveFileJ.builder("a").deletionTimestamp(5L).build()
+  val removeA = addA.remove(4L)
+  val removeA_time5 = addA.remove(5L)
 
   val addA_partX1 = new AddFileJ("a", Map("x" -> "1").asJava, 1, 1, true, null, null)
   val addA_partX2 = new AddFileJ("a", Map("x" -> "2").asJava, 1, 1, true, null, null)


### PR DESCRIPTION
- add various `AddFile::remove` APIs and use those instead of `RemoveFile` constructor calls in tests
- we cannot make the `RemoveFile` constructor private or package-private, so I document that users should use of one the `AddFile::remove` APIs
- added missing @Nullable and @Nonnull annotations to classes along the way