### PR TITLE
Access tables in golden-tables/ directly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -213,7 +213,6 @@ lazy val hiveMR = (project in file("hive-mr")) dependsOn(hiveTest % "test->test"
   name := "hive-mr",
   commonSettings,
   skipReleaseSettings,
-  Test / unmanagedResourceDirectories += file("golden-tables/src/test/resources"),
   libraryDependencies ++= Seq(
     "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
     "org.apache.hive" % "hive-exec" % hiveVersion % "provided" excludeAll(
@@ -240,7 +239,6 @@ lazy val hiveTez = (project in file("hive-tez")) dependsOn(hiveTest % "test->tes
   name := "hive-tez",
   commonSettings,
   skipReleaseSettings,
-  Test / unmanagedResourceDirectories += file("golden-tables/src/test/resources"),
   libraryDependencies ++= Seq(
     "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided" excludeAll (
       ExclusionRule(organization = "com.google.protobuf")
@@ -288,7 +286,6 @@ lazy val hive2MR = (project in file("hive2-mr")) settings (
   name := "hive2-mr",
   commonSettings,
   skipReleaseSettings,
-  Test / unmanagedResourceDirectories += file("golden-tables/src/test/resources"),
   Compile / unmanagedJars ++= Seq(
     (hiveAssembly / Compile / packageBin / packageBin).value,
     (hiveTest / Test / packageBin / packageBin).value
@@ -319,7 +316,6 @@ lazy val hive2Tez = (project in file("hive2-tez")) settings (
   name := "hive2-tez",
   commonSettings,
   skipReleaseSettings,
-  Test / unmanagedResourceDirectories += file("golden-tables/src/test/resources"),
   Compile / unmanagedJars ++= Seq(
     (hiveAssembly / Compile / packageBin / packageBin).value,
     (hiveTest / Test / packageBin / packageBin).value
@@ -420,7 +416,6 @@ lazy val standalone = (project in file("standalone"))
     commonSettings,
     skipReleaseSettings,
     mimaSettings,
-    Test / unmanagedResourceDirectories += file("golden-tables/src/test/resources"),
     // When updating any dependency here, we should also review `pomPostProcess` in project
     // `standaloneCosmetic` and update it accordingly.
     libraryDependencies ++= Seq(

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
@@ -304,7 +304,7 @@ class DeltaDataReaderSuite extends FunSuite {
     }
   }
 
-  ignore("data reader can read partition values") {
+  test("data reader can read partition values") {
     withLogForGoldenTable("data-reader-partition-values") { log =>
       val snapshot = log.update()
       val partitionColumns = snapshot.getMetadata.getPartitionColumns.asScala.toSet

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -206,7 +206,7 @@ abstract class DeltaLogSuiteBase extends FunSuite {
   }
 
   test("handle corrupted '_last_checkpoint' file") {
-    withLogImplForGoldenTable("corrupted-last-checkpoint") { log1 =>
+    withLogImplForWritableGoldenTable("corrupted-last-checkpoint") { log1 =>
       assert(log1.lastCheckpoint.isDefined)
 
       val lastCheckpoint = log1.lastCheckpoint.get


### PR DESCRIPTION
`data reader can read partition values` currently fails because SBT doesn't copy all of files in the table to the correct place. I tried with SBT with various changes and noticed that it won't copy files whose depth is high.

To workaround with the issue, I changed the code to read the tables in `golden-tables/` rather than asking SBT to copy files to `standalone/target/scala-2.12/test-classes/` and use files in this target folder.

As some of tests may need to modify files, I also add utility methods `withLogForWritableGoldenTable`, `withLogImplForWritableGoldenTable`, and `withWritableHiveGoldenTable` for these tests so that we can avoid modifying files in `golden-tables/` when running these tests.