### PR TITLE
Fix Github actions to fail when an sbt test fails

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,11 +24,21 @@ jobs:
           key: delta-sbt-cache-hive23-scala${{ matrix.scala }}
       - name: Run sqlDeltaImport tests
         shell: bash
-        run: build/sbt "++ ${{ matrix.scala }}" sqlDeltaImport/test compatibility/test
+        run: build/sbt "++ ${{ matrix.scala }}" sqlDeltaImport/test
         if: matrix.scala != '2.11.12'
-      - name: Run SBT tests
+      - name: Run testScalastyle
         shell: bash
-        run: >
-          build/sbt "++ ${{ matrix.scala }}" testScalastyle standalone/test
-          testStandaloneCosmetic/test hiveMR/test hiveTez/test hive2MR/test
-          hive2Tez/test flinkConnector/test
+        run: build/sbt "++ ${{ matrix.scala }}" testScalaStyle
+      - name: Run standalone and testStandaloneCosmetic tests
+        shell: bash
+        run: build/sbt "++ ${{ matrix.scala }}" standalone/test testStandaloneCosmetic/test
+      - name: Run compatibility tests
+        shell: bash
+        run: build/sbt "++ ${{ matrix.scala }}" compatibility/test
+        if: matrix.scala != '2.11.12'
+      - name: Run hive tests
+        shell: bash
+        run: build/sbt "++ ${{ matrix.scala }}" hiveMR/test hiveTez/test hive2MR/test hive2Tez/test
+      - name: Run flink tests
+        shell: bash
+        run: build/sbt "++ ${{ matrix.scala }}" flinkConnector/test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: "Run tests "
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         scala: [2.12.8, 2.11.12]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,13 +24,5 @@ jobs:
       - name: Run compatibility tests
         run: build/sbt "++ ${{ matrix.scala }}" compatibility/test
         if: matrix.scala != '2.11.12'
-      - name: Run hive 3 mr tests
-        run: build/sbt "++ ${{ matrix.scala }}" hiveMR/test
-      - name: Run hive 3 tez tests
-        run: build/sbt "++ ${{ matrix.scala }}" hiveTez/test
-      - name: Run hive 2 mr tests
-        run: build/sbt "++ ${{ matrix.scala }}" hive2MR/test
-      - name: Run hive 2 tez tests
-        run: build/sbt "++ ${{ matrix.scala }}" hive2Tez/test
       - name: Run flink tests
         run: build/sbt "++ ${{ matrix.scala }}" flinkConnector/test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
         if: matrix.scala != '2.11.12'
       - name: Run testScalastyle
         shell: bash
-        run: build/sbt "++ ${{ matrix.scala }}" testScalaStyle
+        run: build/sbt "++ ${{ matrix.scala }}" testScalastyle
       - name: Run standalone and testStandaloneCosmetic tests
         shell: bash
         run: build/sbt "++ ${{ matrix.scala }}" standalone/test testStandaloneCosmetic/test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,14 +14,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-      - name: Cache Scala, SBT
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2
-            ~/.cache/coursier
-          key: delta-sbt-cache-hive23-scala${{ matrix.scala }}
       - name: Run sqlDeltaImport tests
         run: build/sbt "++ ${{ matrix.scala }}" sqlDeltaImport/test
         if: matrix.scala != '2.11.12'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,11 +23,11 @@ jobs:
             ~/.cache/coursier
           key: delta-sbt-cache-hive23-scala${{ matrix.scala }}
       - name: Run sqlDeltaImport tests
-        shell: bash -l {0}
+        shell: bash
         run: build/sbt "++ ${{ matrix.scala }}" sqlDeltaImport/test compatibility/test
         if: matrix.scala != '2.11.12'
       - name: Run SBT tests
-        shell: bash -l {0}
+        shell: bash
         run: >
           build/sbt "++ ${{ matrix.scala }}" testScalastyle standalone/test
           testStandaloneCosmetic/test hiveMR/test hiveTez/test hive2MR/test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,10 @@ jobs:
         run: build/sbt "++ ${{ matrix.scala }}" compatibility/test
         if: matrix.scala != '2.11.12'
       - name: Run hive tests
