### PR TITLE
Fix flaky build and add Hive tests back

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
             ~/.cache/coursier
             ~/.m2
           key: build-cache-with-scala_${{ matrix.scala }}
-      - name: Run Scala Style tests
+      - name: Run Scala Style tests on test sources
         run: build/sbt "++ ${{ matrix.scala }}" testScalastyle
       - name: Run sqlDeltaImport tests (Scala 2.12 only)
         run: build/sbt "++ ${{ matrix.scala }}" sqlDeltaImport/test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: "Run tests "
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         scala: [2.12.8, 2.11.12]
@@ -21,24 +21,23 @@ jobs:
             ~/.sbt
             ~/.ivy2
             ~/.cache/coursier
-          key: build-cache-scala${{ matrix.scala }}
-      - name: Run sqlDeltaImport tests
-        run: build/sbt "++ ${{ matrix.scala }}" sqlDeltaImport/test
-        if: matrix.scala != '2.11.12'
-      - name: Run testScalastyle
-        run: build/sbt "++ ${{ matrix.scala }}" testScalastyle
-      - name: Run standalone and testStandaloneCosmetic tests
-        run: build/sbt "++ ${{ matrix.scala }}" standalone/test testStandaloneCosmetic/test
-      - name: Run compatibility tests
-        run: build/sbt "++ ${{ matrix.scala }}" compatibility/test
-        if: matrix.scala != '2.11.12'
-      - name: Run flink tests
-        run: build/sbt "++ ${{ matrix.scala }}" flinkConnector/test
-      - name: Run hive 3 mr tests
-        run: build/sbt "++ ${{ matrix.scala }}" hiveMR/test
-      - name: Run hive 3 tez tests
-        run: build/sbt "++ ${{ matrix.scala }}" hiveTez/test
-      - name: Run hive 2 mr tests
-        run: build/sbt "++ ${{ matrix.scala }}" hive2MR/test
-      - name: Run hive 2 tez tests
-        run: build/sbt "++ ${{ matrix.scala }}" hive2Tez/test
+          key: build-cache
+      - name: Run tests
+        run: |
+          build/sbt "++ 2.12.8 testScalastyle"
+          build/sbt "++ 2.12.8 standalone/test"
+          build/sbt "++ 2.12.8 testStandaloneCosmetic/test"
+          build/sbt "++ 2.12.8 compatibility/test"
+          build/sbt "++ 2.12.8 sqlDeltaImport/test"
+          build/sbt "++ 2.12.8 hiveMR/test"
+          build/sbt "++ 2.12.8 hiveTez/test"
+          build/sbt "++ 2.12.8 hive2MR/test"
+          build/sbt "++ 2.12.8 hive2Tez/test"
+          build/sbt "++ 2.12.8 flinkConnector/test"
+          build/sbt "++ 2.11.12 standalone/test"
+          build/sbt "++ 2.11.12 testStandaloneCosmetic/test"
+          build/sbt "++ 2.11.12 hiveMR/test"
+          build/sbt "++ 2.11.12 hiveTez/test"
+          build/sbt "++ 2.11.12 hive2MR/test"
+          build/sbt "++ 2.11.12 hive2Tez/test"
+          build/sbt "++ 2.11.12 flinkConnector/test"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: "Delta Lake Connectors Tests"
 on: [push, pull_request]
 jobs:
   build:
-    name: "Run tests "
+    name: "Run tests"
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -22,19 +22,19 @@ jobs:
             ~/.ivy2
             ~/.cache/coursier
           key: build-cache-scala${{ matrix.scala }}
-      - name: Run sqlDeltaImport tests
-        run: build/sbt "++ ${{ matrix.scala }} sqlDeltaImport/test"
+      - name: Run Scala Style tests
+      - run: build/sbt "++ ${{ matrix.scala }}" testScalastyle
+      - name: Run sqlDeltaImport tests (Scala 2.12 only)
+        run: build/sbt "++ ${{ matrix.scala }}" sqlDeltaImport/test
         if: matrix.scala != '2.11.12'
