### PR TITLE
Fix MiMa issue in branch-0.3

### DIFF
--- a/project/StandaloneMimaExcludes.scala
+++ b/project/StandaloneMimaExcludes.scala
@@ -31,8 +31,11 @@ object StandaloneMimaExcludes {
     ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.DeltaLog.getChanges"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.DeltaLog.startTransaction"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.Snapshot.scan"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.DeltaLog.tableExists")
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.DeltaLog.tableExists"),
 
-    // scalastyle:on line.size.limit
+    // Ignore missing shaded attributes
+    ProblemFilters.exclude[Problem]("shadedelta.*")
+
+  // scalastyle:on line.size.limit
   )
 }


### PR DESCRIPTION
MiMa compares the compiled class files with the released JAR. `build/sbt standalone/compile` doesn't include the shaded JARs so we ignore them. They will be included with the released `standaloneCosmetic` JAR.