### PR TITLE
Create a Metadata builder from an existing instance

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
+++ b/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
@@ -80,6 +80,18 @@ public interface OptimisticTransaction {
      * Records an update to the metadata that should be committed with this transaction.
      *
      * <p>
+     * Use {@link Metadata#copyBuilder()} to build a new {@link Metadata} instance based on the
+     * current table metadata. For example:
+     *
+     * <pre>{@code
+     * Metadata newMetadata = optimisticTransaction.metadata().copyBuilder()
+     *     .schema(newSchema)
+     *     .createdTime(System.currentTimeMillis())
+     *     .build();
+     * optimisticTransaction.updateMetadata(newMetadata);
+     * }</pre>
+     *
+     * <p>
      * IMPORTANT: It is the responsibility of the caller to ensure that files currently
      * present in the table are still valid under the new metadata.
      *

--- a/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
+++ b/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
@@ -86,7 +86,6 @@ public interface OptimisticTransaction {
      * <pre>{@code
      * Metadata newMetadata = optimisticTransaction.metadata().copyBuilder()
      *     .schema(newSchema)
-     *     .createdTime(System.currentTimeMillis())
      *     .build();
      * optimisticTransaction.updateMetadata(newMetadata);
      * }</pre>

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -155,6 +155,22 @@ public final class Metadata implements Action {
     }
 
     /**
+     * @return a new {@link Metadata.Builder} initialized with the same properties as this
+     *         {@link Metadata} instance
+     */
+    public Builder copyBuilder() {
+        return builder()
+                .id(id)
+                .name(name)
+                .description(description)
+                .format(format)
+                .partitionColumns(partitionColumns)
+                .configuration(configuration)
+                .createdTime(createdTime)
+                .schema(schema);
+    }
+
+    /**
      * @return a new {@link Metadata.Builder}
      */
     public static Builder builder() {
@@ -207,6 +223,11 @@ public final class Metadata implements Action {
 
         public Builder createdTime(Long createdTime) {
             this.createdTime = Optional.of(createdTime);
+            return this;
+        }
+
+        public Builder createdTime(Optional<Long> createdTime) {
+            this.createdTime = createdTime;
             return this;
         }
 

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -159,15 +159,8 @@ public final class Metadata implements Action {
      *         {@link Metadata} instance
      */
     public Builder copyBuilder() {
-        return builder()
-                .id(id)
-                .name(name)
-                .description(description)
-                .format(format)
-                .partitionColumns(partitionColumns)
-                .configuration(configuration)
-                .createdTime(createdTime)
-                .schema(schema);
+        return new Builder(id, name, description, format, partitionColumns, configuration,
+                createdTime, schema);
     }
 
     /**
@@ -190,6 +183,27 @@ public final class Metadata implements Action {
         @Nonnull private Map<String, String> configuration = Collections.emptyMap();
         @Nonnull private Optional<Long> createdTime = Optional.of(System.currentTimeMillis());
         @Nullable private StructType schema;
+
+        public Builder(){};
+
+        public Builder(
+                @Nonnull String id,
+                @Nullable String name,
+                @Nullable String description,
+                @Nonnull Format format,
+                @Nonnull List<String> partitionColumns,
+                @Nonnull Map<String, String> configuration,
+                @Nonnull Optional<Long> createdTime,
+                @Nullable StructType schema) {
+            this.id = id;
+            this.name = name;
+            this.description = description;
+            this.format = format;
+            this.partitionColumns = partitionColumns;
+            this.configuration = configuration;
+            this.createdTime = createdTime;
+            this.schema = schema;
+        }
 
         public Builder id(@Nonnull String id) {
             this.id = id;
@@ -226,7 +240,7 @@ public final class Metadata implements Action {
             return this;
         }
 
-        public Builder createdTime(Optional<Long> createdTime) {
+        public Builder createdTime(@Nonnull Optional<Long> createdTime) {
             this.createdTime = createdTime;
             return this;
         }

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -186,7 +186,7 @@ public final class Metadata implements Action {
 
         public Builder(){};
 
-        public Builder(
+        private Builder(
                 @Nonnull String id,
                 @Nullable String name,
                 @Nullable String description,

--- a/standalone/src/test/scala/io/delta/standalone/internal/ActionBuildersSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ActionBuildersSuite.scala
@@ -64,8 +64,10 @@ class ActionBuildersSuite extends FunSuite {
 
   test("Metadata constructor matches Metadata.Builder constructor") {
     assert(
-      classOf[MetadataJ].getConstructors.map(_.getParameterCount()).toList.max ==
-      classOf[MetadataJ.Builder].getConstructors.map(_.getParameterCount()).toList.max
+      classOf[MetadataJ].getDeclaredConstructors.map(_.getParameterCount()).toList.max ==
+      classOf[MetadataJ.Builder].getDeclaredConstructors.map(_.getParameterCount()).toList.max,
+      "Metadata and Metadata.Builder's constructors are not the same. Please update them" +
+        "accordingly if you add a new field to Metadata."
     )
   }
 

--- a/standalone/src/test/scala/io/delta/standalone/internal/ActionBuildersSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ActionBuildersSuite.scala
@@ -62,6 +62,35 @@ class ActionBuildersSuite extends FunSuite {
     assert(metadataFromBuilder == metadataFromConstructor)
   }
 
+  test("copyBuilder constructor for Metadata") {
+    val metadata = new MetadataJ(
+      "test_id",
+      "test_name",
+      "test_description",
+      new FormatJ("csv", Collections.emptyMap()),
+      List("id", "name").asJava,
+      Map("test"->"foo").asJava,
+      Optional.empty(),
+      null)
+    assert(metadata == metadata.copyBuilder().build())  // values are copied
+
+    val defaultMetadata = MetadataJ.builder().build()
+    assert(defaultMetadata == defaultMetadata.copyBuilder().build())  // default values are copied
+
+    val overwrittenMetadata = new MetadataJ(
+      "foo",
+      "foo",
+      "foo",
+      new FormatJ("csv", Collections.emptyMap()),
+      List("id", "name").asJava,
+      Map("test"->"foo").asJava,
+      Optional.of(0L),
+      null)
+    assert(overwrittenMetadata == metadata.copyBuilder()  // values can be overwritten
+      .id("foo").name("foo").description("foo").createdTime(0L)
+      .build())
+  }
+
   test("builder action class constructor for AddFile") {
     val addFileFromBuilderDefaults = AddFileJ.builder(
       "/test",

--- a/standalone/src/test/scala/io/delta/standalone/internal/ActionBuildersSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ActionBuildersSuite.scala
@@ -62,6 +62,13 @@ class ActionBuildersSuite extends FunSuite {
     assert(metadataFromBuilder == metadataFromConstructor)
   }
 
+  test("Metadata constructor matches Metadata.Builder constructor") {
+    assert(
+      classOf[MetadataJ].getConstructors.map(_.getParameterCount()).toList.max ==
+      classOf[MetadataJ.Builder].getConstructors.map(_.getParameterCount()).toList.max
+    )
+  }
+
   test("copyBuilder constructor for Metadata") {
     val metadata = new MetadataJ(
       "test_id",

--- a/standalone/src/test/scala/io/delta/standalone/internal/ActionBuildersSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ActionBuildersSuite.scala
@@ -64,9 +64,13 @@ class ActionBuildersSuite extends FunSuite {
 
   test("Metadata constructor matches Metadata.Builder constructor") {
     assert(
-      classOf[MetadataJ].getDeclaredConstructors.map(_.getParameterCount()).toList.max ==
-      classOf[MetadataJ.Builder].getDeclaredConstructors.map(_.getParameterCount()).toList.max,
-      "Metadata and Metadata.Builder's constructors are not the same. Please update them" +
+      classOf[MetadataJ].getDeclaredConstructors
+        .filter(!_.isSynthetic)
+        .map(_.getParameterCount()).toList.max ==
+      classOf[MetadataJ.Builder].getDeclaredConstructors
+        .filter(!_.isSynthetic)
+        .map(_.getParameterCount()).toList.max,
+      "Metadata and Metadata.Builder's constructors are not the same. Please update them " +
         "accordingly if you add a new field to Metadata."
     )
   }


### PR DESCRIPTION
Since actions are immutable, it is cumbersome to update an existing table metadata with one or two value changes. This introduces `Metadata::copyBuilder()` which instantiates a `Metadata.Builder` with properties copied over.
- Added `Metadata::copyBuilder()`
- Added tests
- Updated `OptimisticTransaction::updateMetadata(Metadata metadata)` documentation with example usage