### PR TITLE
Minor fixes integration tests

### DIFF
--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -26,8 +26,7 @@ lazy val commonSettings = Seq(
   resolvers += Resolver.mavenLocal,
   libraryDependencies ++= Seq(
     "io.delta" %% "delta-standalone" % getStandaloneVersion(),
-    "org.apache.hadoop" % "hadoop-client" % "3.1.0",
-    "org.apache.parquet" % "parquet-hadoop" % "1.10.1"
+    "org.apache.hadoop" % "hadoop-client" % "3.1.0"
   )
 )
 
@@ -74,6 +73,11 @@ lazy val flinkExample = (project in file("flink-example")) settings (
     "org.apache.flink" %% "flink-parquet" % flinkVersion,
     "org.apache.flink" % "flink-table-common" % flinkVersion,
     "org.apache.hadoop" % "hadoop-client" % flinkHadoopVersion,
+
+    // Log4j runtime dependencies
+    "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.12.1" % "runtime",
+    "org.apache.logging.log4j" % "log4j-api" % "2.12.1" % "runtime",
+    "org.apache.logging.log4j" % "log4j-core" % "2.12.1" % "runtime",
 
     // Below dependencies are needed only to run the example project in memory
     "org.apache.flink" %% "flink-clients" % flinkVersion,

--- a/examples/flink-example/src/main/java/org/utils/Utils.java
+++ b/examples/flink-example/src/main/java/org/utils/Utils.java
@@ -31,8 +31,10 @@ public final class Utils {
     public static String resolveExampleTableAbsolutePath(String resourcesTableDir) {
         String rootPath = Paths.get(".").toAbsolutePath().normalize().toString();
         return rootPath.endsWith("flink-example") ?
+            // Maven commands are run from the examples/flink-example/ directory
             rootPath + "/src/main/resources/" + resourcesTableDir :
-            rootPath + "/examples/flink-example/src/main/resources/" + resourcesTableDir;
+            // while SBT commands are run from the examples/ directory
+            rootPath + "/flink-example/src/main/resources/" + resourcesTableDir;
     }
 
     public static void prepareDirs(String tablePath) throws IOException {


### PR DESCRIPTION
- update the `examples/build.sbt` to no longer depend on `parquet-hadoop` (that dependency is shaded in delta-standalone. we only need to provide it when we use the `ParquetSchemaConverter` class).
- we also add logging support inside of `examples/build.sbt`
- minor fix to flink example util, which now correctly lets us run the SBT command given in the flink example [readme](https://github.com/delta-io/connectors/blob/master/examples/flink-example/README.md). Without this change, it was looking side of `examples/examples/flink-example` instead of inside `examples/flink-example`.