-      - name: Run compatibility tests
+      - name: Run Delta Standalone Compatibility tests (Scala 2.12 only)
       - run: build/sbt "++ ${{ matrix.scala }}" compatibility/test
         if: matrix.scala != '2.11.12'
-      - name: Run SBT tests
-        run: |
-          build/sbt "++ ${{ matrix.scala }} testScalastyle"
-          build/sbt "++ ${{ matrix.scala }} standalone/test"
-          build/sbt "++ ${{ matrix.scala }} testStandaloneCosmetic/test"
-          build/sbt "++ ${{ matrix.scala }} hiveMR/test"
-          build/sbt "++ ${{ matrix.scala }} hiveTez/test"
-          build/sbt "++ ${{ matrix.scala }} hive2MR/test"
-          build/sbt "++ ${{ matrix.scala }} hive2Tez/test"
-          build/sbt "++ ${{ matrix.scala }} flinkConnector/test"
+      - name: Run Delta Standalone tests
+      - run: build/sbt "++ ${{ matrix.scala }}" standalone/test testStandaloneCosmetic/test
+      - name: Run Hive 3 tests
+      - run: build/sbt "++ ${{ matrix.scala }}" hiveMR/test hiveTez/test
+      - name: Run Hive 2 tests
+      - run: build/sbt "++ ${{ matrix.scala }}" hive2MR/test hive2Tez/test
+      - name: Run Fink tests
+      - run: build/sbt "++ ${{ matrix.scala }}" flinkConnector/test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: "Run tests "
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         scala: [2.12.8, 2.11.12]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,18 +23,18 @@ jobs:
             ~/.cache/coursier
           key: build-cache-scala${{ matrix.scala }}
       - name: Run Scala Style tests
-      - run: build/sbt "++ ${{ matrix.scala }}" testScalastyle
+        run: build/sbt "++ ${{ matrix.scala }}" testScalastyle
       - name: Run sqlDeltaImport tests (Scala 2.12 only)
         run: build/sbt "++ ${{ matrix.scala }}" sqlDeltaImport/test
         if: matrix.scala != '2.11.12'
       - name: Run Delta Standalone Compatibility tests (Scala 2.12 only)
-      - run: build/sbt "++ ${{ matrix.scala }}" compatibility/test
+        run: build/sbt "++ ${{ matrix.scala }}" compatibility/test
         if: matrix.scala != '2.11.12'
       - name: Run Delta Standalone tests
-      - run: build/sbt "++ ${{ matrix.scala }}" standalone/test testStandaloneCosmetic/test
+        run: build/sbt "++ ${{ matrix.scala }}" standalone/test testStandaloneCosmetic/test
       - name: Run Hive 3 tests
-      - run: build/sbt "++ ${{ matrix.scala }}" hiveMR/test hiveTez/test
+        run: build/sbt "++ ${{ matrix.scala }}" hiveMR/test hiveTez/test
       - name: Run Hive 2 tests
-      - run: build/sbt "++ ${{ matrix.scala }}" hive2MR/test hive2Tez/test
+        run: build/sbt "++ ${{ matrix.scala }}" hive2MR/test hive2Tez/test
       - name: Run Fink tests
-      - run: build/sbt "++ ${{ matrix.scala }}" flinkConnector/test
+        run: build/sbt "++ ${{ matrix.scala }}" flinkConnector/test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,9 @@ jobs:
   build:
     name: "Run tests "
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        scala: [2.12.8, 2.11.12]
     steps:
       - uses: actions/checkout@v2
       - name: install java
@@ -19,22 +22,17 @@ jobs:
             ~/.ivy2
             ~/.cache/coursier
           key: build-cache
-      - name: Run tests
+      - name: Run sqlDeltaImport tests
+        run: build/sbt "++ ${{ matrix.scala }} sqlDeltaImport/test"
+        if: matrix.scala != '2.11.12'
+      - name: Run SBT tests
         run: |
