### PR TITLE
Fail when committing metadata with incorrect protocol update

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
+++ b/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
@@ -35,10 +35,6 @@ public interface OptimisticTransaction {
      * latest version as of this transaction's instantiation. In the case of a conflict with a
      * concurrent writer this method will throw an exception.
      * <p>
-     * To update the table metadata, use {@link OptimisticTransaction#updateMetadata}. Passing a
-     * {@link Metadata} action to {@link OptimisticTransaction#commit} will throw an
-     * {@link IllegalArgumentException}.
-     * <p>
      * Note: any {@link io.delta.standalone.actions.AddFile} with an absolute path within the table
      * path will be updated to have a relative path (based off of the table path). Because of this,
      * be sure to generate all {@link io.delta.standalone.actions.RemoveFile}s using

--- a/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
+++ b/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
@@ -35,6 +35,10 @@ public interface OptimisticTransaction {
      * latest version as of this transaction's instantiation. In the case of a conflict with a
      * concurrent writer this method will throw an exception.
      * <p>
+     * To update the table metadata, use {@link OptimisticTransaction#updateMetadata}. Passing a
+     * {@link Metadata} action to {@link OptimisticTransaction#commit} will throw an
+     * {@link IllegalArgumentException}.
+     * <p>
      * Note: any {@link io.delta.standalone.actions.AddFile} with an absolute path within the table
      * path will be updated to have a relative path (based off of the table path). Because of this,
      * be sure to generate all {@link io.delta.standalone.actions.RemoveFile}s using

--- a/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
@@ -180,9 +180,9 @@ private[internal] class OptimisticTransactionImpl(
    * - If this is the first commit, the committed metadata configuration includes global Delta
    *   configuration defaults.
    * - Checks for unenforceable NOT NULL constraints in the table schema.
-   *  - Checks for column name duplication.
-   *    - Verifies column names are parquet compatible.
-   *    - Enforces that protocol versions are not part of the table properties.
+   * - Checks for column name duplication.
+   * - Verifies column names are parquet compatible.
+   * - Enforces that protocol versions are not part of the table properties.
    */
   override def updateMetadata(metadataJ: MetadataJ): Unit = {
 

--- a/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
@@ -64,7 +64,8 @@ private[internal] class OptimisticTransactionImpl(
 
   /** Stores the updated metadata (if any) that will result from this txn. */
   private var newMetadata: Option[Metadata] = None
-  private var newMetadataJ: Option[MetadataJ] = None // TODO: document
+  /** Stores the updated Java metadata (if any) that will result from this txn. */
+  private var newMetadataJ: Option[MetadataJ] = None
 
   /** Stores the updated protocol (if any) that will result from this txn. */
   private var newProtocol: Option[Protocol] = None

--- a/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
@@ -189,7 +189,6 @@ private[internal] class OptimisticTransactionImpl(
     if (readVersion == -1 || isCreatingNewTable) {
       latestMetadata = withGlobalConfigDefaults(latestMetadata)
       isCreatingNewTable = true
-      newProtocol = Some(Protocol())
     }
 
     if (snapshot.metadataScala.schemaString != latestMetadata.schemaString) {
@@ -240,7 +239,7 @@ private[internal] class OptimisticTransactionImpl(
       case a: Action => a
     }
 
-    newMetadata.foreach{ m =>
+    newMetadata.foreach { m =>
       verifySchemaCompatibility(snapshot.metadataScala.schema, m.schema, actions)
     }
 
@@ -265,8 +264,6 @@ private[internal] class OptimisticTransactionImpl(
     if (protocolOpt.isDefined) {
       assert(protocolOpt.get == Protocol(), s"Invalid Protocol ${protocolOpt.get.simpleString}. " +
         s"Currently only Protocol readerVersion 1 and writerVersion 2 is supported.")
-    } else {
-      finalActions = newProtocol.toSeq ++ finalActions
     }
 
     val partitionColumns = metadataScala.partitionColumns.toSet

--- a/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionLegacySuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionLegacySuite.scala
@@ -308,7 +308,7 @@ class OptimisticTransactionLegacySuite extends FunSuite {
     }
   }
 
-  test("updateMetadata removes Protocol properties from metadata config") {
+  test("updateMetadata fails for metadata with Protocol configuration properties") {
     // Note: These Protocol properties are not currently exposed to the user. However, they
     //       might be in the future, and nothing is stopping the user now from seeing these
     //       properties in Delta OSS and adding them to the config map here.

--- a/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionLegacySuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionLegacySuite.scala
@@ -164,7 +164,7 @@ class OptimisticTransactionLegacySuite extends FunSuite {
     }
   }
 
-  test("commits shouldn't have more than one Metadata") {
+  test("commits shouldn't have more than one unique Metadata") {
     withTempDir { dir =>
       val log = DeltaLog.forTable(new Configuration(), dir.getCanonicalPath)
       val txn = log.startTransaction()
@@ -187,13 +187,16 @@ class OptimisticTransactionLegacySuite extends FunSuite {
     }
   }
 
-  test("can commit the *same* Metadata as used for updateMetadata ") {
+  test("can commit the same Metadata as used for updateMetadata ") {
     withTempDir { dir =>
       val log = DeltaLog.forTable(new Configuration(), dir.getCanonicalPath)
       val txn = log.startTransaction()
       val metadata = ConversionUtils.convertMetadata(Metadata())
       txn.updateMetadata(metadata)
-      val result = txn.commit((metadata :: Nil).asJava, manualUpdate, engineInfo)
+      val result = txn.commit(
+        (metadata.copyBuilder().build() :: Nil).asJava,
+        manualUpdate,
+        engineInfo)
       assert(result.getVersion == 0)
     }
   }

--- a/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionLegacySuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionLegacySuite.scala
@@ -193,7 +193,8 @@ class OptimisticTransactionLegacySuite extends FunSuite {
       val txn = log.startTransaction()
       val metadata = ConversionUtils.convertMetadata(Metadata())
       txn.updateMetadata(metadata)
-      txn.commit((metadata :: Nil).asJava, manualUpdate, engineInfo) // todo: how to assert no error
+      val result = txn.commit((metadata :: Nil).asJava, manualUpdate, engineInfo)
+      assert(result.getVersion == 0)
     }
   }
 


### PR DESCRIPTION
Resolves #229 

Should we throw an error if protocol configuration properties are provided, but they are correct?