### PR TITLE
OptimisticTransactionImpl.commit changes absolute paths to relative paths

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
+++ b/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
@@ -36,8 +36,8 @@ public interface OptimisticTransaction {
      * concurrent writer this method will throw an exception.
      * <p>
      * Note: any {@link io.delta.standalone.actions.AddFile} with an absolute path within the table
-     * path will be updated to have a relative path (based off of the table path). Because of this, be
-     * sure to generate all {@link io.delta.standalone.actions.RemoveFile}s from
+     * path will be updated to have a relative path (based off of the table path). Because of this,
+     * be sure to generate all {@link io.delta.standalone.actions.RemoveFile}s from
      * {@link io.delta.standalone.actions.AddFile}s read from the Delta Log, and not the
      * {@link io.delta.standalone.actions.AddFile}s created pre-commit.
      *

--- a/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
+++ b/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
@@ -34,6 +34,12 @@ public interface OptimisticTransaction {
      * Modifies the state of the log by adding a new commit that is based on a read at the table's
      * latest version as of this transaction's instantiation. In the case of a conflict with a
      * concurrent writer this method will throw an exception.
+     * <p>
+     * Note: any {@link io.delta.standalone.actions.AddFile} with an absolute path within the table
+     * path will be updated to have a relative path (based off of the table path). Because of this, be
+     * sure to generate all {@link io.delta.standalone.actions.RemoveFile}s from
+     * {@link io.delta.standalone.actions.AddFile}s read from the Delta Log, and not the
+     * {@link io.delta.standalone.actions.AddFile}s created pre-commit.
      *
      * @param <T>  A derived class of {@link Action}. This allows, for example, both a
      *             {@code List<Action>} and a {@code List<AddFile>} to be accepted.

--- a/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
+++ b/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
@@ -37,9 +37,9 @@ public interface OptimisticTransaction {
      * <p>
      * Note: any {@link io.delta.standalone.actions.AddFile} with an absolute path within the table
      * path will be updated to have a relative path (based off of the table path). Because of this,
-     * be sure to generate all {@link io.delta.standalone.actions.RemoveFile}s from
-     * {@link io.delta.standalone.actions.AddFile}s read from the Delta Log, and not the
-     * {@link io.delta.standalone.actions.AddFile}s created pre-commit.
+     * be sure to generate all {@link io.delta.standalone.actions.RemoveFile}s using
+     * {@link io.delta.standalone.actions.AddFile}s read from the Delta Log (do not use the
+     * {@link io.delta.standalone.actions.AddFile}s created pre-commit.)
      *
      * @param <T>  A derived class of {@link Action}. This allows, for example, both a
      *             {@code List<Action>} and a {@code List<AddFile>} to be accepted.

--- a/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
@@ -28,7 +28,9 @@ import javax.annotation.Nullable;
  * deleted permanently.
  * <p>
  * Users should only instantiate {@link RemoveFile} instances using one of the various
- * {@link AddFile#remove()} methods.
+ * {@link AddFile#remove()} methods. Users should use an {@link AddFile} instance read from the
+ * Delta Log since {@link AddFile} paths may be updated during
+ * {@link io.delta.standalone.OptimisticTransaction#commit}.
  * <p>
  * Note that for protocol compatibility reasons, the fields {@code partitionValues},
  * {@code size}, and {@code tags} are only present when the {@code extendedFileMetadata} flag is

--- a/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/RemoveFile.java
@@ -62,7 +62,10 @@ public class RemoveFile implements FileAction {
      * Users should <b>not</b> construct {@link RemoveFile}s themselves, and should instead use one
      * of the various {@link AddFile#remove()} methods to instantiate the correct {@link RemoveFile}
      * for a given {@link AddFile} instance.
+     *
+     * @deprecated {@link RemoveFile} should be created from {@link AddFile#remove()} instead.
      */
+    @Deprecated
     public RemoveFile(
             @Nonnull String path,
             @Nonnull Optional<Long> deletionTimestamp,

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -54,7 +54,7 @@ private[internal] class DeltaLogImpl private(
   lazy val store = createLogStore(hadoopConf)
 
   /** Direct access to the underlying storage system. */
-  protected lazy val fs = logPath.getFileSystem(hadoopConf)
+  lazy val fs = logPath.getFileSystem(hadoopConf)
 
   // TODO: There is a race here where files could get dropped when increasing the
   // retention interval...

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -54,7 +54,7 @@ private[internal] class DeltaLogImpl private(
   lazy val store = createLogStore(hadoopConf)
 
   /** Direct access to the underlying storage system. */
-  lazy val fs = logPath.getFileSystem(hadoopConf)
+  protected[internal] lazy val fs = logPath.getFileSystem(hadoopConf)
 
   // TODO: There is a race here where files could get dropped when increasing the
   // retention interval...

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -54,7 +54,7 @@ private[internal] class DeltaLogImpl private(
   lazy val store = createLogStore(hadoopConf)
 
   /** Direct access to the underlying storage system. */
-  protected[internal] lazy val fs = logPath.getFileSystem(hadoopConf)
+  lazy val fs = logPath.getFileSystem(hadoopConf)
 
   // TODO: There is a race here where files could get dropped when increasing the
   // retention interval...

--- a/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
@@ -22,6 +22,8 @@ import java.util.UUID
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.hadoop.fs.Path
+
 import io.delta.standalone.{CommitResult, DeltaScan, NAME, Operation, OptimisticTransaction, VERSION}
 import io.delta.standalone.actions.{Action => ActionJ, Metadata => MetadataJ}
 import io.delta.standalone.exceptions.DeltaStandaloneException
@@ -32,6 +34,7 @@ import io.delta.standalone.internal.actions.{Action, AddFile, CommitInfo, FileAc
 import io.delta.standalone.internal.exception.DeltaErrors
 import io.delta.standalone.internal.logging.Logging
 import io.delta.standalone.internal.util.{ConversionUtils, FileNames, SchemaMergingUtils, SchemaUtils}
+import io.delta.standalone.internal.util.DeltaFileOperations
 
 private[internal] class OptimisticTransactionImpl(
     deltaLog: DeltaLogImpl,
@@ -216,8 +219,19 @@ private[internal] class OptimisticTransactionImpl(
     val customCommitInfo = actions.exists(_.isInstanceOf[CommitInfo])
     assert(!customCommitInfo, "Cannot commit a custom CommitInfo in a transaction.")
 
+    // Convert absolute paths to relative
+    var finalActions = actions.map {
+      case addFile: AddFile =>
+        addFile.copy(path =
+          DeltaFileOperations.tryRelativizePath(
+            deltaLog.fs,
+            deltaLog.getPath,
+            new Path(addFile.path)).toString)
+      case a: Action => a
+    }
+
     // If the metadata has changed, add that to the set of actions
-    var finalActions = newMetadata.toSeq ++ actions
+    finalActions = newMetadata.toSeq ++ finalActions
 
     val metadataChanges = finalActions.collect { case m: Metadata => m }
     assert(metadataChanges.length <= 1,

--- a/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
@@ -226,7 +226,8 @@ private[internal] class OptimisticTransactionImpl(
           DeltaFileOperations.tryRelativizePath(
             deltaLog.fs,
             deltaLog.getPath,
-            new Path(addFile.path)).toString)
+            new Path(addFile.path)
+          ).toString)
       case a: Action => a
     }
 

--- a/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
@@ -219,7 +219,7 @@ private[internal] class OptimisticTransactionImpl(
     val customCommitInfo = actions.exists(_.isInstanceOf[CommitInfo])
     assert(!customCommitInfo, "Cannot commit a custom CommitInfo in a transaction.")
 
-    // Convert absolute paths to relative
+    // Convert AddFile paths to relative paths if they're in the table path
     var finalActions = actions.map {
       case addFile: AddFile =>
         addFile.copy(path =

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/DeltaFileOperations.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/DeltaFileOperations.scala
@@ -23,7 +23,7 @@ import io.delta.standalone.internal.logging.Logging
 /**
  * Utility methods on files, directories, and paths.
  */
-object DeltaFileOperations extends Logging {
+private[internal] object DeltaFileOperations extends Logging {
 
   /**
    * Given a path `child`:
@@ -76,5 +76,4 @@ object DeltaFileOperations extends Logging {
       child
     }
   }
-
 }

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/DeltaFileOperations.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/DeltaFileOperations.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (2020-present) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.standalone.internal.util
+
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import io.delta.standalone.internal.logging.Logging
+
+/**
+ * Utility methods on files, directories, and paths.
+ */
+object DeltaFileOperations extends Logging {
+
+  /**
+   * Given a path `child`:
+   *   1. Returns `child` if the path is already relative
+   *   2. Tries relativizing `child` with respect to `basePath`
+   *      a) If the `child` doesn't live within the same base path, returns `child` as is
+   *      b) If `child` lives in a different FileSystem, throws an exception
+   * Note that `child` may physically be pointing to a path within `basePath`, but may logically
+   * belong to a different FileSystem, e.g. DBFS mount points and direct S3 paths.
+   */
+  def tryRelativizePath(
+      fs: FileSystem,
+      basePath: Path,
+      child: Path,
+      ignoreError: Boolean = false): Path = {
+    // We can map multiple schemes to the same `FileSystem` class, but `FileSystem.getScheme` is
+    // usually just a hard-coded string. Hence, we need to use the scheme of the URI that we use to
+    // create the FileSystem here.
+    if (child.isAbsolute) {
+      try {
+        new Path(fs.makeQualified(basePath).toUri.relativize(fs.makeQualified(child).toUri))
+      } catch {
+        case _: IllegalArgumentException if ignoreError =>
+          // ES-85571: when the file system failed to make the child path qualified,
+          // it means the child path exists in a different file system
+          // (a different authority or schema). This usually happens when the file is coming
+          // from the across buckets or across cloud storage system shallow clone.
+          // When ignoreError being set to true, not try to relativize this path,
+          // ignore the error and just return `child` as is.
+          child
+        case e: IllegalArgumentException =>
+          logError(s"Failed to relativize the path ($child) " +
+            s"with the base path ($basePath) and the file system URI (${fs.getUri})", e)
+          throw new IllegalStateException(
+            s"""Failed to relativize the path ($child). This can happen when absolute paths make
+               |it into the transaction log, which start with the scheme
+               |s3://, wasbs:// or adls://. This is a bug that has existed before DBR 5.0.
+               |To fix this issue, please upgrade your writer jobs to DBR 5.0 and please run:
+               |%scala com.databricks.delta.Delta.fixAbsolutePathsInLog("$child").
+               |
+               |If this table was created with a shallow clone across file systems
+               |(different buckets/containers) and this table is NOT USED IN PRODUCTION, you can
+               |set the SQL configuration spark.databricks.delta.vacuum.relativize.ignoreError
+               |to true. Using this SQL configuration could lead to accidental data loss,
+               |therefore we do not recommend the use of this flag unless
+               |this is a shallow clone for testing purposes.
+             """.stripMargin)
+      }
+    } else {
+      child
+    }
+  }
+
+}

--- a/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionSuite.scala
@@ -302,7 +302,6 @@ class OptimisticTransactionSuite
       txn.commit(Metadata() :: addFile :: Nil, op, "test")
 
       val committedAddFile = log.update().getAllFiles.asScala.head
-      // TODO Should we be qualifying paths if they're not in the table path?
       assert(Path.getPathWithoutSchemeAndAuthority(new Path(committedAddFile.getPath)).toString ==
         "/absolute/path/to/file/test.parquet")
     }

--- a/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionSuite.scala
@@ -301,12 +301,12 @@ class OptimisticTransactionSuite
       val addFile = AddFile("/absolute/path/to/file/test.parquet", Map(), 0, 0, true)
       txn.commit(Metadata() :: addFile :: Nil, op, "test")
 
-      val committedPath = new Path(log.update().getAllFiles.asScala.head.getPath)
+      val committedAddFile = log.update().getAllFiles.asScala.head
+      val committedPath = new Path(committedAddFile.getPath)
       // Path is fully qualified
       assert(committedPath.isAbsolute && !committedPath.isAbsoluteAndSchemeAuthorityNull)
       // Path is unaltered
-      assert(Path.getPathWithoutSchemeAndAuthority(committedPath).toString ==
-        "/absolute/path/to/file/test.parquet")
+      assert(committedAddFile.getPath === "file:/absolute/path/to/file/test.parquet")
     }
   }
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionSuite.scala
@@ -21,11 +21,13 @@ import java.util.Collections
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
 
 import io.delta.standalone.DeltaLog
-import io.delta.standalone.actions.{Action => ActionJ, AddFile => AddFileJ, CommitInfo, Metadata => MetadataJ, Protocol, SetTransaction => SetTransactionJ}
+import io.delta.standalone.actions.{CommitInfo, Protocol, Action => ActionJ, AddFile => AddFileJ, Metadata => MetadataJ, SetTransaction => SetTransactionJ}
 import io.delta.standalone.types.{IntegerType, StringType, StructField, StructType}
 
+import io.delta.standalone.internal.actions.{AddFile, Metadata}
 import io.delta.standalone.internal.util.TestUtils._
 
 class OptimisticTransactionSuite
@@ -262,5 +264,62 @@ class OptimisticTransactionSuite
     // change of datatype - not all files are removed (should throw)
     testSchemaChange(schema1, schema2, shouldThrow = true, initialActions = addA :: addB :: Nil,
       commitActions = removeA :: Nil)
+  }
+
+  ///////////////////////////////////////////////////////////////////////////
+  // prepareCommit() relativize paths tests
+  ///////////////////////////////////////////////////////////////////////////
+
+  test("converts absolute path to relative path when in table path") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(new Configuration(), dir.getCanonicalPath)
+      val txn = log.startTransaction()
+      val addFile = AddFile(
+        dir.getCanonicalPath + "/path/to/file/test.parquet",
+        Map(),
+        0,
+        0,
+        true)
+      txn.commit(Metadata() :: addFile :: Nil, op, "test")
+
+      val committedAddFile = log.update().getAllFiles.asScala.head
+      assert(committedAddFile.getPath == "path/to/file/test.parquet")
+    }
+  }
+
+  test("relative path is unchanged") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(new Configuration(), dir.getCanonicalPath)
+      val txn = log.startTransaction()
+      val addFile = AddFile(
+        "path/to/file/test.parquet",
+        Map(),
+        0,
+        0,
+        true)
+      txn.commit(Metadata() :: addFile :: Nil, op, "test")
+
+      val committedAddFile = log.update().getAllFiles.asScala.head
+      assert(committedAddFile.getPath == "path/to/file/test.parquet")
+    }
+  }
+
+  test("absolute path unchanged when not in table path") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(new Configuration(), dir.getCanonicalPath)
+      val txn = log.startTransaction()
+      val addFile = AddFile(
+        "/absolute/path/to/file/test.parquet",
+        Map(),
+        0,
+        0,
+        true)
+      txn.commit(Metadata() :: addFile :: Nil, op, "test")
+
+      val committedAddFile = log.update().getAllFiles.asScala.head
+      // Should we be qualifying paths if they're not in the table path?
+      assert(Path.getPathWithoutSchemeAndAuthority(new Path(committedAddFile.getPath)).toString ==
+        "/absolute/path/to/file/test.parquet")
+    }
   }
 }


### PR DESCRIPTION
Resolves #228

`DeltaLogSuite` already has a test to check that `RemoveFile` paths are not relativized.

Re the last test added: Should we be qualifying paths if they're not in the table path?
- `tryRelativizePath` qualifies any absolute path whether or not it's in the table