### PR TITLE
Update AND, OR and NOT to fail during construction and not eval for invalid input expression types

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/expressions/And.java
+++ b/standalone/src/main/java/io/delta/standalone/expressions/And.java
@@ -1,5 +1,6 @@
 package io.delta.standalone.expressions;
 
+import io.delta.standalone.types.BooleanType;
 import io.delta.standalone.internal.exception.DeltaErrors;
 
 /**
@@ -9,18 +10,18 @@ public final class And extends BinaryOperator implements Predicate {
 
     public And(Expression left, Expression right) {
         super(left, right, "&&");
+        if (!(left.dataType() instanceof BooleanType) ||
+                !(right.dataType() instanceof BooleanType)) {
+            throw DeltaErrors.illegalExpressionValueType(
+                    "AND",
+                    "bool",
+                    left.dataType().getTypeName(),
+                    right.dataType().getTypeName());
+        }
     }
 
     @Override
     public Object nullSafeEval(Object leftResult, Object rightResult) {
-        if (!(leftResult instanceof Boolean) || !(rightResult instanceof Boolean)) {
-            throw DeltaErrors.illegalExpressionValueType(
-                    "AND",
-                    "Boolean",
-                    leftResult.getClass().getName(),
-                    rightResult.getClass().getName());
-        }
-
         return (boolean) leftResult && (boolean) rightResult;
     }
 }

--- a/standalone/src/main/java/io/delta/standalone/expressions/Not.java
+++ b/standalone/src/main/java/io/delta/standalone/expressions/Not.java
@@ -1,5 +1,6 @@
 package io.delta.standalone.expressions;
 
+import io.delta.standalone.types.BooleanType;
 import io.delta.standalone.internal.exception.DeltaErrors;
 
 /**
@@ -8,17 +9,16 @@ import io.delta.standalone.internal.exception.DeltaErrors;
 public class Not extends UnaryExpression implements Predicate {
     public Not(Expression child) {
         super(child);
+        if (!(child.dataType() instanceof BooleanType)) {
+            throw DeltaErrors.illegalExpressionValueType(
+                    "NOT",
+                    "bool",
+                    child.dataType().getTypeName());
+        }
     }
 
     @Override
     public Object nullSafeEval(Object childResult) {
-        if (!(childResult instanceof Boolean)) {
-            throw DeltaErrors.illegalExpressionValueType(
-                    "NOT",
-                    "Boolean",
-                    childResult.getClass().getName());
-        }
-
         return !((boolean) childResult);
     }
 

--- a/standalone/src/main/java/io/delta/standalone/expressions/Or.java
+++ b/standalone/src/main/java/io/delta/standalone/expressions/Or.java
@@ -1,5 +1,6 @@
 package io.delta.standalone.expressions;
 
+import io.delta.standalone.types.BooleanType;
 import io.delta.standalone.internal.exception.DeltaErrors;
 
 /**
@@ -9,18 +10,18 @@ public final class Or extends BinaryOperator implements Predicate {
 
     public Or(Expression left, Expression right) {
         super(left, right, "||");
+        if (!(left.dataType() instanceof BooleanType) ||
+                !(right.dataType() instanceof BooleanType)) {
+            throw DeltaErrors.illegalExpressionValueType(
+                    "OR",
+                    "bool",
+                    left.dataType().getTypeName(),
+                    right.dataType().getTypeName());
+        }
     }
 
     @Override
     public Object nullSafeEval(Object leftResult, Object rightResult) {
-        if (!(leftResult instanceof Boolean) || !(rightResult instanceof Boolean)) {
-            throw DeltaErrors.illegalExpressionValueType(
-                    "OR",
-                    "Boolean",
-                    leftResult.getClass().getName(),
-                    rightResult.getClass().getName());
-        }
-
         return (boolean) leftResult || (boolean) rightResult;
     }
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
@@ -73,8 +73,8 @@ class ExpressionSuite extends FunSuite {
     testPredicate(new And(Literal.False, Literal.True), false)
     testPredicate(new And(Literal.True, Literal.True), true)
     testException[IllegalArgumentException](
-      new And(Literal.of(1), Literal.of(2)).eval(null),
-      "AND expression requires Boolean type.")
+      new And(Literal.of(1), Literal.of(2)),
+      "AND expression requires bool type.")
     testException[IllegalArgumentException](
       new And(Literal.False, Literal.ofNull(new IntegerType())),
       "BinaryOperator left and right DataTypes must be the same")
@@ -92,10 +92,9 @@ class ExpressionSuite extends FunSuite {
     testPredicate(new Or(Literal.True, Literal.False), true)
     testPredicate(new Or(Literal.False, Literal.True), true)
     testPredicate(new Or(Literal.True, Literal.True), true)
-    // TODO: fail upon creation instead of eval
     testException[IllegalArgumentException](
-      new Or(Literal.of(1), Literal.of(2)).eval(null),
-      "OR expression requires Boolean type.")
+      new Or(Literal.of(1), Literal.of(2)),
+      "OR expression requires bool type.")
     testException[IllegalArgumentException](
       new Or(Literal.False, Literal.ofNull(new IntegerType())),
       "BinaryOperator left and right DataTypes must be the same")
@@ -105,8 +104,8 @@ class ExpressionSuite extends FunSuite {
     testPredicate(new Not(Literal.True), false)
     testPredicate(new Not(Literal.ofNull(new BooleanType())), null)
     testException[IllegalArgumentException](
-      new Not(Literal.of(1)).eval(null),
-      "NOT expression requires Boolean type.")
+      new Not(Literal.of(1)),
+      "NOT expression requires bool type.")
   }
 
   test("comparison predicates") {
@@ -537,11 +536,11 @@ class ExpressionSuite extends FunSuite {
 
   test("expression content equality") {
     // BinaryExpression
-    val and = new And(partitionSchema.column("col1"), partitionSchema.column("col2"))
-    val andCopy = new And(partitionSchema.column("col1"), partitionSchema.column("col2"))
-    val and2 = new And(dataSchema.column("col3"), Literal.of(44))
-    assert(and == andCopy)
-    assert(and != and2)
+    val equalTo = new EqualTo(partitionSchema.column("col1"), partitionSchema.column("col2"))
+    val equalToCopy = new EqualTo(partitionSchema.column("col1"), partitionSchema.column("col2"))
+    val equalTo2 = new EqualTo(dataSchema.column("col3"), Literal.of(44))
+    assert(equalTo == equalToCopy)
+    assert(equalTo != equalTo2)
 
     // UnaryExpression
     val not = new Not(new EqualTo(Literal.of(1), Literal.of(1)))


### PR DESCRIPTION
Moved the check for boolean input types to construction instead of eval.
- More intuitive
- Matches our behavior in `BinaryOperator`

Updated tests to match.