### PR TITLE
Automatically select LogStore based on path scheme by adding DelegatingLogStore

### DIFF
--- a/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
@@ -26,6 +26,7 @@ import io.delta.standalone.exceptions._
 import io.delta.standalone.types.{DataType, StructType}
 
 import io.delta.standalone.internal.actions.{CommitInfo, Protocol}
+import io.delta.standalone.internal.sources.StandaloneHadoopConf
 import io.delta.standalone.internal.util.JsonUtils
 
 /** A holder object for Delta errors. */
@@ -322,6 +323,13 @@ private[internal] object DeltaErrors {
       realTypes: String*): RuntimeException = {
     new IllegalArgumentException(
       s"$exprName expression requires $expectedType type. But found ${realTypes.mkString(", ")}");
+  }
+
+  def logStoreConfConflicts(schemeConf: Seq[String]): Throwable = {
+    val schemeConfStr = schemeConf.mkString(", ")
+    new IllegalArgumentException(
+      s"(`${StandaloneHadoopConf.LOG_STORE_CLASS_KEY}`) and (`${schemeConfStr}`)" +
+        " cannot be set at the same time. Please set only one group of them.")
   }
 
   ///////////////////////////////////////////////////////////////////////////

--- a/standalone/src/main/scala/io/delta/standalone/internal/storage/DelegatingLogStore.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/storage/DelegatingLogStore.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright (2020-present) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.standalone.internal.storage
+
+import java.util.Locale
+import scala.collection.mutable
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, Path}
+
+import io.delta.standalone.data.CloseableIterator
+import io.delta.standalone.storage.LogStore
+
+import io.delta.standalone.internal.logging.Logging
+
+/**
+ * A delegating LogStore used to dynamically resolve LogStore implementation based
+ * on the scheme of paths.
+ */
+class DelegatingLogStore(hadoopConf: Configuration)
+  extends LogStore(hadoopConf)
+  with Logging {
+
+  // Map scheme to the corresponding LogStore resolved and created. Accesses to this map need
+  // synchronization This could be accessed by multiple threads because it is shared through
+  // shared DeltaLog instances.
+  private val schemeToLogStoreMap = mutable.Map.empty[String, LogStore]
+
+  private lazy val defaultLogStore = createLogStore(DelegatingLogStore.defaultHDFSLogStoreClassName)
+
+  // Creates a LogStore with given LogStore class name.
+  private def createLogStore(className: String): LogStore = {
+    LogStoreProvider.createLogStoreWithClassName(className, hadoopConf)
+  }
+
+  // Create LogStore based on the scheme of `path`.
+  private def schemeBasedLogStore(path: Path): LogStore = {
+    Option(path.toUri.getScheme) match {
+      case Some(origScheme) =>
+        val scheme = origScheme.toLowerCase(Locale.ROOT)
+        this.synchronized {
+          if (schemeToLogStoreMap.contains(scheme)) {
+            schemeToLogStoreMap(scheme)
+          } else {
+            // Resolve LogStore class based on the following order:
+            // 1. Scheme conf if set.
+            // 2. Defaults for scheme if exists.
+            // 3. Default.
+            val logStoreClassNameOpt = Option(
+              hadoopConf.get(LogStoreProvider.logStoreSchemeConfKey(scheme))
+            ).orElse(DelegatingLogStore.getDefaultLogStoreClassName(scheme))
+
+            val logStore = logStoreClassNameOpt.map(createLogStore(_)).getOrElse(defaultLogStore)
+            schemeToLogStoreMap += scheme -> logStore
+            logInfo(s"LogStore ${logStore.getClass.getName} is used for scheme ${scheme}")
+            logStore
+          }
+        }
+      case _ => defaultLogStore
+    }
+  }
+
+  def getDelegate(path: Path): LogStore = schemeBasedLogStore(path)
+
+  //////////////////////////
+  // Public API Overrides //
+  //////////////////////////
+
+  override def read(path: Path, hadoopConf: Configuration): CloseableIterator[String] = {
+    getDelegate(path).read(path, hadoopConf)
+  }
+
+  override def write(
+      path: Path,
+      actions: java.util.Iterator[String],
+      overwrite: java.lang.Boolean,
+      hadoopConf: Configuration): Unit = {
+    getDelegate(path).write(path, actions, overwrite, hadoopConf)
+  }
+
+  override def listFrom(path: Path, hadoopConf: Configuration): java.util.Iterator[FileStatus] = {
+    getDelegate(path).listFrom(path, hadoopConf)
+  }
+
+  override def resolvePathOnPhysicalStorage(path: Path, hadoopConf: Configuration): Path = {
+    getDelegate(path).resolvePathOnPhysicalStorage(path, hadoopConf)
+  }
+
+  override def isPartialWriteVisible(path: Path, hadoopConf: Configuration): java.lang.Boolean = {
+    getDelegate(path).isPartialWriteVisible(path, hadoopConf)
+  }
+}
+
+object DelegatingLogStore {
+
+  val defaultS3LogStoreClassName = classOf[S3SingleDriverLogStore].getName
+  val defaultAzureLogStoreClassName = classOf[AzureLogStore].getName
+  val defaultHDFSLogStoreClassName = classOf[HDFSLogStore].getName
+
+  // Supported schemes with default.
+  val s3Schemes = Set("s3", "s3a", "s3n")
+  val azureSchemes = Set("abfs", "abfss", "adl", "wasb", "wasbs")
+
+  // Returns the default LogStore class name for `scheme`.
+  // None if we do not have a default for it.
+  def getDefaultLogStoreClassName(scheme: String): Option[String] = {
+    if (s3Schemes.contains(scheme)) {
+      return Some(defaultS3LogStoreClassName)
+    } else if (DelegatingLogStore.azureSchemes(scheme: String)) {
+      return Some(defaultAzureLogStoreClassName)
+    }
+    None
+  }
+}
+

