### PR TITLE
[delta-standalone] Implement "get version at time X" APIs

### DIFF
--- a/project/StandaloneMimaExcludes.scala
+++ b/project/StandaloneMimaExcludes.scala
@@ -37,9 +37,9 @@ object StandaloneMimaExcludes {
     ProblemFilters.exclude[Problem]("shadedelta.*"),
 
     // Public API changes in 0.4.0 -> 0.5.0
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.DeltaLog.getVersionBeforeOrAtTime"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.DeltaLog.getVersionAtOrAfterTime")
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.DeltaLog.getVersionBeforeOrAtTimestamp"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.DeltaLog.getVersionAtOrAfterTimestamp")
 
-  // scalastyle:on line.size.limit
+    // scalastyle:on line.size.limit
   )
 }

--- a/project/StandaloneMimaExcludes.scala
+++ b/project/StandaloneMimaExcludes.scala
@@ -34,7 +34,11 @@ object StandaloneMimaExcludes {
     ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.DeltaLog.tableExists"),
 
     // Ignore missing shaded attributes
-    ProblemFilters.exclude[Problem]("shadedelta.*")
+    ProblemFilters.exclude[Problem]("shadedelta.*"),
+
+    // Public API changes in 0.4.0 -> 0.5.0
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.DeltaLog.getVersionBeforeOrAtTime"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.DeltaLog.getVersionAtOrAfterTime")
 
   // scalastyle:on line.size.limit
   )

