### PR TITLE
Cache the partition pruning result in FilteredDeltaScanImpl to improve performance

### DIFF
--- a/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
@@ -68,7 +68,8 @@ private[internal] class SnapshotImpl(
     new FilteredDeltaScanImpl(
       memoryOptimizedLogReplay,
       predicate,
-      metadataScala.partitionSchema)
+      metadataScala.partitionSchema,
+      hadoopConf)
 
   override def getAllFiles: java.util.List[AddFileJ] = activeFilesJ
 
@@ -103,7 +104,8 @@ private[internal] class SnapshotImpl(
     new FilteredDeltaScanImpl(
       memoryOptimizedLogReplay,
       predicate,
-      metadataScala.partitionSchema)
+      metadataScala.partitionSchema,
+      hadoopConf)
 
   def tombstones: Seq[RemoveFileJ] = state.tombstones.toSeq.map(ConversionUtils.convertRemoveFile)
   def setTransactions: Seq[SetTransactionJ] =
@@ -305,5 +307,10 @@ private class InitialSnapshotImpl(
   override def scan(): DeltaScan = new DeltaScanImpl(memoryOptimizedLogReplay)
 
   override def scan(predicate: Expression): DeltaScan =
-    new FilteredDeltaScanImpl(memoryOptimizedLogReplay, predicate, metadataScala.partitionSchema)
+    new FilteredDeltaScanImpl(
+      memoryOptimizedLogReplay,
+      predicate,
+      metadataScala.partitionSchema,
+      hadoopConf
+    )
 }

