### PR TITLE
Flink Sink [PR19 Source plan] - Adding a test that verifies if Flink Delta Source created Delta checkpoint

### DIFF
--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
@@ -19,8 +19,6 @@
 package io.delta.flink.sink;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -30,6 +28,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 import io.delta.flink.sink.utils.DeltaSinkTestUtils;
 import io.delta.flink.utils.DeltaTestUtils;
@@ -54,13 +53,17 @@ import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunctio
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.Row;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.delta.standalone.DeltaLog;
 import io.delta.standalone.actions.AddFile;
@@ -69,57 +72,76 @@ import io.delta.standalone.actions.CommitInfo;
 /**
  * Tests the functionality of the {@link DeltaSink} in STREAMING mode.
  */
-@RunWith(Parameterized.class)
-public class DeltaSinkStreamingExecutionITCase extends StreamingExecutionFileSinkITCase {
+public class DeltaSinkStreamingExecutionITCase {
+
+    private static final int NUM_SOURCES = 4;
+
+    private static final int NUM_SINKS = 3;
+
+    private static final int NUM_RECORDS = 10000;
+
+    private static final double FAILOVER_RATIO = 0.4;
+
+    public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
 
     private static final Map<String, CountDownLatch> LATCH_MAP = new ConcurrentHashMap<>();
 
-    @Parameterized.Parameters(
-        name = "triggerFailover = {0}, isPartitioned = {1}"
-    )
-    public static Collection<Object[]> params() {
-        return Arrays.asList(
-            new Object[]{false, false},
-            new Object[]{false, true},
-            new Object[]{true, false},
-            new Object[]{true, true}
-        );
-    }
-
-    @Parameterized.Parameter(1)
-    public Boolean isPartitioned;
-
     private String latchId;
+
     private String deltaTablePath;
 
-    @Before
-    public void setup() {
-        this.latchId = UUID.randomUUID().toString();
-        LATCH_MAP.put(latchId, new CountDownLatch(NUM_SOURCES * 2));
-        try {
-            deltaTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
-            if (isPartitioned) {
-                DeltaTestUtils.initTestForPartitionedTable(deltaTablePath);
-            } else {
-                DeltaTestUtils.initTestForNonPartitionedTable(deltaTablePath);
-            }
-        } catch (IOException e) {
-            throw new RuntimeException("Weren't able to setup the test dependencies", e);
-        }
+    @BeforeAll
+    public static void beforeAll() throws IOException {
+        TMP_FOLDER.create();
     }
 
-    @After
+    @AfterAll
+    public static void afterAll() {
+        TMP_FOLDER.delete();
+    }
+
+    @BeforeEach
+    public void setup() throws IOException {
+        deltaTablePath = TMP_FOLDER.newFolder().getAbsolutePath();
+        this.latchId = UUID.randomUUID().toString();
+        LATCH_MAP.put(latchId, new CountDownLatch(NUM_SOURCES * 2));
+    }
+
+    @AfterEach
     public void teardown() {
         LATCH_MAP.remove(latchId);
     }
 
-    @Override
-    @Test
-    public void testFileSink() throws Exception {
-        runDeltaSinkTest();
+    private static Stream<Arguments> deltaSinkArguments() {
+        return Stream.of(
+            Arguments.of(false, false),
+            Arguments.of(false, true),
+            Arguments.of(true, false),
+            Arguments.of(true, true)
+        );
     }
 
-    public void runDeltaSinkTest() throws Exception {
+    @ParameterizedTest(name = "triggerFailover = {0}, isPartitioned = {1}")
+    @MethodSource("deltaSinkArguments")
+    public void testFileSink(boolean isPartitioned, boolean triggerFailover) throws Exception {
+
+        initSourceFolder(isPartitioned, deltaTablePath);
+
+        runDeltaSinkTest(deltaTablePath, triggerFailover, isPartitioned);
+    }
+
+    @Test
+    public void testSinkDeltaCheckpoint() throws IOException {
+
+        DeltaTestUtils.initTestForNonPartitionedTable(deltaTablePath);
+        DeltaLog deltaLog = DeltaLog.forTable(DeltaTestUtils.getHadoopConf(), deltaTablePath);
+
+    }
+
+    public void runDeltaSinkTest(
+            String deltaTablePath,
+            boolean triggerFailover,
+            boolean isPartitioned) throws Exception {
         // GIVEN
         DeltaLog deltaLog = DeltaLog.forTable(DeltaTestUtils.getHadoopConf(), deltaTablePath);
         List<AddFile> initialDeltaFiles = deltaLog.snapshot().getAllFiles();
@@ -129,7 +151,7 @@ public class DeltaSinkStreamingExecutionITCase extends StreamingExecutionFileSin
             .readAndValidateAllTableRecords(deltaLog);
         assertEquals(2, initialTableRecordsCount);
 
-        JobGraph jobGraph = createJobGraph(deltaTablePath);
+        JobGraph jobGraph = createJobGraph(deltaTablePath, triggerFailover, isPartitioned);
 
         // WHEN
         try (MiniCluster miniCluster = DeltaSinkTestUtils.getMiniCluster()) {
@@ -171,9 +193,11 @@ public class DeltaSinkStreamingExecutionITCase extends StreamingExecutionFileSin
      * Creating the testing job graph in streaming mode. The graph created is [Source] -> [Delta
      * Sink]. The source would trigger failover if required.
      */
-    @Override
-    protected JobGraph createJobGraph(String path) {
-        StreamExecutionEnvironment env = getTestStreamEnv();
+    protected JobGraph createJobGraph(
+            String deltaTablePath,
+            boolean triggerFailover,
+            boolean isPartitioned) {
+        StreamExecutionEnvironment env = getTestStreamEnv(triggerFailover);
 
         env.addSource(new DeltaStreamingExecutionTestSource(latchId, NUM_RECORDS, triggerFailover))
             .setParallelism(NUM_SOURCES)
@@ -184,7 +208,7 @@ public class DeltaSinkStreamingExecutionITCase extends StreamingExecutionFileSin
         return streamGraph.getJobGraph();
     }
 
-    private StreamExecutionEnvironment getTestStreamEnv() {
+    private StreamExecutionEnvironment getTestStreamEnv(boolean triggerFailover) {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         Configuration config = new Configuration();
@@ -199,6 +223,20 @@ public class DeltaSinkStreamingExecutionITCase extends StreamingExecutionFileSin
         }
 
         return env;
+    }
+
+    private String initSourceFolder(boolean isPartitioned, String deltaTablePath) {
+        try {
+            if (isPartitioned) {
+                DeltaTestUtils.initTestForPartitionedTable(deltaTablePath);
+            } else {
+                DeltaTestUtils.initTestForNonPartitionedTable(deltaTablePath);
+            }
+
+            return deltaTablePath;
+        } catch (IOException e) {
+            throw new RuntimeException("Weren't able to setup the test dependencies", e);
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/flink/src/test/java/io/delta/flink/sink/utils/CheckpointCountingSource.java
+++ b/flink/src/test/java/io/delta/flink/sink/utils/CheckpointCountingSource.java
@@ -1,0 +1,136 @@
+package io.delta.flink.sink.utils;
+
+import java.util.Collections;
+
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.Row;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Each of the source operators outputs records in given number of checkpoints.
+ * Number of records per checkpoint is constant between checkpoints, and defined by user.
+ * When all records are emitted, the source waits for two more checkpoints until it
+ * finishes.
+ * <p>
+ * All credits for this implementation goes to <b>Grzegorz Kolakowski<b>
+ * who implemented the original version of this class for end2end tests.
+ * This class was copied from his Pull Request here.
+ */
+public class CheckpointCountingSource extends RichParallelSourceFunction<RowData>
+    implements CheckpointListener, CheckpointedFunction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CheckpointCountingSource.class);
+
+    private final int numberOfCheckpoints;
+    private final int recordsPerCheckpoint;
+    private ListState<Integer> nextValueState;
+    private int nextValue;
+    private volatile boolean isCanceled;
+    private volatile boolean waitingForCheckpoint;
+
+    public CheckpointCountingSource(int recordsPerCheckpoint, int numberOfCheckpoints) {
+        this.numberOfCheckpoints = numberOfCheckpoints;
+        this.recordsPerCheckpoint = recordsPerCheckpoint;
+    }
+
+    @Override
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+        nextValueState = context.getOperatorStateStore()
+            .getListState(new ListStateDescriptor<>("nextValue", Integer.class));
+
+        if (nextValueState.get() != null && nextValueState.get().iterator().hasNext()) {
+            nextValue = nextValueState.get().iterator().next();
+        }
+        waitingForCheckpoint = false;
+    }
+
+    @Override
+    public void run(SourceContext<RowData> ctx) throws Exception {
+        LOGGER.info("Run subtask={}; attempt={}.",
+            getRuntimeContext().getIndexOfThisSubtask(),
+            getRuntimeContext().getAttemptNumber());
+
+        sendRecordsUntil(numberOfCheckpoints, ctx);
+        idleUntilNextCheckpoint(ctx);
+        LOGGER.info("Source task done; subtask={}.", getRuntimeContext().getIndexOfThisSubtask());
+    }
+
+    private void sendRecordsUntil(int targetCheckpoints, SourceContext<RowData> ctx)
+        throws InterruptedException {
+        while (!isCanceled && nextValue < targetCheckpoints * recordsPerCheckpoint) {
+            synchronized (ctx.getCheckpointLock()) {
+                emitRecordsBatch(recordsPerCheckpoint, ctx);
+                waitingForCheckpoint = true;
+            }
+            LOGGER.info("Waiting for checkpoint to complete; subtask={}.",
+                getRuntimeContext().getIndexOfThisSubtask());
+            while (waitingForCheckpoint) {
+                Thread.sleep(1);
+            }
+        }
+    }
+
+    private void emitRecordsBatch(int batchSize, SourceContext<RowData> ctx) {
+        for (int i = 0; i < batchSize; ++i) {
+            RowData row = DeltaSinkTestUtils.TEST_ROW_TYPE_CONVERTER.toInternal(
+                Row.of(
+                    String.valueOf(nextValue),
+                    String.valueOf((nextValue + nextValue)),
+                    nextValue
+                )
+            );
+            ctx.collect(row);
+            nextValue++;
+        }
+        LOGGER.info("Emitted {} records (total {}); subtask={}.", batchSize, nextValue,
+            getRuntimeContext().getIndexOfThisSubtask());
+    }
+
+    private void idleUntilNextCheckpoint(SourceContext<RowData> ctx) throws InterruptedException {
+        // Idle until the next checkpoint completes to avoid any premature job termination and
+        // race conditions.
+        LOGGER.info("Waiting for an additional checkpoint to complete; subtask={}.",
+            getRuntimeContext().getIndexOfThisSubtask());
+        synchronized (ctx.getCheckpointLock()) {
+            waitingForCheckpoint = true;
+        }
+        while (waitingForCheckpoint) {
+            Thread.sleep(1L);
+        }
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext context) throws Exception {
+        nextValueState.update(Collections.singletonList(nextValue));
+        LOGGER.info("state snapshot done; checkpointId={}; subtask={}.",
+            context.getCheckpointId(),
+            getRuntimeContext().getIndexOfThisSubtask());
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) {
+        waitingForCheckpoint = false;
+        LOGGER.info("Checkpoint {} complete; subtask={}.", checkpointId,
+            getRuntimeContext().getIndexOfThisSubtask());
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        LOGGER.info("Checkpoint {} aborted; subtask={}.", checkpointId,
+            getRuntimeContext().getIndexOfThisSubtask());
+        CheckpointListener.super.notifyCheckpointAborted(checkpointId);
+    }
+
+    @Override
+    public void cancel() {
+        isCanceled = true;
+    }
+}


### PR DESCRIPTION
Adding a test that verifies if Flink Delta Source created Delta checkpoint after 10 commits. This tests produces records using CheckpointCountingSource until at most 12 Flink checkpoints will be created.  For every Flink checkpoint the CheckpointCountingSource produces new batch of records. After approximately 10 Flink checkpoints there should be a Delta checkpoint created.