### PR TITLE
Flink Delta Sink - fix cluster deployment issue for the Flink Delta Sink 

### DIFF
--- a/flink/README.md
+++ b/flink/README.md
@@ -227,42 +227,49 @@ their compatibility. If this check fails (e.g. the change consisted of removing 
 
 ## Known issues:
 
-- Due to the dependency conflict with some Apache Flink's packages, it may be needed to shade
+- (As of 0.4.0) Due to a dependency conflict with some Apache Flink packages, it may be necessary to shade
   classes from `org.apache.flink.streaming.api.functions.sink.filesystem` package when producing a fat-jar
   with a Flink job that uses this connector before deploying it to a Flink cluster.
-  Here's example configuration for achieving this:
+  
+  If that package is not shaded, you may experience errors like the following:
+  
+  ```
+  Caused by: java.lang.IllegalAccessError: tried to access method org.apache.flink.streaming.api.functions.sink.filesystem.OutputStreamBasedPartFileWriter.<init>(Ljava/lang/Object;Lorg/apache/flink/core/fs/RecoverableFsDataOutputStream;J)V from class org.apache.flink.streaming.api.functions.sink.filesystem.DeltaBulkPartWriter
+  ```
+  
+  Here is an example configuration for achieving this:
 
-```xml
-<plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-shade-plugin</artifactId>
-    <version>3.3.0</version>
-    <executions>
-        <execution>
-            <phase>package</phase>
-            <goals>
-                <goal>shade</goal>
-            </goals>
-            <configuration>
-                <shadedArtifactAttached>true</shadedArtifactAttached>
-                <relocations>
-                    <relocation>
-                        <pattern>org.apache.flink.streaming.api.functions.sink.filesystem</pattern>
-                        <shadedPattern>shaded.org.apache.flink.streaming.api.functions.sink.filesystem</shadedPattern>
-                    </relocation>
-                </relocations>
-                <filters>
-                    <filter>
-                        <artifact>*:*</artifact>
-                        <excludes>
-                            <exclude>META-INF/*.SF</exclude>
-                            <exclude>META-INF/*.DSA</exclude>
-                            <exclude>META-INF/*.RSA</exclude>
-                        </excludes>
-                    </filter>
-                </filters>
-            </configuration>
-        </execution>
-    </executions>
-</plugin>
-```
+  ```xml
+  <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-shade-plugin</artifactId>
+      <version>3.3.0</version>
+      <executions>
+          <execution>
+              <phase>package</phase>
+              <goals>
+                  <goal>shade</goal>
+              </goals>
+              <configuration>
+                  <shadedArtifactAttached>true</shadedArtifactAttached>
+                  <relocations>
+                      <relocation>
+                          <pattern>org.apache.flink.streaming.api.functions.sink.filesystem</pattern>
+                          <shadedPattern>shaded.org.apache.flink.streaming.api.functions.sink.filesystem</shadedPattern>
+                      </relocation>
+                  </relocations>
+                  <filters>
+                      <filter>
+                          <artifact>*:*</artifact>
+                          <excludes>
+                              <exclude>META-INF/*.SF</exclude>
+                              <exclude>META-INF/*.DSA</exclude>
+                              <exclude>META-INF/*.RSA</exclude>
+                          </excludes>
+                      </filter>
+                  </filters>
+              </configuration>
+          </execution>
+      </executions>
+  </plugin>
+  ```


### PR DESCRIPTION
Resolves #321 

Due to a conflict with default Flink cluster libraries, deployed Flink jobs that are using Flink Delta Sink may be experiencing following error:
```
Caused by: java.lang.IllegalAccessError: tried to access method org.apache.flink.streaming.api.functions.sink.filesystem.OutputStreamBasedPartFileWriter.<init>(Ljava/lang/Object;Lorg/apache/flink/core/fs/RecoverableFsDataOutputStream;J)V from class org.apache.flink.streaming.api.functions.sink.filesystem.DeltaBulkPartWriter
```

Above can be only fixed by shading the affected package.
The reason for the above is package private constructor in the `OutputStreamBasedPartFileWriter` class which exists in both: Flink's job fat jar and cluster default's libraries and the Flink's classloading precedence which causes an unallowed access to a class loaded from external jar.

This PR fixes above issue by removing inheritance from `OutputStreamBasedPartFileWriter` class and copying it's original methods.