### PR TITLE
Flink Delta Sink - add Flink metrics to the DeltaSink

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -695,6 +695,7 @@ lazy val flink = (project in file("flink"))
       "org.apache.flink" % "flink-connector-test-utils" % flinkVersion % "test",
       "org.apache.flink" % ("flink-clients_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "test",
       "com.github.sbt" % "junit-interface" % "0.12" % Test,
+      "org.mockito" % "mockito-core" % "4.5.1" % Test,
 
       // Compiler plugins
       // -- Bump up the genjavadoc version explicitly to 0.18 to work with Scala 2.12

--- a/flink/README.md
+++ b/flink/README.md
@@ -27,6 +27,16 @@ utilizing [Delta Standalone JVM library](https://github.com/delta-io/connectors#
 - The current version only supports Flink `Datastream` API. Support for Flink Table API / SQL, along with Flink Catalog's implementation for storing Delta table's metadata in an external metastore, are planned to be added in the next releases.
 - The current version only provides Delta Lake's transactional guarantees for tables stored on HDFS and Microsoft Azure Storage.
 
+### Flink metrics
+#### Delta Sink
+Delta Sink currently exposes following Flink metrics:
+
+| metric name |                                        description                                        | update interval |
+|:-----------:|:-----------------------------------------------------------------------------------------:|:---------------:|
+|    DeltaSinkRecordsOut    |                  Counter for how many records were processed by the sink                  | on every record |
+|    DeltaSinkRecordsWritten    |     Counter for how many records were written to the actual files on the file system      |  on checkpoint  |
+|    DeltaSinkBytesWritten    | Counter for how many bytes were written to the actual files on the underlying file system |  on checkpoint  |
+
 ## Java API docs
 See the [Java API docs](https://delta-io.github.io/connectors/latest/delta-flink/api/java/index.html) here.
 

--- a/flink/src/main/java/io/delta/flink/sink/internal/DeltaSinkBuilder.java
+++ b/flink/src/main/java/io/delta/flink/sink/internal/DeltaSinkBuilder.java
@@ -311,6 +311,7 @@ public class DeltaSinkBuilder<IN> implements Serializable {
             rollingPolicy,
             outputFileConfig,
             context.getProcessingTimeService(),
+            context.metricGroup(),
             bucketCheckInterval,
             appId,
             nextCheckpointId);

--- a/flink/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/DeltaBulkPartWriter.java
+++ b/flink/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/DeltaBulkPartWriter.java
@@ -62,7 +62,8 @@ import org.apache.flink.util.Preconditions;
  *
  * <p>
  * This class is almost exact copy of {@link OutputStreamBasedPartFileWriter}. The only modified
- * behaviour is extending {@link this#closeWriter()} method with flushing of the internal buffer.
+ * behaviour is extending {@link DeltaBulkPartWriter#closeWriter()} method with flushing of the
+ * internal buffer.
  *
  * @param <IN>       The type of input elements.
  * @param <BucketID> The type of bucket identifier


### PR DESCRIPTION
this PR resolves #318 

Besides the unit tests in this PR, correctness of the metrics was also validated by deploying a Flink job with DeltaSink (build with the commit from this PR) to a Flink cluster and visually checking the metrics in the Flink UI.

![Screenshot from 2022-04-23 22-27-47](https://user-images.githubusercontent.com/91378169/165149161-181f7af5-7ba3-4354-851d-de035c4c31a4.png)
