### PR TITLE
FlinkDeltaSource_PR_13 - Use Delta's new API DeltaLog::getVersionAtOrAfterTimestamp to support startingTimestamp option

### DIFF
--- a/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/ContinuousSourceSnapshotSupplier.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/ContinuousSourceSnapshotSupplier.java
@@ -64,6 +64,8 @@ public class ContinuousSourceSnapshotSupplier extends SnapshotSupplier {
             DeltaSourceConfiguration sourceConfiguration) {
         Long startingTimestamp = sourceConfiguration.getValue(STARTING_TIMESTAMP);
         if (startingTimestamp != null) {
+            // Delta Lake streaming semantics match timestamps to versions using
+            // 'at or after' semantics. Here we do the same.
             long versionAtOrAfterTimestamp =
                 deltaLog.getVersionAtOrAfterTimestamp(startingTimestamp);
             return TransitiveOptional.ofNullable(

--- a/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/ContinuousSourceSnapshotSupplier.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/ContinuousSourceSnapshotSupplier.java
@@ -59,13 +59,15 @@ public class ContinuousSourceSnapshotSupplier extends SnapshotSupplier {
         }
         return TransitiveOptional.empty();
     }
-
+    // TODO PR 14 add IT test for this
     private TransitiveOptional<Snapshot> getSnapshotFromStartingTimestampOption(
             DeltaSourceConfiguration sourceConfiguration) {
         Long startingTimestamp = sourceConfiguration.getValue(STARTING_TIMESTAMP);
         if (startingTimestamp != null) {
+            long versionAtOrAfterTimestamp =
+                deltaLog.getVersionAtOrAfterTimestamp(startingTimestamp);
             return TransitiveOptional.ofNullable(
-                deltaLog.getSnapshotForTimestampAsOf(startingTimestamp));
+                deltaLog.getSnapshotForVersionAsOf(versionAtOrAfterTimestamp));
         }
         return TransitiveOptional.empty();
     }

--- a/flink/src/test/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilderTest.java
+++ b/flink/src/test/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilderTest.java
@@ -146,7 +146,10 @@ class RowDataContinuousDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderT
         long long_startingTimestamp =
             TimestampFormatConverter.convertToTimestamp(startingTimestamp);
 
-        when(deltaLog.getSnapshotForTimestampAsOf(long_startingTimestamp)).thenReturn(headSnapshot);
+        long snapshotVersion = headSnapshot.getVersion();
+        when(deltaLog.getVersionAtOrAfterTimestamp(long_startingTimestamp))
+            .thenReturn(snapshotVersion);
+        when(deltaLog.getSnapshotForVersionAsOf(snapshotVersion)).thenReturn(headSnapshot);
 
         StructField[] schema = {new StructField("col1", new StringType())};
         mockDeltaTableForSchema(schema);
@@ -168,7 +171,8 @@ class RowDataContinuousDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderT
             }
             // as many calls as we had builders
             verify(deltaLog, times(builders.size()))
-                .getSnapshotForTimestampAsOf(long_startingTimestamp);
+                .getVersionAtOrAfterTimestamp(long_startingTimestamp);
+            verify(deltaLog, times(builders.size())).getSnapshotForVersionAsOf(snapshotVersion);
         });
     }
 

--- a/flink/src/test/java/io/delta/flink/source/internal/enumerator/supplier/ContinuousSourceSnapshotSupplierTest.java
+++ b/flink/src/test/java/io/delta/flink/source/internal/enumerator/supplier/ContinuousSourceSnapshotSupplierTest.java
@@ -93,12 +93,15 @@ class ContinuousSourceSnapshotSupplierTest {
         DeltaSourceConfiguration sourceConfig = new DeltaSourceConfiguration(
             Collections.singletonMap(DeltaSourceOptions.STARTING_TIMESTAMP.key(), dateTime)
         );
-        when(deltaLog.getSnapshotForTimestampAsOf(timestamp)).thenReturn(deltaSnapshot);
+        long snapshotVersion = deltaSnapshot.getVersion();
+        when(deltaLog.getVersionAtOrAfterTimestamp(timestamp)).thenReturn(snapshotVersion);
+        when(deltaLog.getSnapshotForVersionAsOf(snapshotVersion)).thenReturn(deltaSnapshot);
 
         Snapshot snapshot = supplier.getSnapshot(sourceConfig);
 
         assertThat(snapshot, equalTo(deltaSnapshot));
-        verify(deltaLog, never()).getSnapshotForVersionAsOf(anyLong());
+        verify(deltaLog).getVersionAtOrAfterTimestamp(timestamp);
+        verify(deltaLog).getSnapshotForVersionAsOf(snapshotVersion);
         verify(deltaLog, never()).snapshot();
     }
 


### PR DESCRIPTION
Use new DeltaLog API getVersionAtOrAfterTimestamp for continuous getChanges call when using starting timestamp. This uses the "streaming" semantics of timestamp -> version conversion.