-          build/sbt "++ 2.12.8 testScalastyle"
-          build/sbt "++ 2.12.8 standalone/test"
-          build/sbt "++ 2.12.8 testStandaloneCosmetic/test"
-          build/sbt "++ 2.12.8 compatibility/test"
-          build/sbt "++ 2.12.8 sqlDeltaImport/test"
-          build/sbt "++ 2.12.8 hiveMR/test"
-          build/sbt "++ 2.12.8 hiveTez/test"
-          build/sbt "++ 2.12.8 hive2MR/test"
-          build/sbt "++ 2.12.8 hive2Tez/test"
-          build/sbt "++ 2.12.8 flinkConnector/test"
-          build/sbt "++ 2.11.12 standalone/test"
-          build/sbt "++ 2.11.12 testStandaloneCosmetic/test"
-          build/sbt "++ 2.11.12 hiveMR/test"
-          build/sbt "++ 2.11.12 hiveTez/test"
-          build/sbt "++ 2.11.12 hive2MR/test"
-          build/sbt "++ 2.11.12 hive2Tez/test"
-          build/sbt "++ 2.11.12 flinkConnector/test"
+          build/sbt "++ ${{ matrix.scala }} testScalastyle"
+          build/sbt "++ ${{ matrix.scala }} standalone/test"
+          build/sbt "++ ${{ matrix.scala }} testStandaloneCosmetic/test"
+          build/sbt "++ ${{ matrix.scala }} compatibility/test"
+          build/sbt "++ ${{ matrix.scala }} hiveMR/test"
+          build/sbt "++ ${{ matrix.scala }} hiveTez/test"
+          build/sbt "++ ${{ matrix.scala }} hive2MR/test"
+          build/sbt "++ ${{ matrix.scala }} hive2Tez/test"
+          build/sbt "++ ${{ matrix.scala }} flinkConnector/test"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,8 @@ jobs:
             ~/.sbt
             ~/.ivy2
             ~/.cache/coursier
-          key: build-cache-scala${{ matrix.scala }}
+            ~/.m2
+          key: build-cache-with-scala_${{ matrix.scala }}
       - name: Run Scala Style tests
         run: build/sbt "++ ${{ matrix.scala }}" testScalastyle
       - name: Run sqlDeltaImport tests (Scala 2.12 only)
@@ -36,5 +37,5 @@ jobs:
         run: build/sbt "++ ${{ matrix.scala }}" hiveMR/test hiveTez/test
       - name: Run Hive 2 tests
         run: build/sbt "++ ${{ matrix.scala }}" hive2MR/test hive2Tez/test
-      - name: Run Fink tests
+      - name: Run Flink tests
         run: build/sbt "++ ${{ matrix.scala }}" flinkConnector/test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,9 +4,6 @@ jobs:
   build:
     name: "Run tests "
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        scala: [2.12.8, 2.11.12]
     steps:
       - uses: actions/checkout@v2
       - name: install java

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,16 +21,18 @@ jobs:
             ~/.sbt
             ~/.ivy2
             ~/.cache/coursier
-          key: build-cache
+          key: build-cache-scala${{ matrix.scala }}
       - name: Run sqlDeltaImport tests
         run: build/sbt "++ ${{ matrix.scala }} sqlDeltaImport/test"
+        if: matrix.scala != '2.11.12'
+      - name: Run compatibility tests
+      - run: build/sbt "++ ${{ matrix.scala }}" compatibility/test
         if: matrix.scala != '2.11.12'
       - name: Run SBT tests
         run: |
           build/sbt "++ ${{ matrix.scala }} testScalastyle"
           build/sbt "++ ${{ matrix.scala }} standalone/test"
           build/sbt "++ ${{ matrix.scala }} testStandaloneCosmetic/test"
-          build/sbt "++ ${{ matrix.scala }} compatibility/test"
           build/sbt "++ ${{ matrix.scala }} hiveMR/test"
           build/sbt "++ ${{ matrix.scala }} hiveTez/test"
           build/sbt "++ ${{ matrix.scala }} hive2MR/test"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,3 +26,11 @@ jobs:
         if: matrix.scala != '2.11.12'
       - name: Run flink tests
         run: build/sbt "++ ${{ matrix.scala }}" flinkConnector/test
