### PR TITLE
[340] Fix  java.io.IOException when writing delta log to non local path

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitter.java
+++ b/flink/src/main/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitter.java
@@ -212,7 +212,7 @@ public class DeltaGlobalCommitter
         if (appId != null) { // means there are committables to process
             SortedMap<Long, List<DeltaCommittable>> committablesPerCheckpoint =
                 groupCommittablesByCheckpointInterval(globalCommittables);
-            DeltaLog deltaLog = DeltaLog.forTable(conf, basePath.getPath());
+            DeltaLog deltaLog = DeltaLog.forTable(conf, basePath.toString());
 
             for (long checkpointId : committablesPerCheckpoint.keySet()) {
                 OptimisticTransaction transaction = deltaLog.startTransaction();


### PR DESCRIPTION
This PR Fixes #340 by passing the full table path when calling `DeltaLog.forTable` 
