### PR TITLE
Update delta-flink javadocs and README.md

### DIFF
--- a/flink/README.md
+++ b/flink/README.md
@@ -173,7 +173,7 @@ The options relevant to this mode are
 - `startingTimestamp` - Starts reading changes from the table version written at or after the given timestamp.
 - `updateCheckIntervalMillis` - The interval, in milliseconds, at which we will check the underlying Delta table for any changes.
 - `ignoreDeletes` - When set to `true`, the Delta Source will be able to process table versions where data is deleted, and skip those deleted records.
-- `ignoreChanges` - When set to `true`, the Delta Source will be able to process table versions where data is changed (i.e. updated), and return those changed records. Note that this can lead to duplicate processing, as some Delta operations, like `UPDATE`, cause existing rows to be rewritten in new files. Those new files will be treated as new data and be reprocessed. This options subsumes `ignoreDeletes`. Therefore, if you set `ignoreChanges` to `true`, your stream will not be disrupted by either deletions or updates to the source table.
+- `ignoreChanges` - When set to `true`, the Delta Source will be able to process table versions where data is changed (i.e. updated), and return those changed records. Note that this can lead to duplicate processing, as some Delta operations, like `UPDATE`, may cause existing rows to be rewritten in new files. Those new files will be treated as new data and be reprocessed. This options subsumes `ignoreDeletes`. Therefore, if you set `ignoreChanges` to `true`, your stream will not be disrupted by either deletions or updates to the source table.
 - `columnNames` - Which columns to read. If not provided, the Delta Source source will read all columns.
 
 #### Table schema discovery