--- a/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
@@ -43,7 +43,7 @@ final private[internal] class FilteredDeltaScanImpl(
     hadoopConf: Configuration) extends DeltaScanImpl(replay) {
 
   private val partitionColumns = partitionSchema.getFieldNames.toSeq
-  private lazy val evaluationResults = mutable.Map.empty[Map[String, String], Boolean]
+  private val evaluationResults = mutable.Map.empty[Map[String, String], Boolean]
 
   private val (metadataConjunction, dataConjunction) =
     PartitionUtils.splitMetadataAndDataPredicates(expr, partitionColumns)

--- a/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
@@ -54,7 +54,9 @@ final private[internal] class FilteredDeltaScanImpl(
   override protected def accept(addFile: AddFile): Boolean = {
     if (metadataConjunction.isEmpty) return true
 
-    val partitionRowRecord = new PartitionRowRecord(partitionSchema, addFile.partitionValues)
+    // found in micro-benchmarking that eagerly creating
+    // new PartitionRowRecord can destroy the purpose of caching
+    lazy val partitionRowRecord = new PartitionRowRecord(partitionSchema, addFile.partitionValues)
 
     if (partitionFilterRecordCachingEnabled) {
       val cachedResult = evaluationResults.get(addFile.partitionValues)

--- a/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
@@ -20,11 +20,14 @@ import java.util.Optional
 
 import scala.collection.mutable
 
+import org.apache.hadoop.conf.Configuration
+
 import io.delta.standalone.expressions.Expression
 import io.delta.standalone.types.StructType
 
 import io.delta.standalone.internal.actions.{AddFile, MemoryOptimizedLogReplay}
 import io.delta.standalone.internal.data.PartitionRowRecord
+import io.delta.standalone.internal.sources.StandaloneHadoopConf
 import io.delta.standalone.internal.util.PartitionUtils
 
 /**
@@ -36,24 +39,33 @@ import io.delta.standalone.internal.util.PartitionUtils
 final private[internal] class FilteredDeltaScanImpl(
     replay: MemoryOptimizedLogReplay,
     expr: Expression,
-    partitionSchema: StructType) extends DeltaScanImpl(replay) {
+    partitionSchema: StructType,
+    hadoopConf: Configuration) extends DeltaScanImpl(replay) {
 
   private val partitionColumns = partitionSchema.getFieldNames.toSeq
-  private val evaluationResults = mutable.Map.empty[Map[String, String], Boolean]
+  private lazy val evaluationResults = mutable.Map.empty[Map[String, String], Boolean]
 
   private val (metadataConjunction, dataConjunction) =
     PartitionUtils.splitMetadataAndDataPredicates(expr, partitionColumns)
 
+  private val partitionFilterRecordCachingEnabled = hadoopConf
+    .getBoolean(StandaloneHadoopConf.PARTITION_FILTER_RECORD_CACHING_KEY, true)
+
   override protected def accept(addFile: AddFile): Boolean = {
     if (metadataConjunction.isEmpty) return true
 
-    val cachedResult = evaluationResults.get(addFile.partitionValues)
-    if (cachedResult.isDefined) return cachedResult.get
-
     val partitionRowRecord = new PartitionRowRecord(partitionSchema, addFile.partitionValues)
-    val result = metadataConjunction.get.eval(partitionRowRecord).asInstanceOf[Boolean]
-    evaluationResults(addFile.partitionValues) = result
-    result
+
+    if (partitionFilterRecordCachingEnabled) {
+      val cachedResult = evaluationResults.get(addFile.partitionValues)
+      if (cachedResult.isDefined) return cachedResult.get
+      val result = metadataConjunction.get.eval(partitionRowRecord).asInstanceOf[Boolean]
+      evaluationResults(addFile.partitionValues) = result
+      result
+    } else {
+      val result = metadataConjunction.get.eval(partitionRowRecord).asInstanceOf[Boolean]
+      result
+    }
   }
 
   override def getInputPredicate: Optional[Expression] = Optional.of(expr)

--- a/standalone/src/main/scala/io/delta/standalone/internal/sources/StandaloneHadoopConf.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/sources/StandaloneHadoopConf.scala
@@ -29,4 +29,12 @@ private[internal] object StandaloneHadoopConf {
 
   /** Key for the class name of the desired [[LogStore]] implementation to be used. */
   val LOG_STORE_CLASS_KEY = "delta.logStore.class"
+
+  /**
+   * If enabled, partition values evaluation result will be cached in partition pruning in
+   * `FilteredDeltaScanImpl::accept`.
+   * By default, this feature is enabled. Set to `false` to disable.
+   */
+  val PARTITION_FILTER_RECORD_CACHING_KEY =
+    "io.delta.standalone.partitionFilterRecordCaching.enabled"
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/BenchmarkPartitionFilterRecordCachingSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/BenchmarkPartitionFilterRecordCachingSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2020-present) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.delta.standalone.internal
 
 import java.io.File
@@ -50,7 +66,7 @@ class BenchmarkPartitionFilterRecordCachingSuite extends FunSuite with Logging {
       "col1" -> (i % 2).toString,
       "col2" -> (i % 3).toString,
       "col3" -> (i % 2).toString,
-      "col4" -> (i % 5).toString,
+      "col4" -> (i % 5).toString
     )
     AddFile(i.toString, partitionValues, 1L, 1L, dataChange = true)
   }
@@ -62,7 +78,7 @@ class BenchmarkPartitionFilterRecordCachingSuite extends FunSuite with Logging {
     ),
     new And(
       new EqualTo(partitionSchema.column("col3"), Literal.of("1")),
-      new EqualTo(partitionSchema.column("col4"), Literal.of("4")),
+      new EqualTo(partitionSchema.column("col4"), Literal.of("4"))
     )
   )
 

--- a/standalone/src/test/scala/io/delta/standalone/internal/BenchmarkPartitionFilterRecordCachingSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/BenchmarkPartitionFilterRecordCachingSuite.scala
@@ -30,14 +30,14 @@ class BenchmarkPartitionFilterRecordCachingSuite extends FunSuite with Logging {
     new StructField("col2", new StringType(), true),
     new StructField("col3", new StringType(), true),
     new StructField("col4", new StringType(), true),
-    new StructField("col5", new IntegerType(), true),
+    new StructField("col5", new IntegerType(), true)
   ))
 
   private val partitionSchema = new StructType(Array(
     new StructField("col1", new StringType(), true),
     new StructField("col2", new StringType(), true),
     new StructField("col3", new StringType(), true),
-    new StructField("col4", new StringType(), true),
+    new StructField("col4", new StringType(), true)
   ))
 
   private val metadata = Metadata(
@@ -109,6 +109,6 @@ class BenchmarkPartitionFilterRecordCachingSuite extends FunSuite with Logging {
     val totalTimesCaching = elapsedTimesWithCaching.sum
     val totalTimesNoCaching = elapsedTimesWithoutCaching.sum
 
-    assert( totalTimesCaching < totalTimesNoCaching)
+    assert(totalTimesCaching < totalTimesNoCaching)
   }
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/BenchmarkPartitionFilterRecordCachingSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/BenchmarkPartitionFilterRecordCachingSuite.scala
@@ -1,0 +1,104 @@
+package io.delta.standalone.internal
+
+import java.io.File
+
+import scala.collection.mutable
+
+import org.apache.hadoop.conf.Configuration
+import org.scalatest.{FunSuite, Ignore}
+
+import io.delta.standalone.Operation
+import io.delta.standalone.expressions.{And, EqualTo, Literal}
+import io.delta.standalone.types._
+
+import io.delta.standalone.internal.actions.{AddFile, Metadata}
+import io.delta.standalone.internal.logging.Logging
+import io.delta.standalone.internal.sources.StandaloneHadoopConf
+import io.delta.standalone.internal.util.TestUtils._
+
+@Ignore
+class BenchmarkPartitionFilterRecordCachingSuite extends FunSuite with Logging {
+
+  private val op = new Operation(Operation.Name.WRITE)
+
+  private val schema = new StructType(Array(
+    new StructField("col1", new StringType(), true),
+    new StructField("col2", new StringType(), true),
+    new StructField("col3", new StringType(), true),
+    new StructField("col4", new IntegerType(), true)
+  ))
+
+  private val partitionSchema = new StructType(Array(
+    new StructField("col1", new StringType(), true),
+    new StructField("col2", new StringType(), true),
+    new StructField("col3", new StringType(), true),
+  ))
+
+  private val metadata = Metadata(
+    partitionColumns = partitionSchema.getFieldNames,
+    schemaString = schema.toJson
+  )
+
+  private val addFiles = (1 to 10000).map { i =>
+    val partitionValues = Map(
+      "col1" -> (i % 2).toString,
+      "col2" -> (i % 3).toString,
+      "col3" -> (i % 2).toString,
+    )
+    AddFile(i.toString, partitionValues, 1L, 1L, dataChange = true)
+  }
+
+  private val filter = new And(
+    new EqualTo(partitionSchema.column("col3"), Literal.of("1")),
+    new And(
+      new EqualTo(partitionSchema.column("col1"), Literal.of("1")),
+      new EqualTo(partitionSchema.column("col2"), Literal.of("2"))
+    )
+  )
+
+  private def scanAndMeasureTime(configuration: Configuration, file: File): Long = {
+    val deltaLog = DeltaLogImpl.forTable(configuration, file.getCanonicalPath)
+    deltaLog.startTransaction().commit(metadata :: Nil, op, "engineInfo")
+    deltaLog.startTransaction().commit(addFiles, op, "engineInfo")
+    val scan = deltaLog.update().scan(filter)
+
+    val start = System.nanoTime()
+
+    val iter = scan.getFiles
+    while (iter.hasNext) {
+      iter.hasNext
+      iter.next()
+    }
+    iter.close()
+
+    val elapsed = System.nanoTime() - start
+    elapsed
+  }
+
+  test("micro-benchmark with/ without partition filter record caching") {
+    val conf = new Configuration()
+    val confDisabledCaching = new Configuration()
+    confDisabledCaching.setBoolean(StandaloneHadoopConf.PARTITION_FILTER_RECORD_CACHING_KEY, false)
+
+    val elapsedTimesWithCaching = mutable.ArrayBuffer.empty[Long]
+    val elapsedTimesWithoutCaching = mutable.ArrayBuffer.empty[Long]
+
+
+    (1 to 200).foreach { _ =>
+      withTempDir { dir =>
+        val elapsed = scanAndMeasureTime(conf, dir)
+        elapsedTimesWithCaching.append(elapsed)
+      }
+
+      withTempDir { dir =>
+        val elapsed = scanAndMeasureTime(confDisabledCaching, dir)
+        elapsedTimesWithoutCaching.append(elapsed)
+      }
+    }
+
+    val totalTimesCaching = elapsedTimesWithCaching.sum
+    val totalTimesNoCaching = elapsedTimesWithoutCaching.sum
+
+    assert( totalTimesCaching < totalTimesNoCaching)
+  }
+}


### PR DESCRIPTION
Cache the partition pruning result in FilteredDeltaScanImpl to improve performance (#399)
Signed-off-by: sonhmai <14060682+sonhmai@users.noreply.github.com>

Benchmark result: elapsed times, total 200 scans, 10k AddFile ops
- With Caching: total 6.448519193 secs, avg per scan 32.242595965 ms
- Without Caching: 7.452229266 secs, avg per run 37.26114633 ms
- Caching saves on avg 5.018550365 ms per scan