+      - name: Run hive 3 mr tests
+        run: build/sbt "++ ${{ matrix.scala }}" hiveMR/test
+      - name: Run hive 3 tez tests
+        run: build/sbt "++ ${{ matrix.scala }}" hiveTez/test
+      - name: Run hive 2 mr tests
+        run: build/sbt "++ ${{ matrix.scala }}" hive2MR/test
+      - name: Run hive 2 tez tests
+        run: build/sbt "++ ${{ matrix.scala }}" hive2Tez/test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: "Run tests "
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         scala: [2.12.8, 2.11.12]
@@ -14,6 +14,14 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
+      - name: Cache Scala, SBT
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2
+            ~/.cache/coursier
+          key: build-cache-scala${{ matrix.scala }}
       - name: Run sqlDeltaImport tests
         run: build/sbt "++ ${{ matrix.scala }}" sqlDeltaImport/test
         if: matrix.scala != '2.11.12'

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,11 @@ import ReleaseTransformations._
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
 import scala.xml.transform._
 
+// Disable parallel execution to workaround https://github.com/etsy/sbt-checkstyle-plugin/issues/32
+concurrentRestrictions in Global := {
+  Tags.limitAll(1) :: Nil
+}
+
 parallelExecution in ThisBuild := false
 scalastyleConfig in ThisBuild := baseDirectory.value / "scalastyle-config.xml"
 crossScalaVersions in ThisBuild := Seq("2.12.8", "2.11.12")
