### PR TITLE
DeltaLog::getChanges javadoc clarification

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/DeltaLog.java
+++ b/standalone/src/main/java/io/delta/standalone/DeltaLog.java
@@ -94,7 +94,9 @@ public interface DeltaLog {
     Path getPath();
 
     /**
-     * Get all actions starting from {@code startVersion} (inclusive).
+     * Get all actions starting from {@code startVersion} (inclusive) in increasing order of
+     * committed version.
+     * <p>
      * If {@code startVersion} doesn't exist, return an empty {@code Iterator}.
      *
      * @param startVersion the table version to begin retrieving actions from (inclusive)

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -22,13 +22,14 @@ import java.sql.Timestamp
 import java.util.UUID
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
 
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.scalatest.FunSuite
-
 import io.delta.standalone.{DeltaLog, Operation, Snapshot}
+
 import io.delta.standalone.actions.{AddFile => AddFileJ, JobInfo => JobInfoJ, Metadata => MetadataJ, NotebookInfo => NotebookInfoJ, RemoveFile => RemoveFileJ}
 import io.delta.standalone.exceptions.DeltaStandaloneException
 
@@ -381,13 +382,20 @@ abstract class DeltaLogSuiteBase extends FunSuite {
         assert(versionLogs.length == 3 - startVersion,
           s"getChanges($startVersion) skipped some versions")
 
+        val versionsInOrder = new ListBuffer[Long]()
+
         for (versionLog <- versionLogs) {
           val version = versionLog.getVersion
           val actions = versionLog.getActions.asScala.map(_.getClass.getSimpleName)
           val expectedActions = versionToActionsMap(version)
           assert(expectedActions == actions,
             s"getChanges($startVersion) had incorrect actions at version $version.")
+
+          versionsInOrder += version
         }
+
+        // ensure that versions are seen in increasing order
+        assert(versionsInOrder.toList == (startVersion to 2).map(_.toLong).toList)
       }
 
       // standard cases

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -28,8 +28,8 @@ import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.scalatest.FunSuite
-import io.delta.standalone.{DeltaLog, Operation, Snapshot}
 
+import io.delta.standalone.{DeltaLog, Operation, Snapshot}
 import io.delta.standalone.actions.{AddFile => AddFileJ, JobInfo => JobInfoJ, Metadata => MetadataJ, NotebookInfo => NotebookInfoJ, RemoveFile => RemoveFileJ}
 import io.delta.standalone.exceptions.DeltaStandaloneException
 


### PR DESCRIPTION
The prior `DeltaLog::getChanges` API didn't clearly indicate that the versions returned were in increasing order. This PR fixes that.