--- a/standalone/src/main/scala/io/delta/standalone/internal/storage/DelegatingLogStore.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/storage/DelegatingLogStore.scala
@@ -17,6 +17,7 @@
 package io.delta.standalone.internal.storage
 
 import java.util.Locale
+
 import scala.collection.mutable
 
 import org.apache.hadoop.conf.Configuration

--- a/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
@@ -33,7 +33,6 @@ private[internal] trait LogStoreProvider {
   val logStoreClassConfKey: String = StandaloneHadoopConf.LOG_STORE_CLASS_KEY
   val defaultLogStoreClass: String = classOf[DelegatingLogStore].getName
 
-  // TODO: is this the key we want?
   // The conf key for setting the LogStore implementation for `scheme`.
   def logStoreSchemeConfKey(scheme: String): String = s"io.delta.standalone.logStore.${scheme}.impl"
 

--- a/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
@@ -34,7 +34,7 @@ private[internal] trait LogStoreProvider {
   val defaultLogStoreClass: String = classOf[DelegatingLogStore].getName
 
   // The conf key for setting the LogStore implementation for `scheme`.
-  def logStoreSchemeConfKey(scheme: String): String = s"io.delta.standalone.logStore.${scheme}.impl"
+  def logStoreSchemeConfKey(scheme: String): String = s"delta.logStore.${scheme}.impl"
 
   def createLogStore(hadoopConf: Configuration): LogStore = {
     checkLogStoreConfConflicts(hadoopConf)
@@ -65,7 +65,7 @@ private[internal] trait LogStoreProvider {
 
   def checkLogStoreConfConflicts(hadoopConf: Configuration): Unit = {
     val classConf = Option(hadoopConf.get(logStoreClassConfKey))
-    val schemeConf = hadoopConf.getValByRegex("""io\.delta\.standalone\.logStore\.\w+\.impl""")
+    val schemeConf = hadoopConf.getValByRegex("""delta\.logStore\.\w+\.impl""")
 
     if (classConf.nonEmpty && !schemeConf.isEmpty()) {
       throw DeltaErrors.logStoreConfConflicts(schemeConf.keySet().asScala.toSeq)

--- a/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
@@ -16,36 +16,60 @@
 
 package io.delta.standalone.internal.storage
 
+import scala.collection.JavaConverters._
+
 import org.apache.hadoop.conf.Configuration
 
 import io.delta.standalone.exceptions.DeltaStandaloneException
 import io.delta.standalone.storage.LogStore
 
+import io.delta.standalone.internal.exception.DeltaErrors
 import io.delta.standalone.internal.sources.StandaloneHadoopConf
 
 private[internal] object LogStoreProvider extends LogStoreProvider
 
 private[internal] trait LogStoreProvider {
 
-  val defaultLogStoreClassName: String = classOf[HDFSLogStore].getName
+  val logStoreClassConfKey: String = StandaloneHadoopConf.LOG_STORE_CLASS_KEY
+  val defaultLogStoreClass: String = classOf[DelegatingLogStore].getName
+
+  // TODO: is this the key we want?
+  // The conf key for setting the LogStore implementation for `scheme`.
+  def logStoreSchemeConfKey(scheme: String): String = s"io.delta.standalone.logStore.${scheme}.impl"
 
   def createLogStore(hadoopConf: Configuration): LogStore = {
-    val logStoreClassName =
-      hadoopConf.get(StandaloneHadoopConf.LOG_STORE_CLASS_KEY, defaultLogStoreClassName)
+    checkLogStoreConfConflicts(hadoopConf)
+    val logStoreClassName = hadoopConf.get(logStoreClassConfKey, defaultLogStoreClass)
+    createLogStoreWithClassName(logStoreClassName, hadoopConf)
+  }
 
-    // scalastyle:off classforname
-    val logStoreClass =
-      Class.forName(logStoreClassName, true, Thread.currentThread().getContextClassLoader)
-    // scalastyle:on classforname
-
-    if (classOf[LogStore].isAssignableFrom(logStoreClass)) {
-      logStoreClass
-        .getConstructor(classOf[Configuration])
-        .newInstance(hadoopConf)
-        .asInstanceOf[LogStore]
+  def createLogStoreWithClassName(className: String, hadoopConf: Configuration): LogStore = {
+    if (className == classOf[DelegatingLogStore].getName) {
+      new DelegatingLogStore(hadoopConf)
     } else {
-      throw new DeltaStandaloneException(s"Can't instantiate a LogStore with classname " +
-        s"$logStoreClassName.")
+      // scalastyle:off classforname
+      val logStoreClass =
+        Class.forName(className, true, Thread.currentThread().getContextClassLoader)
+      // scalastyle:on classforname
+
+      if (classOf[LogStore].isAssignableFrom(logStoreClass)) {
+        logStoreClass
+          .getConstructor(classOf[Configuration])
+          .newInstance(hadoopConf)
+          .asInstanceOf[LogStore]
+      } else {
+        throw new DeltaStandaloneException(s"Can't instantiate a LogStore with classname " +
+          s"$className.")
+      }
+    }
+  }
+
+  def checkLogStoreConfConflicts(hadoopConf: Configuration): Unit = {
+    val classConf = Option(hadoopConf.get(logStoreClassConfKey))
+    val schemeConf = hadoopConf.getValByRegex("""io\.delta\.standalone\.logStore\.\w+\.impl""")
+
+    if (classConf.nonEmpty && !schemeConf.isEmpty()) {
+      throw DeltaErrors.logStoreConfConflicts(schemeConf.keySet().asScala.toSeq)
     }
   }
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DelegatingLogStoreSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DelegatingLogStoreSuite.scala
@@ -73,7 +73,7 @@ class DelegatingLogStoreSuite extends FunSuite {
         DelegatingLogStore.defaultHDFSLogStoreClassName,
         customLogStoreClassName
       )) {
-        // we set io.delta.standalone.logStore.${scheme}.impl -> $store
+        // we set delta.logStore.${scheme}.impl -> $store
         testDelegatingLogStore(scheme, Some(store), store)
       }
     }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DelegatingLogStoreSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DelegatingLogStoreSuite.scala
@@ -73,7 +73,7 @@ class DelegatingLogStoreSuite extends FunSuite {
         DelegatingLogStore.defaultHDFSLogStoreClassName,
         customLogStoreClassName
       )) {
-        // we set spark.delta.logStore.${scheme}.impl -> $store
+        // we set io.delta.standalone.logStore.${scheme}.impl -> $store
         testDelegatingLogStore(scheme, Some(store), store)
       }
     }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DelegatingLogStoreSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DelegatingLogStoreSuite.scala
@@ -16,10 +16,9 @@
 
 package io.delta.standalone.internal
 
-import org.scalatest.FunSuite
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.scalatest.FunSuite
 
 import io.delta.standalone.internal.storage.{DelegatingLogStore, LogStoreProvider}
 

--- a/standalone/src/test/scala/io/delta/standalone/internal/DelegatingLogStoreSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DelegatingLogStoreSuite.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (2020-present) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.standalone.internal
+
+import org.scalatest.FunSuite
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import io.delta.standalone.internal.storage.{DelegatingLogStore, LogStoreProvider}
+
+class DelegatingLogStoreSuite extends FunSuite {
+
+  private val customLogStoreClassName = classOf[UserDefinedLogStore].getName
+
+  private def fakeSchemeWithNoDefault = "fake"
+
+  /**
+   * Test DelegatingLogStore by directly creating a DelegatingLogStore and test LogStore
+   * resolution based on input `scheme`. This is not an end-to-end test.
+   *
+   * @param scheme The scheme to be used for testing.
+   * @param schemeConf The scheme conf value to be set. If None, scheme conf will be unset.
+   * @param expClassName Expected LogStore class name resolved by DelegatingLogStore.
+   */
+  private def testDelegatingLogStore(
+      scheme: String,
+      schemeConf: Option[String],
+      expClassName: String): Unit = {
+
+    val hadoopConf = new Configuration()
+    val schemeConfKey = LogStoreProvider.logStoreSchemeConfKey(scheme)
+    schemeConf.map(hadoopConf.set(schemeConfKey, _))
+
+    val delegatingLogStore = new DelegatingLogStore(hadoopConf)
+    val actualLogStore = delegatingLogStore.getDelegate(
+      new Path(s"${scheme}://dummy")
+    )
+    assert(actualLogStore.getClass.getName == expClassName)
+  }
+
+  test("DelegatingLogStore resolution using default scheme confs") {
+    for (scheme <- DelegatingLogStore.s3Schemes) {
+      testDelegatingLogStore(scheme, None, DelegatingLogStore.defaultS3LogStoreClassName)
+    }
+    for (scheme <- DelegatingLogStore.azureSchemes) {
+      testDelegatingLogStore(scheme, None, DelegatingLogStore.defaultAzureLogStoreClassName)
+    }
+    testDelegatingLogStore(fakeSchemeWithNoDefault, None,
+      DelegatingLogStore.defaultHDFSLogStoreClassName)
+  }
+
+  test("DelegatingLogStore resolution using customized scheme confs") {
+    val allTestSchemes = DelegatingLogStore.s3Schemes ++ DelegatingLogStore.azureSchemes +
+      fakeSchemeWithNoDefault
+    for (scheme <- allTestSchemes) {
+      for (store <- Seq(
+        DelegatingLogStore.defaultS3LogStoreClassName,
+        DelegatingLogStore.defaultAzureLogStoreClassName,
+        DelegatingLogStore.defaultHDFSLogStoreClassName,
+        customLogStoreClassName
+      )) {
+        // we set spark.delta.logStore.${scheme}.impl -> $store
+        testDelegatingLogStore(scheme, Some(store), store)
+      }
+    }
+  }
+}

--- a/standalone/src/test/scala/io/delta/standalone/internal/LogStoreProviderSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/LogStoreProviderSuite.scala
@@ -16,9 +16,8 @@
 
 package io.delta.standalone.internal
 
-import org.scalatest.FunSuite
-
 import org.apache.hadoop.conf.Configuration
+import org.scalatest.FunSuite
 
 import io.delta.standalone.exceptions.DeltaStandaloneException
 

--- a/standalone/src/test/scala/io/delta/standalone/internal/LogStoreProviderSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/LogStoreProviderSuite.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (2020-present) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.standalone.internal
+
+import org.scalatest.FunSuite
+
+import org.apache.hadoop.conf.Configuration
+
+import io.delta.standalone.exceptions.DeltaStandaloneException
+
+import io.delta.standalone.internal.storage.{DelegatingLogStore, LogStoreProvider}
+
+class LogStoreProviderSuite extends FunSuite {
+
+  private def fakeSchemeWithNoDefault = "fake"
+  private val customLogStoreClassName = classOf[UserDefinedLogStore].getName
+
+  private def newHadoopConf(confs: Seq[(String, String)]): Configuration = {
+    val hadoopConf = new Configuration()
+    confs.foreach{ case (key, value) => hadoopConf.set(key, value)}
+    hadoopConf
+  }
+
+  private def testClassAndSchemeConfSet(scheme: String, classConf: String, schemeConf: String)
+    : Unit = {
+
+    val classConfKey = LogStoreProvider.logStoreClassConfKey
+    val schemeConfKey = LogStoreProvider.logStoreSchemeConfKey(scheme)
+    val hadoopConf = newHadoopConf(
+      Seq((classConfKey, classConf), (schemeConfKey, schemeConf))
+    )
+
+    val e = intercept[IllegalArgumentException](
+      LogStoreProvider.createLogStore(hadoopConf)
+    )
+    assert(e.getMessage.contains(
+      "(`io.delta.standalone.LOG_STORE_CLASS_KEY`) and " +
+        f"(`${LogStoreProvider.logStoreSchemeConfKey(scheme)}`) cannot be set at the same time"
+    ))
+  }
+
+  test("class-conf = set, scheme has no default, scheme-conf = set") {
+    testClassAndSchemeConfSet(fakeSchemeWithNoDefault, customLogStoreClassName,
+      DelegatingLogStore.defaultAzureLogStoreClassName
+    )
+  }
+
+  test("class-conf = set, scheme has default, scheme-conf = set") {
+    testClassAndSchemeConfSet("s3a", customLogStoreClassName,
+      DelegatingLogStore.defaultAzureLogStoreClassName
+    )
+  }
+
+  test("DelegatingLogStore is default") {
+    val hadoopConf = new Configuration()
+    assert(LogStoreProvider.createLogStore(hadoopConf).getClass.getName
+      == "io.delta.standalone.internal.storage.DelegatingLogStore")
+  }
+
+  test("Set class Conf to class that doesn't extend LogStore") {
+    val hadoopConf = newHadoopConf(
+      Seq((LogStoreProvider.logStoreClassConfKey, "io.delta.standalone.DeltaLog")))
+    val e = intercept[DeltaStandaloneException](
+      LogStoreProvider.createLogStore(hadoopConf)
+    )
+    assert(e.getMessage.contains(
+      "Can't instantiate a LogStore with classname io.delta.standalone.DeltaLog"
+    ))
+  }
+
+  test("Set scala class with class Conf") {
+    val hadoopConf = newHadoopConf(
+      Seq((LogStoreProvider.logStoreClassConfKey,
+        "io.delta.standalone.internal.storage.AzureLogStore")))
+    assert(LogStoreProvider.createLogStore(hadoopConf).getClass.getName
+      == "io.delta.standalone.internal.storage.AzureLogStore")
+  }
+
+  // todo: set delta-storage class with class Conf
+}

--- a/standalone/src/test/scala/io/delta/standalone/internal/LogStoreSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/LogStoreSuite.scala
@@ -26,11 +26,11 @@ import org.scalatest.FunSuite
 
 import io.delta.standalone.Operation
 import io.delta.standalone.actions.{AddFile => AddFileJ, Metadata => MetadataJ}
-import io.delta.standalone.data.{CloseableIterator => CloseableIteratorJ}
+import io.delta.standalone.data.CloseableIterator
 import io.delta.standalone.storage.LogStore
 
 import io.delta.standalone.internal.sources.StandaloneHadoopConf
-import io.delta.standalone.internal.storage.{AzureLogStore, HDFSLogStore, LocalLogStore, LogStoreProvider, S3SingleDriverLogStore}
+import io.delta.standalone.internal.storage.{AzureLogStore, DelegatingLogStore, HDFSLogStore, LocalLogStore, LogStoreProvider, S3SingleDriverLogStore}
 import io.delta.standalone.internal.util.TestUtils._
 
 abstract class LogStoreSuiteBase extends FunSuite with LogStoreProvider {
@@ -52,7 +52,7 @@ abstract class LogStoreSuiteBase extends FunSuite with LogStoreProvider {
   protected def shouldUseRenameToWriteCheckpoint: Boolean
 
   test("instantiation through HadoopConf") {
-    val expectedClassName = logStoreClassName.getOrElse(LogStoreProvider.defaultLogStoreClassName)
+    val expectedClassName = logStoreClassName.getOrElse(LogStoreProvider.defaultLogStoreClass)
     assert(createLogStore(hadoopConf).getClass.getName == expectedClassName)
   }
 
@@ -189,6 +189,8 @@ class LocalLogStoreSuite extends LogStoreSuiteBase {
 /**
  * Test not providing a LogStore classname, in which case [[LogStoreProvider]] will use
  * the default value.
+ *
+ * This tests [[DelegatingLogStore]].
  */
 class DefaultLogStoreSuite extends LogStoreSuiteBase {
   override def logStoreClassName: Option[String] = None
@@ -212,15 +214,10 @@ class UserDefinedLogStoreSuite extends LogStoreSuiteBase {
 class UserDefinedLogStore(override val initHadoopConf: Configuration)
   extends LogStore(initHadoopConf) {
 
-  private val mockImpl = new HDFSLogStore(initHadoopConf)
+  private val logStoreInternal = new HDFSLogStore(initHadoopConf)
 
-  override def read(path: Path, hadoopConf: Configuration): CloseableIteratorJ[String] = {
-    val iter = mockImpl.read(path, hadoopConf)
-    new CloseableIteratorJ[String] {
-      override def close(): Unit = iter.close()
-      override def hasNext: Boolean = iter.hasNext
-      override def next(): String = iter.next
-    }
+  override def read(path: Path, hadoopConf: Configuration): CloseableIterator[String] = {
+    logStoreInternal.read(path, hadoopConf)
   }
 
   override def write(
@@ -228,15 +225,15 @@ class UserDefinedLogStore(override val initHadoopConf: Configuration)
       actions: java.util.Iterator[String],
       overwrite: java.lang.Boolean,
       hadoopConf: Configuration): Unit = {
-    mockImpl.write(path, actions, overwrite, hadoopConf)
+    logStoreInternal.write(path, actions, overwrite, hadoopConf)
   }
 
   override def listFrom(path: Path, hadoopConf: Configuration): java.util.Iterator[FileStatus] = {
-    mockImpl.listFrom(path, hadoopConf)
+    logStoreInternal.listFrom(path, hadoopConf)
   }
 
   override def resolvePathOnPhysicalStorage(path: Path, hadoopConf: Configuration): Path = {
-    mockImpl.resolvePathOnPhysicalStorage(path, hadoopConf)
+    logStoreInternal.resolvePathOnPhysicalStorage(path, hadoopConf)
   }
 
   override def isPartialWriteVisible(path: Path, hadoopConf: Configuration): java.lang.Boolean = {


### PR DESCRIPTION
• Adds `DelegatingLogStore` which automatically selects LogStore based on path scheme (largely copied over from delta)
• Updates `LogStoreProvider` to default to `DelegatingLogStore`
• Adds `DelegatingLogStoreSuite` and `LogStoreProviderSuite` (somewhat copied over from delta `DelegatingLogStoreSuite`)
