### PR TITLE
Flink integration tests check if table directory exists

### DIFF
--- a/examples/flink-example/src/main/java/DeltaSinkExampleBase.java
+++ b/examples/flink-example/src/main/java/DeltaSinkExampleBase.java
@@ -55,8 +55,10 @@ public abstract class DeltaSinkExampleBase implements DeltaSinkLocalJobRunner {
     void run(String tablePath) throws IOException, InterruptedException {
         System.out.println("Will use table path: " + tablePath);
         File tableDir = new File(tablePath);
-        if (tableDir.list().length > 0) {
+        if (tableDir.exists()) {
             FileUtils.cleanDirectory(tableDir);
+        } else {
+            tableDir.mkdirs();
         }
         StreamExecutionEnvironment env = getFlinkStreamExecutionEnvironment(tablePath);
         runFlinkJobInBackground(env);


### PR DESCRIPTION
Thought I accidentally deleted necessary folder structure in #305 by removing the `.gitkeep`s in `examples/flink-example/src/main/resources/...` but realized the integration test actually deletes them when running. Without them, we get a `NullPointerException` because the folders don't exist.

Instead updated the test to first check if the directory exists, and then either clear it or create it accordingly.