-        run: build/sbt "++ ${{ matrix.scala }}" hiveMR/test hiveTez/test hive2MR/test hive2Tez/test
+        run: |
+          build/sbt "++ ${{ matrix.scala }}" hiveMR/test
+          build/sbt "++ ${{ matrix.scala }}" hiveTez/test
+          build/sbt "++ ${{ matrix.scala }}" hive2MR/test
+          build/sbt "++ ${{ matrix.scala }}" hive2Tez/test
       - name: Run flink tests
         run: build/sbt "++ ${{ matrix.scala }}" flinkConnector/test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,13 +28,7 @@ jobs:
         if: matrix.scala != '2.11.12'
       - name: Run SBT tests
         shell: bash -l {0}
-        run: |
-          build/sbt "++ ${{ matrix.scala }} testScalastyle"
-          build/sbt "++ ${{ matrix.scala }} standalone/test"
-          build/sbt "++ ${{ matrix.scala }} testStandaloneCosmetic/test"
-          build/sbt "++ ${{ matrix.scala }} compatibility/test"
-          build/sbt "++ ${{ matrix.scala }} hiveMR/test"
-          build/sbt "++ ${{ matrix.scala }} hiveTez/test"
-          build/sbt "++ ${{ matrix.scala }} hive2MR/test"
-          build/sbt "++ ${{ matrix.scala }} hive2Tez/test"
-          build/sbt "++ ${{ matrix.scala }} flinkConnector/test"
+        run: >
+          build/sbt "++ ${{ matrix.scala }}" testScalastyle standalone/test
+          testStandaloneCosmetic/test compatibility/test hiveMR/test hiveTez/test hive2MR/test
+          hive2Tez/test flinkConnector/test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,22 +23,16 @@ jobs:
             ~/.cache/coursier
           key: delta-sbt-cache-hive23-scala${{ matrix.scala }}
       - name: Run sqlDeltaImport tests
-        shell: bash
         run: build/sbt "++ ${{ matrix.scala }}" sqlDeltaImport/test
         if: matrix.scala != '2.11.12'
       - name: Run testScalastyle
-        shell: bash
         run: build/sbt "++ ${{ matrix.scala }}" testScalastyle
       - name: Run standalone and testStandaloneCosmetic tests
-        shell: bash
         run: build/sbt "++ ${{ matrix.scala }}" standalone/test testStandaloneCosmetic/test
       - name: Run compatibility tests
-        shell: bash
         run: build/sbt "++ ${{ matrix.scala }}" compatibility/test
         if: matrix.scala != '2.11.12'
       - name: Run hive tests
-        shell: bash
         run: build/sbt "++ ${{ matrix.scala }}" hiveMR/test hiveTez/test hive2MR/test hive2Tez/test
       - name: Run flink tests
-        shell: bash
         run: build/sbt "++ ${{ matrix.scala }}" flinkConnector/test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,11 +32,13 @@ jobs:
       - name: Run compatibility tests
         run: build/sbt "++ ${{ matrix.scala }}" compatibility/test
         if: matrix.scala != '2.11.12'
-      - name: Run hive tests
-        run: |
-          build/sbt "++ ${{ matrix.scala }}" hiveMR/test
-          build/sbt "++ ${{ matrix.scala }}" hiveTez/test
-          build/sbt "++ ${{ matrix.scala }}" hive2MR/test
-          build/sbt "++ ${{ matrix.scala }}" hive2Tez/test
+      - name: Run hive 3 mr tests
+        run: build/sbt "++ ${{ matrix.scala }}" hiveMR/test
+      - name: Run hive 3 tez tests
+        run: build/sbt "++ ${{ matrix.scala }}" hiveTez/test
+      - name: Run hive 2 mr tests
+        run: build/sbt "++ ${{ matrix.scala }}" hive2MR/test
+      - name: Run hive 2 tez tests
+        run: build/sbt "++ ${{ matrix.scala }}" hive2Tez/test
       - name: Run flink tests
         run: build/sbt "++ ${{ matrix.scala }}" flinkConnector/test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,11 +24,11 @@ jobs:
           key: delta-sbt-cache-hive23-scala${{ matrix.scala }}
       - name: Run sqlDeltaImport tests
         shell: bash -l {0}
-        run: build/sbt "++ ${{ matrix.scala }} sqlDeltaImport/test"
+        run: build/sbt "++ ${{ matrix.scala }}" sqlDeltaImport/test compatibility/test
         if: matrix.scala != '2.11.12'
       - name: Run SBT tests
         shell: bash -l {0}
         run: >
           build/sbt "++ ${{ matrix.scala }}" testScalastyle standalone/test
