### PR TITLE
Fix delta-standalone jackson module vulnerability CVE-2020-36518

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -443,7 +443,7 @@ lazy val standalone = (project in file("standalone"))
         ExclusionRule("org.slf4j", "slf4j-api"),
         ExclusionRule("org.apache.parquet", "parquet-hadoop")
       ),
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.3",
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.3",
       "org.json4s" %% "json4s-jackson" % "3.7.0-M11" excludeAll (
         ExclusionRule("com.fasterxml.jackson.core"),
         ExclusionRule("com.fasterxml.jackson.module")


### PR DESCRIPTION
As pointed out here https://github.com/delta-io/connectors/issues/343, the current version of jackson-module has a known vulnerability. We upgrade to a newer version.

See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518.