### PR TITLE
[delta-standalone] Add `DataType::fromJson` API

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/types/DataType.java
+++ b/standalone/src/main/java/io/delta/standalone/types/DataType.java
@@ -52,6 +52,16 @@ import io.delta.standalone.internal.util.DataTypeParser;
 public abstract class DataType {
 
     /**
+     * Parses the input {@code json} into a {@link DataType}.
+     *
+     * @param json the {@link String} json to parse
+     * @return the parsed {@link DataType}
+     */
+    public static DataType fromJson(String json) {
+        return DataTypeParser.fromJson(json);
+    }
+
+    /**
      * @return the name of the type used in JSON serialization
      */
     public String getTypeName() {

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
@@ -18,19 +18,18 @@ package io.delta.standalone.internal
 
 import java.math.{BigDecimal => JBigDecimal}
 import java.sql.Timestamp
-import java.util.{List => JList, Map => JMap, TimeZone}
+import java.util.{TimeZone, List => JList, Map => JMap}
 import java.util.Arrays.{asList => asJList}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
+import com.fasterxml.jackson.core.JsonParseException
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.FunSuite
-
 import io.delta.standalone.DeltaLog
 import io.delta.standalone.data.{CloseableIterator, RowRecord => JRowRecord}
 import io.delta.standalone.types._
-
 import io.delta.standalone.internal.data.RowParquetRecordImpl
 import io.delta.standalone.internal.sources.StandaloneHadoopConf
 import io.delta.standalone.internal.util.DataTypeParser
@@ -359,14 +358,16 @@ class DeltaDataReaderSuite extends FunSuite {
 
   private def checkDataTypeToJsonFromJson(dataType: DataType): Unit = {
     test(s"DataType to Json and from Json - $dataType") {
-      assert(DataTypeParser.fromJson(dataType.toJson) === dataType)
+      assert(DataTypeParser.fromJson(dataType.toJson) === dataType) // internal API
+      assert(DataType.fromJson(dataType.toJson) === dataType) // public API
     }
 
     test(s"DataType inside StructType to Json and from Json - $dataType") {
       val field1 = new StructField("foo", dataType, true)
       val field2 = new StructField("bar", dataType, true)
       val struct = new StructType(Array(field1, field2))
-      assert(DataTypeParser.fromJson(struct.toJson) === struct)
+      assert(DataTypeParser.fromJson(struct.toJson) === struct) // internal API
+      assert(DataType.fromJson(struct.toJson) === struct) // public API
     }
   }
 
@@ -414,7 +415,23 @@ class DeltaDataReaderSuite extends FunSuite {
       new StructField("singleListMetadata", new BooleanType, true, singleListMetadata),
       new StructField("multipleEntriesMetadata", new BooleanType, true, multipleEntriesMetadata))
     val struct = new StructType(field_array)
-    assert(struct == DataTypeParser.fromJson(struct.toJson()))
+    assert(struct == DataTypeParser.fromJson(struct.toJson())) // internal API
+    assert(struct == DataType.fromJson(struct.toJson)) // public API
+  }
+
+  test("DataType.fromJson - invalid json") {
+    assertThrows[JsonParseException] {
+      DataType.fromJson("foo" + new BooleanType().toJson + "bar")
+    }
+    assertThrows[JsonParseException] {
+      DataType.fromJson(
+        new StructType()
+          .add("col1", new IntegerType())
+          .add("col2", new StringType())
+          .toJson
+          .replaceAll("\"", "?")
+      )
+    }
   }
 
   test("#124: getBigDecimal decode correctly for LongValue") {

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaDataReaderSuite.scala
@@ -18,7 +18,7 @@ package io.delta.standalone.internal
 
 import java.math.{BigDecimal => JBigDecimal}
 import java.sql.Timestamp
-import java.util.{TimeZone, List => JList, Map => JMap}
+import java.util.{List => JList, Map => JMap, TimeZone}
 import java.util.Arrays.{asList => asJList}
 
 import scala.collection.JavaConverters._
@@ -27,9 +27,11 @@ import scala.collection.mutable.ListBuffer
 import com.fasterxml.jackson.core.JsonParseException
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.FunSuite
+
 import io.delta.standalone.DeltaLog
 import io.delta.standalone.data.{CloseableIterator, RowRecord => JRowRecord}
 import io.delta.standalone.types._
+
 import io.delta.standalone.internal.data.RowParquetRecordImpl
 import io.delta.standalone.internal.sources.StandaloneHadoopConf
 import io.delta.standalone.internal.util.DataTypeParser


### PR DESCRIPTION
This PR adds a `DataType fromJson(String json)` API to the DataType class.

This is just a helpful, quality-of-life public API to have.

As well, the Flink/Delta Source Connector may want to, in the future, serialize and then deserialize the snapshot metadata schema, as a performance optimization.