--- a/standalone/src/main/java/io/delta/standalone/DeltaLog.java
+++ b/standalone/src/main/java/io/delta/standalone/DeltaLog.java
@@ -108,7 +108,7 @@ public interface DeltaLog {
     Iterator<VersionLog> getChanges(long startVersion, boolean failOnDataLoss);
 
     /**
-     * Returns the latest commit that happened before or at {@code timestamp}.
+     * Returns the latest version that was committed before or at {@code timestamp}.
      *
      * Specifically:
      * <ul>
@@ -124,10 +124,10 @@ public interface DeltaLog {
      * @throws IllegalArgumentException if the timestamp is less than the timestamp of any committed
      *                                  version
      */
-    long getVersionBeforeOrAtTime(long timestamp);
+    long getVersionBeforeOrAtTimestamp(long timestamp);
 
     /**
-     * Returns the latest commit that happened at or after {@code timestamp}.
+     * Returns the latest version that was committed at or after {@code timestamp}.
      *
      * Specifically:
      * <ul>
@@ -143,7 +143,7 @@ public interface DeltaLog {
      * @throws IllegalArgumentException if the timestamp is more than the timestamp of any committed
      *                                  version
      */
-    long getVersionAtOrAfterTime(long timestamp);
+    long getVersionAtOrAfterTimestamp(long timestamp);
 
     /**
      * @return Whether a Delta table exists at this directory.

--- a/standalone/src/main/java/io/delta/standalone/DeltaLog.java
+++ b/standalone/src/main/java/io/delta/standalone/DeltaLog.java
@@ -108,6 +108,44 @@ public interface DeltaLog {
     Iterator<VersionLog> getChanges(long startVersion, boolean failOnDataLoss);
 
     /**
+     * Returns the latest commit that happened before or at {@code timestamp}.
+     *
+     * Specifically:
+     * <ul>
+     *     <li>if a commit version exactly matches the provided timestamp, we return it</li>
+     *     <li>else, we return the latest commit version with a timestamp less than the
+     *         provided one</li>
+     *     <li>If the provided timestamp is less than the timestamp of any committed version,
+     *         we throw an error.</li>
+     * </ul>.
+     *
+     * @param timestamp the number of milliseconds since midnight, January 1, 1970 UTC
+     * @return latest commit that happened before or at {@code timestamp}.
+     * @throws IllegalArgumentException if the timestamp is less than the timestamp of any committed
+     *                                  version
+     */
+    long getVersionBeforeOrAtTime(long timestamp);
+
+    /**
+     * Returns the latest commit that happened at or after {@code timestamp}.
+     *
+     * Specifically:
+     * <ul>
+     *     <li>if a commit version exactly matches the provided timestamp, we return it</li>
+     *     <li>else, we return the earliest commit version with a timestamp greater than the
+     *         provided one</li>
+     *     <li>If the provided timestamp is larger than the timestamp of any committed version,
+     *         we throw an error.</li>
+     * </ul>.
+     *
+     * @param timestamp the number of milliseconds since midnight, January 1, 1970 UTC
+     * @return latest commit that happened at or before {@code timestamp}.
+     * @throws IllegalArgumentException if the timestamp is more than the timestamp of any committed
+     *                                  version
+     */
+    long getVersionAtOrAfterTime(long timestamp);
+
+    /**
      * @return Whether a Delta table exists at this directory.
      */
     boolean tableExists();

--- a/standalone/src/main/java/io/delta/standalone/DeltaLog.java
+++ b/standalone/src/main/java/io/delta/standalone/DeltaLog.java
@@ -108,7 +108,8 @@ public interface DeltaLog {
     Iterator<VersionLog> getChanges(long startVersion, boolean failOnDataLoss);
 
     /**
-     * Returns the latest version that was committed before or at {@code timestamp}.
+     * Returns the latest version that was committed before or at {@code timestamp}. If no version
+     * exists, returns -1.
      *
      * Specifically:
      * <ul>
@@ -127,7 +128,8 @@ public interface DeltaLog {
     long getVersionBeforeOrAtTimestamp(long timestamp);
 
     /**
-     * Returns the latest version that was committed at or after {@code timestamp}.
+     * Returns the latest version that was committed at or after {@code timestamp}. If no version
+     * exists, returns -1.
      *
      * Specifically:
      * <ul>

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaHistoryManager.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaHistoryManager.scala
@@ -20,9 +20,10 @@ import java.sql.Timestamp
 
 import scala.collection.JavaConverters._
 
-import io.delta.standalone.DeltaLog
 import org.apache.hadoop.fs.Path
+
 import io.delta.standalone.storage.LogStore
+
 import io.delta.standalone.internal.actions.{Action, CommitInfo, CommitMarker}
 import io.delta.standalone.internal.exception.DeltaErrors
 import io.delta.standalone.internal.logging.Logging

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaHistoryManager.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaHistoryManager.scala
@@ -69,15 +69,22 @@ private[internal] case class DeltaHistoryManager(deltaLog: DeltaLogImpl) extends
   /**
    * Returns the latest commit that happened at or before `time`.
    *
+   * If the given timestamp is outside the range of [earliestCommit, latestCommit] then use params
+   * `canReturnLastCommit` and `canReturnEarliestCommit` to control whether an exception is thrown
+   * or the corresponding earliest/latest commit is returned. See param docs below.
+   *
    * @param timestamp the timestamp to search for
    * @param canReturnLastCommit Whether we can return the latest version of the table if the
    *                            provided timestamp is after the latest commit
    * @param mustBeRecreatable Whether the state at the given commit should be recreatable
-   * @param canReturnEarliestCommit Whether we can return the earliest commit if no such commit
-   *                                exists.
-   * @throws RuntimeException if the state at the given commit in not recreatable
-   * @throws IllegalArgumentException if the provided timestamp is before the earliest commit or
-   *                                  after the latest commit
+   * @param canReturnEarliestCommit Whether we can return the earliest version of the table if the
+   *                                provided timestamp is before the earliest commit
+   * @throws RuntimeException if the state at the given commit in not recreatable and
+   *                          mustBeRecreatable is true
+   * @throws IllegalArgumentException if the provided timestamp is before the earliest commit and
+   *                                  canReturnEarliestCommit is false
+   * @throws IllegalArgumentException if the provided timestamp is after the latest commit and
+   *                                  canReturnLastCommit is false
    */
   def getActiveCommitAtTime(
       timestamp: Timestamp,

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -25,8 +25,10 @@ import scala.collection.JavaConverters._
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+
 import io.delta.standalone.{DeltaLog, OptimisticTransaction, VersionLog}
 import io.delta.standalone.actions.{CommitInfo => CommitInfoJ}
+
 import io.delta.standalone.internal.actions.{Action, Metadata, Protocol}
 import io.delta.standalone.internal.exception.DeltaErrors
 import io.delta.standalone.internal.logging.Logging

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -135,6 +135,8 @@ private[internal] class DeltaLogImpl private(
   }
 
   override def getVersionBeforeOrAtTimestamp(timestamp: Long): Long = {
+    if (!tableExists) return -1
+
     // Note: if the provided timestamp is earlier than any committed version, then
     // `getActiveCommitAtTime` will throw IllegalArgumentException (specifically,
     // `DeltaErrors.timestampEarlierThanTableFirstCommit`).
@@ -149,6 +151,8 @@ private[internal] class DeltaLogImpl private(
   }
 
   override def getVersionAtOrAfterTimestamp(timestamp: Long): Long = {
+    if (!tableExists) return -1
+
     // Note: if the provided timestamp is later than any committed version, then
     // `getActiveCommitAtTime` will throw IllegalArgumentException (specifically,
     // `DeltaErrors.timestampLaterThanTableLastCommit`).

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -134,8 +134,7 @@ private[internal] class DeltaLogImpl private(
     }.asJava
   }
 
-
-  override def getVersionBeforeOrAtTime(timestamp: Long): Long = {
+  override def getVersionBeforeOrAtTimestamp(timestamp: Long): Long = {
     // Note: if the provided timestamp is earlier than any committed version, then
     // `getActiveCommitAtTime` will throw IllegalArgumentException (specifically,
     // `DeltaErrors.timestampEarlierThanTableFirstCommit`).
@@ -144,12 +143,12 @@ private[internal] class DeltaLogImpl private(
       // e.g. if we give time T+2 and last commit has time T, then we DO want that last commit
       canReturnLastCommit = true,
       mustBeRecreatable = false,
-      // e.g. we give time T-1 and first commit has time T, then do not want that earliest commit
+      // e.g. we give time T-1 and first commit has time T, then do NOT want that earliest commit
       canReturnEarliestCommit = false
     ).version
   }
 
-  override def getVersionAtOrAfterTime(timestamp: Long): Long = {
+  override def getVersionAtOrAfterTimestamp(timestamp: Long): Long = {
     // Note: if the provided timestamp is later than any committed version, then
     // `getActiveCommitAtTime` will throw IllegalArgumentException (specifically,
     // `DeltaErrors.timestampLaterThanTableLastCommit`).

--- a/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
@@ -93,7 +93,7 @@ private[internal] object DeltaErrors {
   def timestampLaterThanTableLastCommit(
       userTimestamp: java.sql.Timestamp,
       commitTs: java.sql.Timestamp): Throwable = {
-    new DeltaStandaloneException(
+    new IllegalArgumentException(
       s"""The provided timestamp ($userTimestamp) is after the latest version available to this
          |table ($commitTs). Please use a timestamp less than or equal to $commitTs.
        """.stripMargin)

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -486,49 +486,49 @@ abstract class DeltaLogSuiteBase extends FunSuite {
       val logPath = new Path(dir.getCanonicalPath, "_delta_log")
       val logDir = new File(dir.getCanonicalPath, "_delta_log")
       // local file system truncates to seconds
-      val nowEpochMillis = System.currentTimeMillis() / 1000 * 1000
+      val nowEpochMs = System.currentTimeMillis() / 1000 * 1000
 
       val delta0 = FileNames.deltaFile(logPath, 0)
       val delta1 = FileNames.deltaFile(logPath, 1)
       val delta2 = FileNames.deltaFile(logPath, 2)
 
-      new File(logDir, delta0.getName).setLastModified(nowEpochMillis)
-      new File(logDir, delta1.getName).setLastModified(nowEpochMillis + 1.minutes)
-      new File(logDir, delta2.getName).setLastModified(nowEpochMillis + 2.minutes)
+      new File(logDir, delta0.getName).setLastModified(nowEpochMs)
+      new File(logDir, delta1.getName).setLastModified(nowEpochMs + 1.minutes)
+      new File(logDir, delta2.getName).setLastModified(nowEpochMs + 2.minutes)
 
       // ========== case 1: before first commit ==========
       // case 1a
       val e1 = intercept[IllegalArgumentException] {
-        log.getVersionBeforeOrAtTime(nowEpochMillis - 1.minutes)
+        log.getVersionBeforeOrAtTimestamp(nowEpochMs - 1.minutes)
       }.getMessage
       assert(e1.contains("is before the earliest version"))
       // case 1b
-      assert(log.getVersionAtOrAfterTime(nowEpochMillis - 1.minutes) == 0)
+      assert(log.getVersionAtOrAfterTimestamp(nowEpochMs - 1.minutes) == 0)
 
       // ========== case 2: at first commit ==========
       // case 2a
-      assert(log.getVersionBeforeOrAtTime(nowEpochMillis) == 0)
+      assert(log.getVersionBeforeOrAtTimestamp(nowEpochMs) == 0)
       // case 2b
-      assert(log.getVersionAtOrAfterTime(nowEpochMillis) == 0)
+      assert(log.getVersionAtOrAfterTimestamp(nowEpochMs) == 0)
 
       // ========== case 3: between two normal commits ==========
       // case 3a
-      assert(log.getVersionBeforeOrAtTime(nowEpochMillis + 30.seconds) == 0) // round down to v0
+      assert(log.getVersionBeforeOrAtTimestamp(nowEpochMs + 30.seconds) == 0) // round down to v0
       // case 3b
-      assert(log.getVersionAtOrAfterTime(nowEpochMillis + 30.seconds) == 1) // round up to v1
+      assert(log.getVersionAtOrAfterTimestamp(nowEpochMs + 30.seconds) == 1) // round up to v1
 
       // ========== case 4: at last commit ==========
       // case 4a
-      assert(log.getVersionBeforeOrAtTime(nowEpochMillis + 2.minutes) == 2)
+      assert(log.getVersionBeforeOrAtTimestamp(nowEpochMs + 2.minutes) == 2)
       // case 4b
-      assert(log.getVersionAtOrAfterTime(nowEpochMillis + 2.minutes) == 2)
+      assert(log.getVersionAtOrAfterTimestamp(nowEpochMs + 2.minutes) == 2)
 
       // ========== case 5: after last commit ==========
       // case 5a
-      assert(log.getVersionBeforeOrAtTime(nowEpochMillis + 3.minutes) == 2)
+      assert(log.getVersionBeforeOrAtTimestamp(nowEpochMs + 3.minutes) == 2)
       // case 5b
       val e2 = intercept[IllegalArgumentException] {
-        log.getVersionAtOrAfterTime(nowEpochMillis + 3.minutes)
+        log.getVersionAtOrAfterTimestamp(nowEpochMs + 3.minutes)
       }.getMessage
       assert(e2.contains("is after the latest version"))
     }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -23,6 +23,7 @@ import java.util.UUID
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
+import scala.concurrent.duration._
 
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
@@ -63,6 +64,10 @@ abstract class DeltaLogSuiteBase extends FunSuite {
   }
 
   implicit def createCustomAddFilesAccessor(snapshot: Snapshot): CustomAddFilesAccessor
+
+  private implicit def durationToLong(duration: FiniteDuration): Long = {
+    duration.toMillis
+  }
 
   // scalastyle:on funsuite
   test("checkpoint") {
@@ -457,6 +462,75 @@ abstract class DeltaLogSuiteBase extends FunSuite {
         "test"
       )
       assert(log.tableExists())
+    }
+  }
+
+  test("getVersionBeforeOrAtTime and getVersionAtOrAfterTime") {
+    // Note:
+    // - all Xa test cases will test getVersionBeforeOrAtTime
+    // - all Xb test cases will test getVersionAtOrAfterTime
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(new Configuration(), dir.getCanonicalPath)
+      // Setup part 1/2: create log files
+      (0 to 2).foreach { i =>
+        val txn = log.startTransaction()
+        val files = AddFile(i.toString, Map.empty, 1, 1, true) :: Nil
+        val metadata = if (i == 0) Metadata() :: Nil else Nil
+        log.startTransaction().commit(
+          (metadata ++ files).map(ConversionUtils.convertAction).asJava,
+          manualUpdate, engineInfo
+        )
+      }
+
+      // Setup part 2/2: edit lastModified times
+      val logPath = new Path(dir.getCanonicalPath, "_delta_log")
+      val logDir = new File(dir.getCanonicalPath, "_delta_log")
+      // local file system truncates to seconds
+      val nowEpochMillis = System.currentTimeMillis() / 1000 * 1000
+
+      val delta0 = FileNames.deltaFile(logPath, 0)
+      val delta1 = FileNames.deltaFile(logPath, 1)
+      val delta2 = FileNames.deltaFile(logPath, 2)
+
+      new File(logDir, delta0.getName).setLastModified(nowEpochMillis)
+      new File(logDir, delta1.getName).setLastModified(nowEpochMillis + 1.minutes)
+      new File(logDir, delta2.getName).setLastModified(nowEpochMillis + 2.minutes)
+
+      // ========== case 1: before first commit ==========
+      // case 1a
+      val e1 = intercept[IllegalArgumentException] {
+        log.getVersionBeforeOrAtTime(nowEpochMillis - 1.minutes)
+      }.getMessage
+      assert(e1.contains("is before the earliest version"))
+      // case 1b
+      assert(log.getVersionAtOrAfterTime(nowEpochMillis - 1.minutes) == 0)
+
+      // ========== case 2: at first commit ==========
+      // case 2a
+      assert(log.getVersionBeforeOrAtTime(nowEpochMillis) == 0)
+      // case 2b
+      assert(log.getVersionAtOrAfterTime(nowEpochMillis) == 0)
+
+      // ========== case 3: between two normal commits ==========
+      // case 3a
+      assert(log.getVersionBeforeOrAtTime(nowEpochMillis + 30.seconds) == 0) // round down to v0
+      // case 3b
+      assert(log.getVersionAtOrAfterTime(nowEpochMillis + 30.seconds) == 1) // round up to v1
+
+      // ========== case 4: at last commit ==========
+      // case 4a
+      assert(log.getVersionBeforeOrAtTime(nowEpochMillis + 2.minutes) == 2)
+      // case 4b
+      assert(log.getVersionAtOrAfterTime(nowEpochMillis + 2.minutes) == 2)
+
+      // ========== case 5: after last commit ==========
+      // case 5a
+      assert(log.getVersionBeforeOrAtTime(nowEpochMillis + 3.minutes) == 2)
+      // case 5b
+      val e2 = intercept[IllegalArgumentException] {
+        log.getVersionAtOrAfterTime(nowEpochMillis + 3.minutes)
+      }.getMessage
+      assert(e2.contains("is after the latest version"))
     }
   }
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -496,50 +496,43 @@ abstract class DeltaLogSuiteBase extends FunSuite {
       val delta1 = FileNames.deltaFile(logPath, 1)
       val delta2 = FileNames.deltaFile(logPath, 2)
 
-      val TIME_BEFORE_START = nowEpochMs - 1.minutes
-      val TIME_START = nowEpochMs
-      val TIME_PLUS_30_SECS = nowEpochMs + 30.seconds
-      val TIME_PLUS_ONE_MINUTE = nowEpochMs + 1.minutes
-      val TIME_END = nowEpochMs + 2.minutes
-      val TIME_PAST_END = nowEpochMs + 3.minutes
-
-      new File(logDir, delta0.getName).setLastModified(TIME_START)
-      new File(logDir, delta1.getName).setLastModified(TIME_PLUS_ONE_MINUTE)
-      new File(logDir, delta2.getName).setLastModified(TIME_END)
+      new File(logDir, delta0.getName).setLastModified(1000)
+      new File(logDir, delta1.getName).setLastModified(2000)
+      new File(logDir, delta2.getName).setLastModified(3000)
 
       // ========== case 1: before first commit ==========
       // case 1a
       val e1 = intercept[IllegalArgumentException] {
-        log.getVersionBeforeOrAtTimestamp(TIME_BEFORE_START)
+        log.getVersionBeforeOrAtTimestamp(500)
       }.getMessage
       assert(e1.contains("is before the earliest version"))
       // case 1b
-      assert(log.getVersionAtOrAfterTimestamp(TIME_BEFORE_START) == 0)
+      assert(log.getVersionAtOrAfterTimestamp(500) == 0)
 
       // ========== case 2: at first commit ==========
       // case 2a
-      assert(log.getVersionBeforeOrAtTimestamp(TIME_START) == 0)
+      assert(log.getVersionBeforeOrAtTimestamp(1000) == 0)
       // case 2b
-      assert(log.getVersionAtOrAfterTimestamp(TIME_START) == 0)
+      assert(log.getVersionAtOrAfterTimestamp(1000) == 0)
 
       // ========== case 3: between two normal commits ==========
       // case 3a
-      assert(log.getVersionBeforeOrAtTimestamp(TIME_PLUS_30_SECS) == 0) // round down to v0
+      assert(log.getVersionBeforeOrAtTimestamp(1500) == 0) // round down to v0
       // case 3b
-      assert(log.getVersionAtOrAfterTimestamp(TIME_PLUS_30_SECS) == 1) // round up to v1
+      assert(log.getVersionAtOrAfterTimestamp(1500) == 1) // round up to v1
 
       // ========== case 4: at last commit ==========
       // case 4a
-      assert(log.getVersionBeforeOrAtTimestamp(TIME_END) == 2)
+      assert(log.getVersionBeforeOrAtTimestamp(3000) == 2)
       // case 4b
-      assert(log.getVersionAtOrAfterTimestamp(TIME_END) == 2)
+      assert(log.getVersionAtOrAfterTimestamp(3000) == 2)
 
       // ========== case 5: after last commit ==========
       // case 5a
-      assert(log.getVersionBeforeOrAtTimestamp(TIME_PAST_END) == 2)
+      assert(log.getVersionBeforeOrAtTimestamp(4000) == 2)
       // case 5b
       val e2 = intercept[IllegalArgumentException] {
-        log.getVersionAtOrAfterTimestamp(TIME_PAST_END)
+        log.getVersionAtOrAfterTimestamp(4000)
       }.getMessage
       assert(e2.contains("is after the latest version"))
     }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaTimeTravelSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaTimeTravelSuite.scala
@@ -157,7 +157,7 @@ class DeltaTimeTravelSuite extends FunSuite {
       new File(logDir, "00000000000000000002.json").setLastModified(start + 40.minutes)
       val log = DeltaLog.forTable(new Configuration(), tablePath)
 
-      val e = intercept[DeltaStandaloneException] {
+      val e = intercept[IllegalArgumentException] {
         log.getSnapshotForTimestampAsOf(start + 50.minutes) // later by 10 mins
       }
 


### PR DESCRIPTION
See the design doc [here](https://docs.google.com/document/d/1j9tHRmqSGuTlbwxjnFexaDFGJ-2LUCH6DuWGnGZrMDE/edit#heading=h.4cz970y1mk93).

This PR adds two new APIs
- `long getVersionBeforeOrAtTimestamp(long timestamp)`
- `long getVersionAtOrAfterTimestamp(long timestamp)`

The latter is used to provide the "streaming" semantics needed for the Delta/Flink connector. Specifically, this means that when using the "startingTimestamp" option for a streaming/continuous query, we return the commit version "at or after" that timestamp.

The result of this method (`getVersionAtOrAfterTime`) can then be passed to `DeltaLog::getSnapshotForVersionAsOf` to get the metadata for a particular version, and to `DeltaLog::getChanges` to get the changes from a particular version, for the version corresponding to the input timestamp.

This is different from the "batch" semantics, where for options like "timestampAsOf" we use the snapshot version "at or before" that timestamp.