### PR TITLE
FlinkDeltaSorce_SupressFLinkLogs_FixNPE - Log Level for Flink classes

### DIFF
--- a/flink/src/test/java/io/delta/flink/utils/DeltaTestUtils.java
+++ b/flink/src/test/java/io/delta/flink/utils/DeltaTestUtils.java
@@ -25,8 +25,12 @@ import org.apache.flink.streaming.api.operators.collect.ClientAndIterator;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.types.Row;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DeltaTestUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeltaTestUtils.class);
 
     ///////////////////////////////////////////////////////////////////////////
     // hadoop conf test utils
@@ -97,7 +101,7 @@ public class DeltaTestUtils {
 
     public static void triggerJobManagerFailover(
         JobID jobId, Runnable afterFailAction, MiniCluster miniCluster) throws Exception {
-        System.out.println("Triggering Job Manager failover.");
+        LOG.info("Triggering Job Manager failover.");
         HaLeadershipControl haLeadershipControl = miniCluster.getHaLeadershipControl().get();
         haLeadershipControl.revokeJobMasterLeadership(jobId).get();
         afterFailAction.run();
@@ -106,7 +110,7 @@ public class DeltaTestUtils {
 
     public static void restartTaskManager(Runnable afterFailAction, MiniCluster miniCluster)
         throws Exception {
-        System.out.println("Triggering Task Manager failover.");
+        LOG.info("Triggering Task Manager failover.");
         miniCluster.terminateTaskManager(0).get();
         afterFailAction.run();
         miniCluster.startTaskManager();

--- a/flink/src/test/java/io/delta/flink/utils/RecordCounterToFail.java
+++ b/flink/src/test/java/io/delta/flink/utils/RecordCounterToFail.java
@@ -6,6 +6,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A wrapper class for {@link DataStream} that counts number of processed records and for each
@@ -15,8 +17,12 @@ import org.apache.flink.streaming.api.datastream.DataStream;
  */
 public class RecordCounterToFail implements Serializable {
 
+    private static final Logger LOG = LoggerFactory.getLogger(RecordCounterToFail.class);
+
     private static AtomicInteger records;
+
     private static CompletableFuture<Void> fail;
+
     private static CompletableFuture<Void> continueProcessing;
 
     /**
@@ -48,7 +54,7 @@ public class RecordCounterToFail implements Serializable {
      */
     public static void waitToFail() throws Exception {
         fail.get();
-        System.out.println("Wait to fail Finished.");
+        LOG.info("Fail.get finished.");
     }
 
     /**

--- a/flink/src/test/resources/log4j2-test.properties
+++ b/flink/src/test/resources/log4j2-test.properties
@@ -18,6 +18,8 @@
 
 rootLogger.level = INFO
 rootLogger.appenderRef.console.ref = ConsoleAppender
+logger.flink.name = org.apache.flink
+logger.flink.level = ERROR
 
 appender.console.name = ConsoleAppender
 appender.console.type = CONSOLE


### PR DESCRIPTION
Setting log level for Flink classes to ERROR -> suppressing all unnecessary log lines that were adding noise to the logs.
Fixing NPE in couple of tests. NPE was not causing any issue other than adding a confusing noise to the logs.
Add two log lines to tests.