-          testStandaloneCosmetic/test compatibility/test hiveMR/test hiveTez/test hive2MR/test
+          testStandaloneCosmetic/test hiveMR/test hiveTez/test hive2MR/test
           hive2Tez/test flinkConnector/test

--- a/build.sbt
+++ b/build.sbt
@@ -225,7 +225,7 @@ lazy val hiveMR = (project in file("hive-mr")) dependsOn(hiveTest % "test->test"
   )
 )
 
-lazy val hiveTez = (project in file("hive-tez")) dependsOn(hive % "test->test") settings (
+lazy val hiveTez = (project in file("hive-tez")) dependsOn(hiveTest % "test->test") settings (
   name := "hive-tez",
   commonSettings,
   skipReleaseSettings,

--- a/build.sbt
+++ b/build.sbt
@@ -500,6 +500,7 @@ lazy val standalone = (project in file("standalone"))
       "-windowtitle", "Delta Standalone Reader " + version.value.replaceAll("-SNAPSHOT", "") + " JavaDoc",
       "-noqualifier", "java.lang",
       // `doclint` is disabled on Circle CI. Need to enable it manually to test our javadoc.
+      "-tag", "implNote:a:Implementation Note:",
       "-Xdoclint:all"
     ),
     unidocAllSources in(JavaUnidoc, unidoc) := {

--- a/build.sbt
+++ b/build.sbt
@@ -499,7 +499,6 @@ lazy val standalone = (project in file("standalone"))
       "-public",
       "-windowtitle", "Delta Standalone Reader " + version.value.replaceAll("-SNAPSHOT", "") + " JavaDoc",
       "-noqualifier", "java.lang",
-      // `doclint` is disabled on Circle CI. Need to enable it manually to test our javadoc.
       "-tag", "implNote:a:Implementation Note:",
       "-Xdoclint:all"
     ),

--- a/flink-connector/src/main/java/org/apache/flink/connector/delta/sink/committer/DeltaCommitter.java
+++ b/flink-connector/src/main/java/org/apache/flink/connector/delta/sink/committer/DeltaCommitter.java
@@ -50,7 +50,6 @@ import org.apache.flink.connector.file.sink.FileSink;
  *       Valid note here is that's also the default {@link FileSink}'s behaviour for all of the
  *       bulk formats (Parquet included).
  * </ol>
- * </p>
  */
 public class DeltaCommitter implements Committer<DeltaCommittable> {
 

--- a/hive2-mr/src/test/scala/io/delta/hive/HiveMRSuite.scala
+++ b/hive2-mr/src/test/scala/io/delta/hive/HiveMRSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (2020) The Delta Lake Project Authors.
+ * Copyright (2020-present) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/oss-compatibility-tests/src/test/scala/io/delta/standalone/internal/util/StandaloneUtil.scala
+++ b/oss-compatibility-tests/src/test/scala/io/delta/standalone/internal/util/StandaloneUtil.scala
@@ -69,16 +69,7 @@ class StandaloneUtil(now: Long) {
     )
   }
 
-  val removeFiles: Seq[RemoveFile] = addFiles.map { a =>
-    RemoveFile.builder(a.getPath)
-      .deletionTimestamp(now + 100)
-      .dataChange(true)
-      .extendedFileMetadata(true)
-      .partitionValues(a.getPartitionValues)
-      .size(a.getSize)
-      .tags(a.getTags)
-      .build()
-  }
+  val removeFiles: Seq[RemoveFile] = addFiles.map(_.remove(now + 100, true))
 
   val setTransaction: SetTransaction =
     new SetTransaction("appId", 123, java.util.Optional.of(now + 200))


### PR DESCRIPTION
A few issues fixed:
- Github actions wasn't reporting any failed tests unless the last test on the list failed, since it restarted `build/sbt` each time, and Github actions only considers the final exit code.
- Moved `compatibility/test` to only run on Scala 2.12 since it uses Delta 1.0.0
-  Fixed a few JavaDoc compilation errors that were merged in #196.
   - [QUESTION] Documentation in #196 uses `@implNote` Javadoc tag. I added it to the Javadoc compilation, but should we just change that doc instead?
   - [NOTE] Seems related to https://github.com/sbt/sbt/issues/875, but when there is a compilation error, all the other warnings are reported as errors. For example in the previous commit, it showed 18 `[error]` messages but also: 
```
[info] 2 errors
[info] 18 warnings
[error] (standalone/javaunidoc:doc) javadoc returned nonzero exit code
```
- Fixed the other tests that were failing