### PR TITLE
Fix `build.sbt` for flink connector release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -669,7 +669,7 @@ lazy val flinkConnector = (project in file("flink-connector"))
     name := "flink-connector",
     commonSettings,
     releaseSettings,
-    publishArtifact := scalaBinaryVersion.value == "2.12",
+    publishArtifact := scalaBinaryVersion.value == "2.12", // only publish once
     autoScalaLibrary := false, // exclude scala-library from dependencies
     Test / publishArtifact := false,
     pomExtra :=

--- a/build.sbt
+++ b/build.sbt
@@ -636,6 +636,7 @@ lazy val sqlDeltaImport = (project in file("sql-delta-import"))
   .settings (
     name := "sql-delta-import",
     commonSettings,
+    skipReleaseSettings,
     publishArtifact := scalaBinaryVersion.value != "2.11",
     Test / publishArtifact := false,
     libraryDependencies ++= Seq(
@@ -650,7 +651,6 @@ lazy val sqlDeltaImport = (project in file("sql-delta-import"))
       "org.apache.spark" % ("spark-sql_" + sqlDeltaImportScalaVersion(scalaBinaryVersion.value)) % "3.2.0" % "test"
     )
   )
-  .settings(releaseSettings)
 
 def flinkScalaVersion(scalaBinaryVersion: String): String = {
   scalaBinaryVersion match {
@@ -667,11 +667,11 @@ lazy val flinkConnector = (project in file("flink-connector"))
   .enablePlugins(GenJavadocPlugin, JavaUnidocPlugin)
   .settings (
     name := "flink-connector",
-    scalaVersion := "2.12.8",
     commonSettings,
-    publishArtifact := scalaBinaryVersion.value != "2.13",
-    Test / publishArtifact := false,
     releaseSettings,
+    publishArtifact := scalaBinaryVersion.value == "2.12",
+    autoScalaLibrary := false, // exclude scala-library from dependencies
+    Test / publishArtifact := false,
     pomExtra :=
       <url>https://github.com/delta-io/connectors</url>
         <scm>


### PR DESCRIPTION
- fixes `build.sbt` publishing the flink connector for two versions of scala, which caused a double publishing error
- adds `autoScalaLibrary := false` for flink connector which excludes `scala-lang` from the dependenceis
- halts release for `sql-delta-import` which will be waiting to release until next version
    - also needs `releaseSettings` moved up before updating any `releaseSettings` variables (was previously publishing for all 3 versions)