### PR TITLE
use dummy_col to simply the creating-table syntax

### DIFF
--- a/hive-test/src/test/scala/io/delta/hive/HiveConnectorTest.scala
+++ b/hive-test/src/test/scala/io/delta/hive/HiveConnectorTest.scala
@@ -462,9 +462,9 @@ abstract class HiveConnectorTest extends HiveTest with BeforeAndAfterEach {
             "dummy_col array<string>"
           } else {
             s"""
-               |c1 tinyint, c2 binary, c3 boolean, c4 int, c5 bigint, c6 string, c7 float, c8 double,
-               |c9 smallint, c10 date, c11 timestamp, c12 decimal(38, 18), c13 array<string>,
-               |c14 map<string, bigint>, c15 struct<f1: string, f2: bigint>
+               |c1 tinyint, c2 binary, c3 boolean, c4 int, c5 bigint, c6 string, c7 float,
+               |c8 double, c9 smallint, c10 date, c11 timestamp, c12 decimal(38, 18),
+               |c13 array<string>, c14 map<string, bigint>, c15 struct<f1: string, f2: bigint>
                |""".stripMargin
           }
           runQuery(

--- a/hive/src/main/scala/io/delta/hive/DeltaStorageHandler.scala
+++ b/hive/src/main/scala/io/delta/hive/DeltaStorageHandler.scala
@@ -216,7 +216,7 @@ class DeltaStorageHandler extends DefaultStorageHandler with HiveMetaHook
     // Extract the table schema in Hive to compare it with the latest table schema in Delta logs,
     // and fail the query if it was changed.
     val cols = tbl.getSd.getCols
-    if (!needExtractSchemaFromDelta(cols.asScala)) {
+    if (!needExtractSchemaFromDelta(cols.asScala.toSeq)) {
       val cols = tbl.getSd.getCols
       val columnNames = new JArrayList[String](cols.size)
       val columnTypes = new JArrayList[TypeInfo](cols.size)

--- a/standalone/src/main/java/io/delta/standalone/types/ArrayType.java
+++ b/standalone/src/main/java/io/delta/standalone/types/ArrayType.java
@@ -56,6 +56,11 @@ public final class ArrayType extends DataType {
         this.containsNull = containsNull;
     }
 
+    @Override
+    public String getCatalogString() {
+        return String.format("array<%s>", elementType.getCatalogString());
+    }
+
     /**
      * @return the type of array elements
      */

--- a/standalone/src/main/java/io/delta/standalone/types/DecimalType.java
+++ b/standalone/src/main/java/io/delta/standalone/types/DecimalType.java
@@ -75,6 +75,11 @@ public final class DecimalType extends DataType {
     }
 
     @Override
+    public String getCatalogString() {
+        return String.format("decimal(%s,%s)", precision, scale);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/standalone/src/main/java/io/delta/standalone/types/MapType.java
+++ b/standalone/src/main/java/io/delta/standalone/types/MapType.java
@@ -73,6 +73,12 @@ public final class MapType extends DataType {
         return valueType;
     }
 
+    @Override
+    public String getCatalogString() {
+        return String.format("map<%s,%s>",
+            keyType.getCatalogString(), valueType.getCatalogString());
+    }
+
     /**
      * @return {@code true} if this map has null values, else {@code false}
      */

--- a/standalone/src/main/java/io/delta/standalone/types/StructType.java
+++ b/standalone/src/main/java/io/delta/standalone/types/StructType.java
@@ -64,6 +64,23 @@ public final class StructType extends DataType {
         Arrays.stream(fields).forEach(field -> nameToField.put(field.getName(), field));
     }
 
+    @Override
+    public String getCatalogString() {
+        StringBuilder sb = new StringBuilder();
+        int len = fields.length;
+        sb.append("struct<");
+        int i = 0;
+        while (i < len) {
+            sb.append(fields[i].getName())
+                .append(":")
+                .append(fields[i].getDataType().getCatalogString());
+            i += 1;
+            if (i < len) sb.append(",");
+        }
+        sb.append(">");
+        return sb.toString();
+    }
+
     /**
      * Creates a new {@link StructType} by adding a new field.
      *


### PR DESCRIPTION
when we create external delta table in Hive, we have to provide the all columns with the right name and the right data type.
here, we can just use `dummy_col array<string>` to simply and make it work. The SQL like: 

`
CREATE TABLE table_name (dummy_col array<string>) STORED BY 'io.delta.hive.DeltaStorageHandler' LOCATION "/path/to/delta";
`