--- a/flink/README.md
+++ b/flink/README.md
@@ -14,9 +14,7 @@ Official Delta Lake connector for [Apache Flink](https://flink.apache.org/).
 - [Delta Source](#delta-source)
   - [Modes](#modes)
     - [Bounded Mode](#bounded-mode)
-      - [Bounded Mode Options](#bounded-mode-options)
     - [Continuous Mode](#continuous-mode)
-      - [Continuous Mode Options](#continuous-mode-options)
   - [Examples](#delta-source-examples)
 - [Usage](#usage)
   - [Maven](#maven)
@@ -160,8 +158,7 @@ The `DeltaSource` class provides factory methods to create sources for both mode
 ### Bounded Mode
 Suitable for batch jobs, where we want to read content of Delta table for specific table version only. Create a source of this mode using the `DeltaSource.forBoundedRowData` API.
 
-#### Bounded Mode Options
-The relevant options for this mode are
+The options relevant to this mode are
 - `versionAsOf` - Loads the state of the Delta table at that version.
 - `timestampAsOf` - Loads the state of the Delta table at the table version written at or before the given timestamp.
 - `columnNames` - Which columns to read. If not provided, the Delta Source source will read all columns.
@@ -171,8 +168,7 @@ Suitable for streaming jobs, where we want to continuously check the Delta table
 
 Note that by default, the Delta Source will load the full state of the latest Delta table, and then start streaming changes. When you use the `startingTimestamp` or `startingVersion` APIs on the `ContinuousDeltaSourceBuilder`, then the Delta Source will process changes only from that corresponding historical version.
 
-#### Continuous Mode Options
-The relevant options for this mode are
+The options relevant to this mode are
 - `startingVersion` - Starts reading changes from this table version.
 - `startingTimestamp` - Starts reading changes from the table version written at or after the given timestamp.
 - `updateCheckIntervalMillis` - The interval, in milliseconds, at which we will check the underlying Delta table for any changes.

--- a/flink/README.md
+++ b/flink/README.md
@@ -13,6 +13,10 @@ Official Delta Lake connector for [Apache Flink](https://flink.apache.org/).
   - [Examples](#delta-sink-examples)
 - [Delta Source](#delta-source)
   - [Modes](#modes)
+    - [Bounded Mode](#bounded-mode)
+      - [Bounded Mode Options](#bounded-mode-options)
+    - [Continuous Mode](#continuous-mode)
+      - [Continuous Mode Options](#continuous-mode-options)
   - [Examples](#delta-source-examples)
 - [Usage](#usage)
   - [Maven](#maven)
@@ -149,12 +153,32 @@ public DataStream<RowData> createDeltaSink(
 
 ### Modes
 
-Delta Source can work in one of two modes:
-- `bounded` - suitable for batch jobs, where we want to read content of Delta table for specific Snapshot version only.
-- `continuous` - suitable for streaming jobs, where we want to read content of Delta table for specific snapshot version and continuously check Delta table for new changes and versions.
+Delta Source can work in one of two modes, described below.
 
-The `DeltaSource` class provides factory methods to create sources for both modes.
-Please see [documentation](https://delta-io.github.io/connectors/latest/delta-flink/api/java/index.html) and examples for details.
+The `DeltaSource` class provides factory methods to create sources for both modes. Please see [documentation](https://delta-io.github.io/connectors/latest/delta-flink/api/java/index.html) and examples for details.
+
+### Bounded Mode
+Suitable for batch jobs, where we want to read content of Delta table for specific table version only. Create a source of this mode using the `DeltaSource.forBoundedRowData` API.
+
+#### Bounded Mode Options
+The relevant options for this mode are
+- `versionAsOf` - Loads the state of the Delta table at that version.
+- `timestampAsOf` - Loads the state of the Delta table at the table version written at or before the given timestamp.
+- `columnNames` - Which columns to read. If not provided, the Delta Source source will read all columns.
+
+### Continuous Mode
+Suitable for streaming jobs, where we want to continuously check the Delta table for new changes and versions. Create a source of this mode using the `DeltaSource.forContinuousRowData` API.
+
+Note that by default, the Delta Source will load the full state of the latest Delta table, and then start streaming changes. When you use the `startingTimestamp` or `startingVersion` APIs on the `ContinuousDeltaSourceBuilder`, then the Delta Source will process changes only from that corresponding historical version.
+
+#### Continuous Mode Options
+The relevant options for this mode are
+- `startingVersion` - Starts reading changes from this table version.
+- `startingTimestamp` - Starts reading changes from the table version written at or after the given timestamp.
+- `updateCheckIntervalMillis` - The interval, in milliseconds, at which we will check the underlying Delta table for any changes.
+- `ignoreDeletes` - When set to `true`, the Delta Source will be able to process table versions where data is deleted, and skip those deleted records.
+- `ignoreChanges` - When set to `true`, the Delta Source will be able to process table versions where data is changed (i.e. updated), and return those changed records. Note that this can lead to duplicate processing, as some Delta operations, like `UPDATE`, cause existing rows to be rewritten in new files. Those new files will be treated as new data and be reprocessed. This options subsumes `ignoreDeletes`. Therefore, if you set `ignoreChanges` to `true`, your stream will not be disrupted by either deletions or updates to the source table.
+- `columnNames` - Which columns to read. If not provided, the Delta Source source will read all columns.
 
 #### Table schema discovery
 

--- a/flink/src/main/java/io/delta/flink/source/RowDataBoundedDeltaSourceBuilder.java
+++ b/flink/src/main/java/io/delta/flink/source/RowDataBoundedDeltaSourceBuilder.java
@@ -66,13 +66,13 @@ public class RowDataBoundedDeltaSourceBuilder
     }
 
     /**
-     * Sets value of "versionAsOf" option. With this option we will load the given
-     * {@link io.delta.standalone.Snapshot} version and read from it.
+     * Sets value of "versionAsOf" option. With this option we will load the given table version and
+     * read from it.
      *
      * <p>
      * This option is mutually exclusive with {@link #timestampAsOf(String)} option.
      *
-     * @param snapshotVersion Delta {@link io.delta.standalone.Snapshot} version to time travel to.
+     * @param snapshotVersion Delta table version to time travel to.
      */
     @Override
     public RowDataBoundedDeltaSourceBuilder versionAsOf(long snapshotVersion) {
@@ -80,8 +80,8 @@ public class RowDataBoundedDeltaSourceBuilder
     }
 
     /**
-     * Sets value of "timestampAsOf" option. With this option we will load the latest
-     * {@link io.delta.standalone.Snapshot} that was generated at or before the given timestamp.
+     * Sets value of "timestampAsOf" option. With this option we will load the latest table version
+     * that was generated at or before the given timestamp.
      * <p>
      * This option is mutually exclusive with {@link #versionAsOf(long)} option.
      *
@@ -146,7 +146,7 @@ public class RowDataBoundedDeltaSourceBuilder
 
     /**
      * Creates an instance of {@link DeltaSource} for a stream of {@link RowData}. Created source
-     * will work in Bounded mode, meaning it will read the content of the configured Delta Snapshot
+     * will work in Bounded mode, meaning it will read the content of the configured Delta snapshot
      * at the fixed version, ignoring all changes done to this table after starting this source.
      *
      * <p>

--- a/flink/src/main/java/io/delta/flink/source/RowDataBoundedDeltaSourceBuilder.java
+++ b/flink/src/main/java/io/delta/flink/source/RowDataBoundedDeltaSourceBuilder.java
@@ -42,7 +42,7 @@ public class RowDataBoundedDeltaSourceBuilder
      * Specifies a {@link List} of column names that should be read from Delta table. If this method
      * is not used, Source will read all columns from Delta table.
      * <p>
-     * Is provided List is null or contains null, empty or blank elements it will cause to throw a
+     * If provided List is null or contains null, empty or blank elements it will throw a
      * {@code DeltaSourceValidationException} by builder after calling {@code build()} method.
      *
      * @param columnNames column names that should be read.
@@ -56,7 +56,7 @@ public class RowDataBoundedDeltaSourceBuilder
      * Specifies an array of column names that should be read from Delta table. If this method
      * is not used, Source will read all columns from Delta table.
      * <p>
-     * Is provided List is null or contains null, empty or blank elements it will cause to throw a
+     * If provided List is null or contains null, empty or blank elements it will throw a
      * {@code DeltaSourceValidationException} by builder after calling {@code build()} method.
      *
      * @param columnNames column names that should be read.
@@ -66,10 +66,8 @@ public class RowDataBoundedDeltaSourceBuilder
     }
 
     /**
-     * Sets value of "versionAsOf" option. Applicable for
-     * {@link org.apache.flink.api.connector.source.Boundedness#BOUNDED}
-     * mode only. With this option we can time travel to given {@link io.delta.standalone.Snapshot}
-     * version and read from it.
+     * Sets value of "versionAsOf" option. With this option we will load the given
+     * {@link io.delta.standalone.Snapshot} version and read from it.
      *
      * <p>
      * This option is mutually exclusive with {@link #timestampAsOf(String)} option.
@@ -82,10 +80,8 @@ public class RowDataBoundedDeltaSourceBuilder
     }
 
     /**
-     * Sets value of "timestampAsOf" option. Applicable for
-     * {@link org.apache.flink.api.connector.source.Boundedness#BOUNDED}
-     * mode only. With this option we can time travel to the latest {@link
-     * io.delta.standalone.Snapshot} that was generated at or before given timestamp.
+     * Sets value of "timestampAsOf" option. With this option we will load the latest
+     * {@link io.delta.standalone.Snapshot} that was generated at or before the given timestamp.
      * <p>
      * This option is mutually exclusive with {@link #versionAsOf(long)} option.
      *
@@ -150,8 +146,8 @@ public class RowDataBoundedDeltaSourceBuilder
 
     /**
      * Creates an instance of {@link DeltaSource} for a stream of {@link RowData}. Created source
-     * will work in Bounded mode, meaning it will read content of configured Delta's snapshot
-     * version ignoring all changes done to this table after starting this source.
+     * will work in Bounded mode, meaning it will read the content of the configured Delta Snapshot
+     * at the fixed version, ignoring all changes done to this table after starting this source.
      *
      * <p>
      * This method can throw {@code DeltaSourceValidationException} in case of invalid arguments

--- a/flink/src/main/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilder.java
+++ b/flink/src/main/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilder.java
@@ -144,15 +144,10 @@ public class RowDataContinuousDeltaSourceBuilder
     }
 
     /**
-     * Sets the "ignoreDeletes" option. This option allows processing Delta table versions
-     * containing only {@link io.delta.standalone.actions.RemoveFile} actions.
-     *
-     * <p> If this option is set to true, Source connector will not throw an exception when
-     * processing version containing only {@link io.delta.standalone.actions.RemoveFile} actions
-     * regardless of {@link io.delta.standalone.actions.RemoveFile#isDataChange()} flag.
-     *
+     * Sets the "ignoreDeletes" option. This option allows processing Delta table versions where
+     * data is deleted.
      * <p>
-     * The default value for these options is false.
+     * The default value for these option is false.
      */
     @Override
     public RowDataContinuousDeltaSourceBuilder ignoreDeletes(boolean ignoreDeletes) {
@@ -160,15 +155,13 @@ public class RowDataContinuousDeltaSourceBuilder
     }
 
     /**
-     * Sets the "ignoreChanges" option. This option allows processing Delta table versions
-     * containing both {@link io.delta.standalone.actions.RemoveFile} and
-     * {@link io.delta.standalone.actions.AddFile} actions. This option subsumes
-     * {@link #ignoreDeletes} option.
+     * Sets the "ignoreChanges" option. This option allows processing Delta table versions where
+     * data is changed (i.e. updated), or deleted. This option subsumes {@link #ignoreDeletes}
+     * option. Therefore if you use ignoreChanges, your stream will not be disrupted by either
+     * deletions or updates to the source table.
      *
-     * <p> If this option is set to true, Source connector will not
-     * throw an exception when processing version containing combination of {@link
-     * io.delta.standalone.actions.RemoveFile} and {@link io.delta.standalone.actions.AddFile}
-     * actions regardless of {@link io.delta.standalone.actions.RemoveFile#isDataChange()} flag.
+     * <p>
+     * The default value for these option is false.
      */
     @Override
     public RowDataContinuousDeltaSourceBuilder ignoreChanges(boolean ignoreChanges) {

--- a/flink/src/main/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilder.java
+++ b/flink/src/main/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilder.java
@@ -73,8 +73,8 @@ public class RowDataContinuousDeltaSourceBuilder
     }
 
     /**
-     * Sets value of "startingVersion" option. This option specifies the
-     * {@link io.delta.standalone.Snapshot} version from which we want to start reading changes.
+     * Sets value of "startingVersion" option. This option specifies the starting table version from
+     * which we want to start reading changes.
      *
      * <p>
      * This option is mutually exclusive with {@link #startingTimestamp(String)} option.
@@ -90,8 +90,8 @@ public class RowDataContinuousDeltaSourceBuilder
     }
 
     /**
-     * Sets value of "startingVersion" option. This option specifies the
-     * {@link io.delta.standalone.Snapshot} version from which we want to start reading changes.
+     * Sets value of "startingVersion" option. This option specifies the starting table version from
+     * which we want to start reading changes.
      *
      * <p>
      * This option is mutually exclusive with {@link #startingTimestamp(String)} option.
@@ -105,8 +105,8 @@ public class RowDataContinuousDeltaSourceBuilder
     }
 
     /**
-     * Sets value of "startingTimestamp" option. This option is used to read only changes from the
-     * {@link io.delta.standalone.Snapshot} that was generated at or before given timestamp.
+     * Sets value of "startingTimestamp" option. This option is used to read only changes starting
+     * from the table version that was generated at or before the given timestamp.
      *
      * <p>
      * This option is mutually exclusive with {@link #startingVersion(String)} and {@link

--- a/flink/src/main/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilder.java
+++ b/flink/src/main/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilder.java
@@ -157,7 +157,7 @@ public class RowDataContinuousDeltaSourceBuilder
      * versions where data is changed (i.e. updated) or deleted.
      * <p>
      * Note that setting this option to true can lead to duplicate processing of data, as, in the
-     * case of updates, existing rows are rewritten in new files, and those new files will be
+     * case of updates, existing rows may be rewritten in new files, and those new files will be
      * treated as new data and be fully reprocessed.
      * <p>
      * This option subsumes {@link #ignoreDeletes} option. Therefore, if you set "ignoreChanges" to

--- a/flink/src/main/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilder.java
+++ b/flink/src/main/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilder.java
@@ -20,7 +20,7 @@ import static io.delta.flink.source.internal.DeltaSourceOptions.LOADED_SCHEMA_SN
  * <p>
  * In Continuous mode, the {@link DeltaSource} will, by default, load the full state of the latest
  * table version, and then start monitoring for changes. If you use either the
- * @link RowDataContinuousDeltaSourceBuilder#startingVersion} or
+ * {@link RowDataContinuousDeltaSourceBuilder#startingVersion} or
  * {@link RowDataContinuousDeltaSourceBuilder#startingTimestamp} APIs, then the {@link DeltaSource}
  * will start monitoring for changes from that historical version. It will not load the full table
  * state at that historical table version.

--- a/flink/src/main/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilder.java
+++ b/flink/src/main/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilder.java
@@ -147,7 +147,7 @@ public class RowDataContinuousDeltaSourceBuilder
      * Sets the "ignoreDeletes" option. This option allows processing Delta table versions where
      * data is deleted.
      * <p>
-     * The default value for these option is false.
+     * The default value for this option is false.
      */
     @Override
     public RowDataContinuousDeltaSourceBuilder ignoreDeletes(boolean ignoreDeletes) {
@@ -161,7 +161,7 @@ public class RowDataContinuousDeltaSourceBuilder
      * deletions or updates to the source table.
      *
      * <p>
-     * The default value for these option is false.
+     * The default value for this option is false.
      */
     @Override
     public RowDataContinuousDeltaSourceBuilder ignoreChanges(boolean ignoreChanges) {

--- a/flink/src/main/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilder.java
+++ b/flink/src/main/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilder.java
@@ -79,10 +79,9 @@ public class RowDataContinuousDeltaSourceBuilder
      * <p>
      * This option is mutually exclusive with {@link #startingTimestamp(String)} option.
      *
-     * @param startingVersion Delta {@link io.delta.standalone.Snapshot} version to start reading
-     *                        changes from. The values can be string numbers like "1", "10" etc. or
-     *                        keyword "latest", where in that case, changes from the latest Delta
-     *                        table version will be read.
+     * @param startingVersion Delta table version to start reading changes from. The values can be
+     *                        string numbers like "1", "10" etc. or keyword "latest", where in that
+     *                        case, changes from the latest Delta table version will be read.
      */
     @Override
     public RowDataContinuousDeltaSourceBuilder startingVersion(String startingVersion) {
@@ -96,8 +95,7 @@ public class RowDataContinuousDeltaSourceBuilder
      * <p>
      * This option is mutually exclusive with {@link #startingTimestamp(String)} option.
      *
-     * @param startingVersion Delta {@link io.delta.standalone.Snapshot} version to start reading
-     *                        changes from.
+     * @param startingVersion Delta table version to start reading changes from.
      */
     @Override
     public RowDataContinuousDeltaSourceBuilder startingVersion(long startingVersion) {
@@ -106,14 +104,14 @@ public class RowDataContinuousDeltaSourceBuilder
 
     /**
      * Sets value of "startingTimestamp" option. This option is used to read only changes starting
-     * from the table version that was generated at or before the given timestamp.
+     * from the table version that was generated at or after the given timestamp.
      *
      * <p>
      * This option is mutually exclusive with {@link #startingVersion(String)} and {@link
      * #startingVersion(long)} option.
      *
-     * @param startingTimestamp The timestamp of {@link io.delta.standalone.Snapshot} that we start
-     *                          reading changes from. Supported formats are:
+     * @param startingTimestamp The timestamp of the table from which we start reading changes.
+     *                          Supported formats are:
      *                          <ul>
      *                                <li>2022-02-24</li>
      *                                <li>2022-02-24 04:55:00</li>
@@ -144,8 +142,8 @@ public class RowDataContinuousDeltaSourceBuilder
     }
 
     /**
-     * Sets the "ignoreDeletes" option. This option allows processing Delta table versions where
-     * data is deleted.
+     * Sets the "ignoreDeletes" option. When set to true, this option allows processing Delta table
+     * versions where data is deleted.
      * <p>
      * The default value for this option is false.
      */
@@ -155,11 +153,15 @@ public class RowDataContinuousDeltaSourceBuilder
     }
 
     /**
-     * Sets the "ignoreChanges" option. This option allows processing Delta table versions where
-     * data is changed (i.e. updated), or deleted. This option subsumes {@link #ignoreDeletes}
-     * option. Therefore if you use ignoreChanges, your stream will not be disrupted by either
-     * deletions or updates to the source table.
-     *
+     * Sets the "ignoreChanges" option. When set to true, this option allows processing Delta table
+     * versions where data is changed (i.e. updated) or deleted.
+     * <p>
+     * Note that setting this option to true can lead to duplicate processing of data, as, in the
+     * case of updates, existing rows are rewritten in new files, and those new files will be
+     * treated as new data and be fully reprocessed.
+     * <p>
+     * This option subsumes {@link #ignoreDeletes} option. Therefore, if you set "ignoreChanges" to
+     * true, your stream will not be disrupted by either deletions or updates to the source table.
      * <p>
      * The default value for this option is false.
      */

--- a/flink/src/main/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilder.java
+++ b/flink/src/main/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilder.java
@@ -18,6 +18,13 @@ import static io.delta.flink.source.internal.DeltaSourceOptions.LOADED_SCHEMA_SN
  * A builder class for {@link DeltaSource} for a stream of {@link RowData} where the created source
  * instance will operate in Continuous mode.
  * <p>
+ * In Continuous mode, the {@link DeltaSource} will, by default, load the full state of the latest
+ * table version, and then start monitoring for changes. If you use either the
+ * @link RowDataContinuousDeltaSourceBuilder#startingVersion} or
+ * {@link RowDataContinuousDeltaSourceBuilder#startingTimestamp} APIs, then the {@link DeltaSource}
+ * will start monitoring for changes from that historical version. It will not load the full table
+ * state at that historical table version.
+ * <p>
  * For most common use cases use {@link DeltaSource#forContinuousRowData} utility method to
  * instantiate the source. After instantiation of this builder you can either call {@link
  * RowDataBoundedDeltaSourceBuilder#build()} method to get the instance of a {@link DeltaSource} or
@@ -42,7 +49,7 @@ public class RowDataContinuousDeltaSourceBuilder
      * Specifies a {@link List} of column names that should be read from Delta table. If this method
      * is not used, Source will read all columns from Delta table.
      * <p>
-     * Is provided List is null or contains null, empty or blank elements it will cause to throw a
+     * If provided List is null or contains null, empty or blank elements it will throw a
      * {@code DeltaSourceValidationException} by builder after calling {@code build()} method.
      *
      * @param columnNames column names that should be read.
@@ -56,7 +63,7 @@ public class RowDataContinuousDeltaSourceBuilder
      * Specifies an array of column names that should be read from Delta table. If this method
      * is not used, Source will read all columns from Delta table.
      * <p>
-     * Is provided List is null or contains null, empty or blank elements it will cause to throw a
+     * If provided List is null or contains null, empty or blank elements it will throw a
      * {@code DeltaSourceValidationException} by builder after calling {@code build()} method.
      *
      * @param columnNames column names that should be read.
@@ -66,10 +73,8 @@ public class RowDataContinuousDeltaSourceBuilder
     }
 
     /**
-     * Sets value of "startingVersion" option. Applicable for
-     * {@link org.apache.flink.api.connector.source.Boundedness#CONTINUOUS_UNBOUNDED}
-     * mode only. This option specifies the {@link io.delta.standalone.Snapshot} version from which
-     * we want to start reading the changes.
+     * Sets value of "startingVersion" option. This option specifies the
+     * {@link io.delta.standalone.Snapshot} version from which we want to start reading changes.
      *
      * <p>
      * This option is mutually exclusive with {@link #startingTimestamp(String)} option.
@@ -85,10 +90,8 @@ public class RowDataContinuousDeltaSourceBuilder
     }
 
     /**
-     * Sets value of "startingVersion" option. Applicable for
-     * {@link org.apache.flink.api.connector.source.Boundedness#CONTINUOUS_UNBOUNDED}
-     * mode only. This option specifies the {@link io.delta.standalone.Snapshot} version from which
-     * we want to start reading the changes.
+     * Sets value of "startingVersion" option. This option specifies the
+     * {@link io.delta.standalone.Snapshot} version from which we want to start reading changes.
      *
      * <p>
      * This option is mutually exclusive with {@link #startingTimestamp(String)} option.
@@ -102,10 +105,8 @@ public class RowDataContinuousDeltaSourceBuilder
     }
 
     /**
-     * Sets value of "startingTimestamp" option. Applicable for {@link
-     * org.apache.flink.api.connector.source.Boundedness#CONTINUOUS_UNBOUNDED} mode only. This
-     * option is used to read only changes from {@link io.delta.standalone.Snapshot} that was
-     * generated at or before given timestamp.
+     * Sets value of "startingTimestamp" option. This option is used to read only changes from the
+     * {@link io.delta.standalone.Snapshot} that was generated at or before given timestamp.
      *
      * <p>
      * This option is mutually exclusive with {@link #startingVersion(String)} and {@link
@@ -128,10 +129,8 @@ public class RowDataContinuousDeltaSourceBuilder
     }
 
     /**
-     * Sets the value for "updateCheckIntervalMillis" option. Applicable for {@link
-     * org.apache.flink.api.connector.source.Boundedness#CONTINUOUS_UNBOUNDED} mode only. This
-     * option is used to specify the check interval (in milliseconds) used for periodic Delta table
-     * changes checks.
+     * Sets the value for "updateCheckIntervalMillis" option. This option is used to specify the
+     * check interval (in milliseconds) used for periodic Delta table changes checks.
      *
      * <p>
      * The default value for this option is 5000 ms.
@@ -145,10 +144,8 @@ public class RowDataContinuousDeltaSourceBuilder
     }
 
     /**
-     * Sets the "ignoreDeletes" option. Applicable for
-     * {@link org.apache.flink.api.connector.source.Boundedness#CONTINUOUS_UNBOUNDED}
-     * mode only. This option allows processing Delta table versions containing only {@link
-     * io.delta.standalone.actions.RemoveFile} actions.
+     * Sets the "ignoreDeletes" option. This option allows processing Delta table versions
+     * containing only {@link io.delta.standalone.actions.RemoveFile} actions.
      *
      * <p> If this option is set to true, Source connector will not throw an exception when
      * processing version containing only {@link io.delta.standalone.actions.RemoveFile} actions
@@ -163,11 +160,10 @@ public class RowDataContinuousDeltaSourceBuilder
     }
 
     /**
-     * Sets the "ignoreChanges" option. Applicable for
-     * {@link org.apache.flink.api.connector.source.Boundedness#CONTINUOUS_UNBOUNDED}
-     * mode only. This option allows processing Delta table versions containing both {@link
-     * io.delta.standalone.actions.RemoveFile} and {@link io.delta.standalone.actions.AddFile}
-     * actions. This option subsumes {@link #ignoreDeletes} option.
+     * Sets the "ignoreChanges" option. This option allows processing Delta table versions
+     * containing both {@link io.delta.standalone.actions.RemoveFile} and
+     * {@link io.delta.standalone.actions.AddFile} actions. This option subsumes
+     * {@link #ignoreDeletes} option.
      *
      * <p> If this option is set to true, Source connector will not
      * throw an exception when processing version containing combination of {@link


### PR DESCRIPTION
- Clarify in the README that the continuous delta source can either load the full table state and then start streaming changes, or just stream changes.
- Add delta options to the README
- Various javadoc improvements.
