### PR TITLE
[324] Fix examples

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -734,6 +734,7 @@ lazy val flink = (project in file("flink"))
       "-windowtitle", "Flink/Delta Connector " + version.value.replaceAll("-SNAPSHOT", "") + " JavaDoc",
       "-noqualifier", "java.lang",
       "-tag", "implNote:a:Implementation Note:",
+      "-tag", "apiNote:a:API Note:",
       "-Xdoclint:all"
     ),
     Compile / doc / javacOptions := (JavaUnidoc / unidoc / javacOptions).value,

--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -38,7 +38,7 @@ def getStandaloneVersion(): String = {
     println("Using Delta version " + version)
     version
   } else {
-    "0.3.0"
+    "0.4.0"
   }
 }
 

--- a/examples/convert-to-delta/pom.xml
+++ b/examples/convert-to-delta/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.-->
         <maven.compiler.target>1.8</maven.compiler.target>
         <staging.repo.url>""</staging.repo.url>
         <scala.version>2.12</scala.version>
-        <standalone.version>0.3.0</standalone.version>
+        <standalone.version>0.4.0</standalone.version>
     </properties>
 
     <repositories>

--- a/examples/convert-to-delta/src/main/java/example/ConvertToDelta.java
+++ b/examples/convert-to-delta/src/main/java/example/ConvertToDelta.java
@@ -55,6 +55,22 @@ import org.apache.hadoop.fs.Path;
  * To run with SBT:
  * - cd connectors/examples
  * - build/sbt "convertToDelta/runMain example.ConvertToDelta"
+ * - If you encounter any sort of errors like
+ *      ```
+ *      sbt.ResolveException: unresolved dependency: javax.servlet#javax.servlet-api;3.1.0
+ *      ```
+ *   then clear your ~/.ivy2/cache/io.delta
+ *
+ * To run with IntelliJ:
+ * - make sure that this `convert-to-delta` folder is marked as a Module in IntelliJ.
+ *   e.g. File > Project Structure... > Modules > '+' > Import Module >
+ *        Create module from existing sources
+ *
+ * - then, mark the parent `java` folder as Sources Root.
+ *   e.g. right click on `java` > Mark Directory as > Sources Root
+ *
+ * - then, import `pom.xml` as a Maven project.
+ *   e.g. right click on `pom.xml` > Add as Maven Project
  *
  * Find the converted table in: target/classes/$targetTable
  */

--- a/examples/hello-world/pom.xml
+++ b/examples/hello-world/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.-->
         <maven.compiler.target>1.8</maven.compiler.target>
         <staging.repo.url>""</staging.repo.url>
         <scala.version>2.12</scala.version>
-        <standalone.version>0.3.0</standalone.version>
+        <standalone.version>0.4.0</standalone.version>
     </properties>
 
     <repositories>

--- a/examples/hello-world/src/main/java/example/HelloWorld.java
+++ b/examples/hello-world/src/main/java/example/HelloWorld.java
@@ -46,6 +46,22 @@ import io.delta.standalone.types.StructType;
  * To run with SBT:
  * - cd connectors/examples
  * - build/sbt "helloWorld/runMain example.HelloWorld"
+ * - If you encounter any sort of errors like
+ *      ```
+ *      sbt.ResolveException: unresolved dependency: javax.servlet#javax.servlet-api;3.1.0
+ *      ```
+ *   then clear your ~/.ivy2/cache/io.delta
+ *
+ * To run with IntelliJ:
+ * - make sure that this `hello-world` folder is marked as a Module in IntelliJ.
+ *   e.g. File > Project Structure... > Modules > '+' > Import Module >
+ *        Create module from existing sources
+ *
+ * - then, mark the parent `java` folder as Sources Root.
+ *   e.g. right click on `java` > Mark Directory as > Sources Root
+ *
+ * - then, import `pom.xml` as a Maven project.
+ *   e.g. right click on `pom.xml` > Add as Maven Project
  */
 public class HelloWorld {
     public static void main(String[] args) throws IOException {
@@ -88,6 +104,7 @@ public class HelloWorld {
                         .build();
 
                 txn.commit(Collections.singletonList(addFile), op, engineInfo);
+                System.out.println(String.format("Committed version %d", i));
             }
 
             DeltaLog log2 = DeltaLog.forTable(new Configuration(), tmpDirPath);
@@ -99,6 +116,7 @@ public class HelloWorld {
 
             for (int i = 0; i < 15; i++) {
                 if (!pathVals.contains(i)) throw new RuntimeException();
+                System.out.println(String.format("Read version %d", i));
             }
 
         } finally {

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -96,7 +96,8 @@ class WorkingDirectory(object):
 if __name__ == "__main__":
     """
     Script to run integration tests which are located in the examples directory.
-    Call this by running "python3 run-examples.py".
+    Call this by running "python3 run-examples.py --version <version>", where <version> is the
+    Delta Connectors repo version to use.
     
     There are two version 'modes' you should use to run this file.
     1. using published or staged jar: explicitly pass in the --version argument.

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -96,17 +96,28 @@ class WorkingDirectory(object):
 if __name__ == "__main__":
     """
     Script to run integration tests which are located in the examples directory.
-    call this by running "python3 run-integration-tests.py"
-    additionally the version can be provided as a command line argument.
+    Call this by running "python3 run-examples.py".
+    
+    There are two version 'modes' you should use to run this file.
+    1. using published or staged jar: explicitly pass in the --version argument.
+    2. using locally-generated jar (e.g. 0.4.0-SNAPSHOT): explicitly pass in the --version argument
+       and --use-local-cache argument.
+       
+       In this mode, ensure that the local jar exists for all scala versions. You can generate it
+       by running the following commands in the root connectors folder.
+       
+       build/sbt '++2.11.12 publishM2'
+       build/sbt '++2.12.8 publishM2'
+       build/sbt '++2.13.8 publishM2'
     """
 
+    # get the version of the package
     root_dir = path.dirname(__file__)
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--version",
-        required=False,
-        default="0.3.0",
+        required=True,
         help="Delta Standalone version to use to run the integration tests")
     parser.add_argument(
         "--maven-repo",


### PR DESCRIPTION
- resolves #324 
- refactor some example classes (e.g. to `example` folder)
- update class comments for how to run in IntelliJ
- update `run_examples.py` with how to run locally vs with staged jar
- fix flink `publishM2` javadoc error due to missing javadoc annotation