### PR TITLE
Trivial doc updates for 0.5.0 release

### DIFF
--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -38,7 +38,7 @@ def getStandaloneVersion(): String = {
     println("Using Delta version " + version)
     version
   } else {
-    "0.4.1"
+    "0.5.0"
   }
 }
 

--- a/examples/convert-to-delta/pom.xml
+++ b/examples/convert-to-delta/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.-->
         <maven.compiler.target>1.8</maven.compiler.target>
         <staging.repo.url>""</staging.repo.url>
         <scala.version>2.12</scala.version>
-        <standalone.version>0.4.1</standalone.version>
+        <standalone.version>0.5.0</standalone.version>
     </properties>
 
     <repositories>

--- a/examples/hello-world/pom.xml
+++ b/examples/hello-world/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.-->
         <maven.compiler.target>1.8</maven.compiler.target>
         <staging.repo.url>""</staging.repo.url>
         <scala.version>2.12</scala.version>
-        <standalone.version>0.4.1</standalone.version>
+        <standalone.version>0.5.0</standalone.version>
     </properties>
 
     <repositories>

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
     
     There are two version 'modes' you should use to run this file.
     1. using published or staged jar: explicitly pass in the --version argument.
-    2. using locally-generated jar (e.g. 0.4.1-SNAPSHOT): explicitly pass in the --version argument
+    2. using locally-generated jar (e.g. x.y.z-SNAPSHOT): explicitly pass in the --version argument
        and --use-local-cache argument.
        
        In this mode, ensure that the local jar exists for all scala versions. You can generate it

--- a/flink/README.md
+++ b/flink/README.md
@@ -315,12 +315,12 @@ Scala 2.12:
         <dependency>
             <groupId>io.delta</groupId>
             <artifactId>delta-flink</artifactId>
-            <version>0.4.1</version>
+            <version>0.5.0</version>
         </dependency>
         <dependency>
             <groupId>io.delta</groupId>
             <artifactId>delta-standalone_${scala.main.version}</artifactId>
-            <version>0.4.1</version>
+            <version>0.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -359,8 +359,8 @@ Please replace the versions of the dependencies with the ones you are using.
 
 ```scala
 libraryDependencies ++= Seq(
-  "io.delta" %% "delta-flink" % "0.4.1",
-  "io.delta" %% "delta-standalone" % "0.4.1",  
+  "io.delta" %% "delta-flink" % deltaConnectorsVersion,
+  "io.delta" %% "delta-standalone" % deltaConnectorsVersion,
   "org.apache.flink" %% "flink-clients" % flinkVersion,
   "org.apache.flink" %% "flink-parquet" % flinkVersion,
   "org.apache.hadoop" % "hadoop-client" % hadoopVersion,

--- a/hive/README.md
+++ b/hive/README.md
@@ -1,5 +1,5 @@
 # Hive Connector
-This project is a library to make Hive read Delta tables. The project provides a uber JAR `delta-hive-assembly_<scala_version>-0.4.1.jar` to use in Hive. You can use either Scala 2.11, 2.12 or 2.13. The released JARs are available in the [releases](https://github.com/delta-io/connectors/releases) page. Please download the uber JAR for the corresponding Scala version you would like to use.
+This project is a library to make Hive read Delta tables. The project provides a uber JAR `delta-hive-assembly_<scala_version>-<delta_connectors_version>.jar` to use in Hive. You can use either Scala 2.11, 2.12 or 2.13. The released JARs are available in the [releases](https://github.com/delta-io/connectors/releases) page. Please download the uber JAR for the corresponding Scala version you would like to use.
 
 You can also use the following instructions to build it as well.
 
@@ -12,10 +12,10 @@ Please skip this section if you have downloaded the connector JARs.
 - To run Hive 2 tests, run `build/sbt hive2MR/test hive2Tez/test`
 - To generate the uber JAR that contains all libraries needed for Hive, run `build/sbt hiveAssembly/assembly`
 
-The above commands will generate the following JAR:
+The above commands will generate the following JAR, for latest Delta Connectors version x.y.z:
 
 ```
-hive/target/scala-2.12/delta-hive-assembly_2.12-0.4.1.jar
+hive/target/scala-2.12/delta-hive-assembly_2.12-x.y.z.jar
 ```
 
 This uber JAR includes the Hive connector and all its dependencies. They need to be put in Hive’s classpath.
@@ -23,7 +23,7 @@ This uber JAR includes the Hive connector and all its dependencies. They need to
 Note: if you would like to build using Scala 2.11, you can run the SBT command `build/sbt "++ 2.11.12 hiveAssembly/assembly"` to generate the following JAR:
 
 ```
-hive/target/scala-2.11/delta-hive-assembly_2.11-0.4.1.jar
+hive/target/scala-2.11/delta-hive-assembly_2.11-x.y.z.jar
 ```
 
 ## Setting up Hive


### PR DESCRIPTION
Updates versions from 0.4.1 to 0.5.0. Merge to master just after 0.5.0 release. This commit has been added to `branch-0.5` already.