### PR TITLE
Fix hive assembly JAR name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -179,7 +179,7 @@ lazy val hiveAssembly = (project in file("hive-assembly")) dependsOn(hive) setti
   skipReleaseSettings,
 
   assembly / logLevel := Level.Info,
-  assembly / assemblyJarName := s"${name.value}-assembly_${scalaBinaryVersion.value}-${version.value}.jar",
+  assembly / assemblyJarName := s"${name.value}_${scalaBinaryVersion.value}-${version.value}.jar",
   assembly / test := {},
   // Make the 'compile' invoke the 'assembly' task to generate the uber jar.
   Compile / packageBin := assembly.value

--- a/build.sbt
+++ b/build.sbt
@@ -173,7 +173,7 @@ lazy val hive = (project in file("hive")) dependsOn(standaloneCosmetic) settings
 )
 
 lazy val hiveAssembly = (project in file("hive-assembly")) dependsOn(hive) settings(
-  name := "hive-assembly",
+  name := "delta-hive-assembly",
   Compile / unmanagedJars += (hive / assembly).value,
   commonSettings,
   skipReleaseSettings,


### PR DESCRIPTION
Currently creates `hive-assembly-assembly_2.11-0.3.0.jar`