### PR TITLE
DeltaLog.tableExists API

### DIFF
--- a/project/StandaloneMimaExcludes.scala
+++ b/project/StandaloneMimaExcludes.scala
@@ -30,7 +30,8 @@ object StandaloneMimaExcludes {
     // Public API changes in 0.2.0 -> 0.3.0
     ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.DeltaLog.getChanges"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.DeltaLog.startTransaction"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.Snapshot.scan")
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.Snapshot.scan"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.DeltaLog.tableExists")
 
     // scalastyle:on line.size.limit
   )

--- a/standalone/src/main/java/io/delta/standalone/DeltaLog.java
+++ b/standalone/src/main/java/io/delta/standalone/DeltaLog.java
@@ -128,4 +128,22 @@ public interface DeltaLog {
     static DeltaLog forTable(Configuration hadoopConf, Path path) {
         return DeltaLogImpl.forTable(hadoopConf, path);
     }
+
+    /**
+     * @param hadoopConf  Hadoop {@code Configuration} to use when accessing the Delta table
+     * @param path  the path to the Delta table
+     * @return whether a Delta table exists at the given path
+     */
+    static boolean tableExists(Configuration hadoopConf, String path) {
+        return DeltaLogImpl.tableExists(hadoopConf, path);
+    }
+
+    /**
+     * @param hadoopConf  Hadoop {@code Configuration} to use when accessing the Delta table
+     * @param path  the path to the Delta table
+     * @return whether a Delta table exists at the given path
+     */
+    static boolean tableExists(Configuration hadoopConf, Path path) {
+        return DeltaLogImpl.tableExists(hadoopConf, path);
+    }
 }

--- a/standalone/src/main/java/io/delta/standalone/DeltaLog.java
+++ b/standalone/src/main/java/io/delta/standalone/DeltaLog.java
@@ -106,6 +106,11 @@ public interface DeltaLog {
     Iterator<VersionLog> getChanges(long startVersion, boolean failOnDataLoss);
 
     /**
+     * @return Whether a Delta table exists at this directory.
+     */
+    boolean tableExists();
+
+    /**
      * Create a {@link DeltaLog} instance representing the table located at the provided
      * {@code path}.
      *
@@ -127,23 +132,5 @@ public interface DeltaLog {
      */
     static DeltaLog forTable(Configuration hadoopConf, Path path) {
         return DeltaLogImpl.forTable(hadoopConf, path);
-    }
-
-    /**
-     * @param hadoopConf  Hadoop {@code Configuration} to use when accessing the Delta table
-     * @param path  the path to the Delta table
-     * @return whether a Delta table exists at the given path
-     */
-    static boolean tableExists(Configuration hadoopConf, String path) {
-        return DeltaLogImpl.tableExists(hadoopConf, path);
-    }
-
-    /**
-     * @param hadoopConf  Hadoop {@code Configuration} to use when accessing the Delta table
-     * @param path  the path to the Delta table
-     * @return whether a Delta table exists at the given path
-     */
-    static boolean tableExists(Configuration hadoopConf, Path path) {
-        return DeltaLogImpl.tableExists(hadoopConf, path);
     }
 }

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -139,7 +139,7 @@ private[internal] class DeltaLogImpl private(
   }
 
   /** Whether a Delta table exists at this directory. */
-  def tableExists: Boolean = snapshot.version >= 0
+  override def tableExists: Boolean = snapshot.version >= 0
 
   ///////////////////////////////////////////////////////////////////////////
   // Internal Methods

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -138,6 +138,9 @@ private[internal] class DeltaLogImpl private(
     new OptimisticTransactionImpl(this, snapshot)
   }
 
+  /** Whether a Delta table exists at this directory. */
+  def tableExists: Boolean = snapshot.version >= 0
+
   ///////////////////////////////////////////////////////////////////////////
   // Internal Methods
   ///////////////////////////////////////////////////////////////////////////
