### PR TITLE
Add null-check for data reader partition field

### DIFF
--- a/standalone/src/main/scala/io/delta/standalone/internal/data/RowParquetRecordImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/data/RowParquetRecordImpl.scala
@@ -144,9 +144,16 @@ private[internal] case class RowParquetRecordImpl(
   private def getAs[T](fieldName: String): T = {
     val schemaField = schema.get(fieldName)
 
-    if (partitionValues.contains(fieldName)) { // partition field
+    // Partition Field
+    if (partitionValues.contains(fieldName)) {
+      if (partitionValues(fieldName) == null && !schemaField.isNullable) {
+        throw DeltaErrors.nullValueFoundForNonNullSchemaField(fieldName, schema)
+      }
+
       return partitionValues(fieldName).asInstanceOf[T]
     }
+
+    // Data Field
     val parquetVal = record.get(fieldName)
 
     if (parquetVal == NullValue && !schemaField.isNullable) {


### PR DESCRIPTION
Our `RowRecord` APIs say that we will throw a `NullPointerException if field is not nullable and {@code null} data value read`. We are doing this for data fields, but we forgot to do this for partition fields.

We can't test this as we can't insert a row with a null value for a a non-nullable collumn.