@@ -60,15 +65,15 @@ lazy val commonSettings = Seq(
   compileScalastyle := scalastyle.in(Compile).toTask("").value,
   (compile in Compile) := ((compile in Compile) dependsOn compileScalastyle).value,
   testScalastyle := scalastyle.in(Test).toTask("").value,
-  (test in Test) := ((test in Test) dependsOn testScalastyle).value
+  (test in Test) := ((test in Test) dependsOn testScalastyle).value,
 
   // Can be run explicitly via: build/sbt $module/checkstyle
   // Will automatically be run during compilation (e.g. build/sbt compile)
   // and during tests (e.g. build/sbt test)
-//  checkstyleConfigLocation := CheckstyleConfigLocation.File("dev/checkstyle.xml"),
-//  checkstyleSeverityLevel := Some(CheckstyleSeverityLevel.Error),
-//  (checkstyle in Compile) := (checkstyle in Compile).triggeredBy(compile in Compile).value,
-//  (checkstyle in Test) := (checkstyle in Test).triggeredBy(compile in Test).value
+  checkstyleConfigLocation := CheckstyleConfigLocation.File("dev/checkstyle.xml"),
+  checkstyleSeverityLevel := Some(CheckstyleSeverityLevel.Error),
+  (checkstyle in Compile) := (checkstyle in Compile).triggeredBy(compile in Compile).value,
+  (checkstyle in Test) := (checkstyle in Test).triggeredBy(compile in Test).value
 )
 
 lazy val releaseSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -60,15 +60,15 @@ lazy val commonSettings = Seq(
   compileScalastyle := scalastyle.in(Compile).toTask("").value,
   (compile in Compile) := ((compile in Compile) dependsOn compileScalastyle).value,
   testScalastyle := scalastyle.in(Test).toTask("").value,
-  (test in Test) := ((test in Test) dependsOn testScalastyle).value,
+  (test in Test) := ((test in Test) dependsOn testScalastyle).value
 
   // Can be run explicitly via: build/sbt $module/checkstyle
   // Will automatically be run during compilation (e.g. build/sbt compile)
   // and during tests (e.g. build/sbt test)
-  checkstyleConfigLocation := CheckstyleConfigLocation.File("dev/checkstyle.xml"),
-  checkstyleSeverityLevel := Some(CheckstyleSeverityLevel.Error),
-  (checkstyle in Compile) := (checkstyle in Compile).triggeredBy(compile in Compile).value,
-  (checkstyle in Test) := (checkstyle in Test).triggeredBy(compile in Test).value
+//  checkstyleConfigLocation := CheckstyleConfigLocation.File("dev/checkstyle.xml"),
+//  checkstyleSeverityLevel := Some(CheckstyleSeverityLevel.Error),
+//  (checkstyle in Compile) := (checkstyle in Compile).triggeredBy(compile in Compile).value,
+//  (checkstyle in Test) := (checkstyle in Test).triggeredBy(compile in Test).value
 )
 
 lazy val releaseSettings = Seq(

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -111,7 +111,7 @@ addDebugger () {
 # a ham-fisted attempt to move some memory settings in concert
 # so they need not be dicked around with individually.
 get_mem_opts () {
-  local mem=${1:-2048}
+  local mem=${1:-3072}
   local perm=$(( $mem / 4 ))
   (( $perm > 256 )) || perm=256
   (( $perm < 4096 )) || perm=4096

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -111,7 +111,7 @@ addDebugger () {
 # a ham-fisted attempt to move some memory settings in concert
 # so they need not be dicked around with individually.
 get_mem_opts () {
-  local mem=${1:-3072}
+  local mem=${1:-2048}
   local perm=$(( $mem / 4 ))
   (( $perm > 256 )) || perm=256
   (( $perm < 4096 )) || perm=4096

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -111,7 +111,7 @@ addDebugger () {
 # a ham-fisted attempt to move some memory settings in concert
 # so they need not be dicked around with individually.
 get_mem_opts () {
-  local mem=${1:-1000}
+  local mem=${1:-2048}
   local perm=$(( $mem / 4 ))
   (( $perm > 256 )) || perm=256
   (( $perm < 4096 )) || perm=4096


### PR DESCRIPTION
I noticed the following output in each failed build.

```
Files to process must be specified, found 0.
Files to process must be specified, found 0.
Error: Process completed with exit code 255.
```

After digging more, I found the root cause of our flaky build is the same as https://github.com/etsy/sbt-checkstyle-plugin/issues/32

sbt-checkstyle calls Java checkstyle library which will [call System.exit when the style check fails](https://github.com/etsy/sbt-checkstyle-plugin/blob/58b5c5fc4fc2d45b56ea07a9ad858089e34853e7/src/main/scala/com/etsy/sbt/checkstyle/Checkstyle.scala#L47-L52). In order to avoid exiting SBT JVM process, sbt-checkstyle [uses its own NoExitSecurityManager to prevent exits from the JVM](https://github.com/etsy/sbt-checkstyle-plugin/blob/58b5c5fc4fc2d45b56ea07a9ad858089e34853e7/src/main/scala/com/etsy/sbt/checkstyle/Checkstyle.scala#L122-L141). However, the implementation is [not thread thread](https://github.com/etsy/sbt-checkstyle-plugin/issues/32#issuecomment-976206148), and cannot prevent from exiting the JVM when two concurrent threads are running the [noExit](https://github.com/etsy/sbt-checkstyle-plugin/blob/58b5c5fc4fc2d45b56ea07a9ad858089e34853e7/src/main/scala/com/etsy/sbt/checkstyle/Checkstyle.scala#L122-L141) method.

As most of our projects have zero Java files, Java checkstyle library will fail and call System.exit for most of our projects. Due to the above race condition, the SBT JVM may be killed when sbt-checkstyle's `noExit` method cannot prevent from exiting the JVM. `exit code 255` in our output matches the following code in Checkstyle:
- https://github.com/checkstyle/checkstyle/blob/a42a3e1733f3c7583177a3c96de65e6a2fd7671f/src/main/java/com/puppycrawl/tools/checkstyle/Main.java#L87
- https://github.com/checkstyle/checkstyle/blob/a42a3e1733f3c7583177a3c96de65e6a2fd7671f/src/main/java/com/puppycrawl/tools/checkstyle/Main.java#L184-L189
- https://github.com/checkstyle/checkstyle/blob/a42a3e1733f3c7583177a3c96de65e6a2fd7671f/src/main/java/com/puppycrawl/tools/checkstyle/Main.java#L810-L812

The fix is just disabling parallel execution. While it makes the build slower, the speed is still acceptable since most of time is spent on tests which cannot run in parallel anyway.

This PR also adds build cache, hive tests back and upgrade Ubuntu back to 20.04. The SBT heap size is increased as well as I hit SBT OOM occasionally during my investigation.