@@ -210,14 +213,6 @@ private[standalone] object DeltaLogImpl {
 
   def forTable(hadoopConf: Configuration, dataPath: Path, clock: Clock): DeltaLogImpl = {
     apply(hadoopConf, new Path(dataPath, "_delta_log"), clock)
-  }
-
-  def tableExists(hadoopConf: Configuration, dataPath: String): Boolean = {
-    DeltaLogImpl.forTable(hadoopConf, dataPath).snapshot.version >= 0
-  }
-
-  def tableExists(hadoopConf: Configuration, dataPath: Path): Boolean = {
-    DeltaLogImpl.forTable(hadoopConf, dataPath).snapshot.version >= 0
   }
 
   private def apply(

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -212,6 +212,17 @@ private[standalone] object DeltaLogImpl {
     apply(hadoopConf, new Path(dataPath, "_delta_log"), clock)
   }
 
+  def tableExists(hadoopConf: Configuration, dataPath: String): Boolean = {
+    tableExists(hadoopConf, new Path(dataPath))
+  }
+
+  def tableExists(hadoopConf: Configuration, dataPath: Path): Boolean = {
+    val fs = dataPath.getFileSystem(hadoopConf)
+    val path = fs.makeQualified(dataPath)
+    val deltaLogPath = new Path(path, "_delta_log")
+    fs.exists(deltaLogPath)
+  }
+
   private def apply(
       hadoopConf: Configuration,
       rawPath: Path,

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -213,14 +213,11 @@ private[standalone] object DeltaLogImpl {
   }
 
   def tableExists(hadoopConf: Configuration, dataPath: String): Boolean = {
-    tableExists(hadoopConf, new Path(dataPath))
+    DeltaLogImpl.forTable(hadoopConf, dataPath).snapshot.version >= 0
   }
 
   def tableExists(hadoopConf: Configuration, dataPath: Path): Boolean = {
-    val fs = dataPath.getFileSystem(hadoopConf)
-    val path = fs.makeQualified(dataPath)
-    val deltaLogPath = new Path(path, "_delta_log")
-    fs.exists(deltaLogPath)
+    DeltaLogImpl.forTable(hadoopConf, dataPath).snapshot.version >= 0
   }
 
   private def apply(

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -437,13 +437,19 @@ abstract class DeltaLogSuiteBase extends FunSuite {
 
   test("DeltaLog.tableExists") {
     withTempDir { dir =>
+
       val conf = new Configuration()
       assert(!DeltaLog.tableExists(conf, dir.getCanonicalPath))
 
-      // let's check we didn't accidentally create a _delta_log during the above call
+      val log = DeltaLog.forTable(conf, dir.getCanonicalPath)
+      // check that we didn't create a table by instantiating a DeltaLog instance
       assert(!DeltaLog.tableExists(conf, dir.getCanonicalPath))
 
-      val log = DeltaLog.forTable(conf, dir.getCanonicalPath)
+      log.startTransaction().commit(
+        Seq(MetadataJ.builder().build()).asJava,
+        new Operation(Operation.Name.CREATE_TABLE),
+        "test"
+      )
       assert(DeltaLog.tableExists(conf, dir.getCanonicalPath))
     }
   }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -439,18 +439,16 @@ abstract class DeltaLogSuiteBase extends FunSuite {
     withTempDir { dir =>
 
       val conf = new Configuration()
-      assert(!DeltaLog.tableExists(conf, dir.getCanonicalPath))
-
       val log = DeltaLog.forTable(conf, dir.getCanonicalPath)
-      // check that we didn't create a table by instantiating a DeltaLog instance
-      assert(!DeltaLog.tableExists(conf, dir.getCanonicalPath))
+
+      assert(!log.tableExists())
 
       log.startTransaction().commit(
         Seq(MetadataJ.builder().build()).asJava,
         new Operation(Operation.Name.CREATE_TABLE),
         "test"
       )
-      assert(DeltaLog.tableExists(conf, dir.getCanonicalPath))
+      assert(log.tableExists())
     }
   }
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -434,6 +434,19 @@ abstract class DeltaLogSuiteBase extends FunSuite {
       }
     }
   }
+
+  test("DeltaLog.tableExists") {
+    withTempDir { dir =>
+      val conf = new Configuration()
+      assert(!DeltaLog.tableExists(conf, dir.getCanonicalPath))
+
+      // let's check we didn't accidentally create a _delta_log during the above call
+      assert(!DeltaLog.tableExists(conf, dir.getCanonicalPath))
+
+      val log = DeltaLog.forTable(conf, dir.getCanonicalPath)
+      assert(DeltaLog.tableExists(conf, dir.getCanonicalPath))
+    }
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
@scottsand-db Changed implementation to match Delta and check for snapshot version. If we just checked for `_delta_log` existence, (I assume) we would encounter the same error later on for an empty directory.

[Question] Are these tests sufficient or should it be tested for `/dir_a/` or `/dir_a/dir_b/_delta_log/dir_c` or `/dir_a/dir_b/_delta_log/` or something along those lines.
```
├── dir_a
│   └── dir_b
│         └── _delta_log
│                 └── dir_c
```