### PR TITLE
Column stats file pruning: feature flag

### DIFF
--- a/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
@@ -60,8 +60,8 @@ private[internal] class SnapshotImpl(
     new MemoryOptimizedLogReplay(files, deltaLog.store, hadoopConf, deltaLog.timezone)
 
   /** Feature flag of stats based file pruning. */
-  private val statsSkippingFlag = hadoopConf
-    .getBoolean(StandaloneHadoopConf.STATS_SKIPPING_KEY, false)
+  private val statsSkippingEnabled = hadoopConf
+    .getBoolean(StandaloneHadoopConf.STATS_SKIPPING_KEY, true)
 
   ///////////////////////////////////////////////////////////////////////////
   // Public API Methods
@@ -75,7 +75,7 @@ private[internal] class SnapshotImpl(
       predicate,
       metadataScala.partitionSchema,
       metadataScala.dataSchema,
-      statsSkippingFlag)
+      hadoopConf)
 
   override def getAllFiles: java.util.List[AddFileJ] = activeFilesJ
 
@@ -112,7 +112,7 @@ private[internal] class SnapshotImpl(
       predicate,
       metadataScala.partitionSchema,
       metadataScala.dataSchema,
-      statsSkippingFlag)
+      hadoopConf)
 
   def tombstones: Seq[RemoveFileJ] = state.tombstones.toSeq.map(ConversionUtils.convertRemoveFile)
   def setTransactions: Seq[SetTransactionJ] =
@@ -311,10 +311,6 @@ private class InitialSnapshotImpl(
 
   override lazy val metadataScala: Metadata = Metadata()
 
-  /** Feature flag of stats based file pruning. */
-  private val statsSkippingFlag = hadoopConf
-    .getBoolean(StandaloneHadoopConf.STATS_SKIPPING_KEY, false)
-
   override def scan(): DeltaScan = new DeltaScanImpl(memoryOptimizedLogReplay)
 
   override def scan(predicate: Expression): DeltaScan =
@@ -323,5 +319,5 @@ private class InitialSnapshotImpl(
       predicate,
       metadataScala.partitionSchema,
       metadataScala.dataSchema,
-      statsSkippingFlag)
+      hadoopConf)
 }

--- a/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
@@ -59,10 +59,6 @@ private[internal] class SnapshotImpl(
   private val memoryOptimizedLogReplay =
     new MemoryOptimizedLogReplay(files, deltaLog.store, hadoopConf, deltaLog.timezone)
 
-  /** Feature flag of stats based file pruning. */
-  private val statsSkippingEnabled = hadoopConf
-    .getBoolean(StandaloneHadoopConf.STATS_SKIPPING_KEY, true)
-
   ///////////////////////////////////////////////////////////////////////////
   // Public API Methods
   ///////////////////////////////////////////////////////////////////////////

--- a/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
@@ -20,11 +20,14 @@ import java.util.Optional
 
 import scala.util.control.NonFatal
 
+import org.apache.hadoop.conf.Configuration
+
 import io.delta.standalone.expressions.Expression
 import io.delta.standalone.types.StructType
 
 import io.delta.standalone.internal.actions.{AddFile, MemoryOptimizedLogReplay}
 import io.delta.standalone.internal.data.{ColumnStatsRowRecord, PartitionRowRecord}
+import io.delta.standalone.internal.sources.StandaloneHadoopConf
 import io.delta.standalone.internal.util.{DataSkippingUtils, PartitionUtils}
 
 /**
@@ -38,12 +41,16 @@ final private[internal] class FilteredDeltaScanImpl(
     expr: Expression,
     partitionSchema: StructType,
     dataSchema: StructType,
-    statsSkippingFlag: Boolean) extends DeltaScanImpl(replay) {
+    hadoopConf: Configuration) extends DeltaScanImpl(replay) {
 
   private val partitionColumns = partitionSchema.getFieldNames.toSeq
 
   private val (metadataConjunction, dataConjunction) =
     PartitionUtils.splitMetadataAndDataPredicates(expr, partitionColumns)
+
+  /** Feature flag of stats based file pruning. */
+  private val statsSkippingEnabled = hadoopConf
+    .getBoolean(StandaloneHadoopConf.STATS_SKIPPING_KEY, true)
 
   /**
    * If column stats filter is evaluated as true, it means some row in this file may meet the query
@@ -72,7 +79,7 @@ final private[internal] class FilteredDeltaScanImpl(
       true
     }
 
-    if (statsSkippingFlag && partitionFilterResult && columnStatsFilter.isDefined) {
+    if (statsSkippingEnabled && partitionFilterResult && columnStatsFilter.isDefined) {
       // Evaluate the column stats filter when feature flag is true, partition filter passed, and
       // column stats filter is not empty.
 

--- a/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
@@ -80,9 +80,6 @@ final private[internal] class FilteredDeltaScanImpl(
     }
 
     if (statsSkippingEnabled && partitionFilterResult && columnStatsFilter.isDefined) {
-      // Evaluate the column stats filter when stats skipping is enabled, partition filter is
-      // passed, and column stats filter is not empty.
-
       // Get stats value from each AddFile.
       val (fileStats, columnStats) = try {
         DataSkippingUtils.parseColumnStats(dataSchema, addFile.stats)

--- a/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
@@ -37,7 +37,8 @@ final private[internal] class FilteredDeltaScanImpl(
     replay: MemoryOptimizedLogReplay,
     expr: Expression,
     partitionSchema: StructType,
-    dataSchema: StructType) extends DeltaScanImpl(replay) {
+    dataSchema: StructType,
+    statsSkippingFlag: Boolean) extends DeltaScanImpl(replay) {
 
   private val partitionColumns = partitionSchema.getFieldNames.toSeq
 
@@ -71,9 +72,9 @@ final private[internal] class FilteredDeltaScanImpl(
       true
     }
 
-    if (partitionFilterResult && columnStatsFilter.isDefined) {
-      // Evaluate the column stats filter when partition filter passed and column stats filter is
-      // not empty.
+    if (statsSkippingFlag && partitionFilterResult && columnStatsFilter.isDefined) {
+      // Evaluate the column stats filter when feature flag is true, partition filter passed, and
+      // column stats filter is not empty.
 
       // Get stats value from each AddFile.
       val (fileStats, columnStats) = try {

--- a/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/scan/FilteredDeltaScanImpl.scala
@@ -80,8 +80,8 @@ final private[internal] class FilteredDeltaScanImpl(
     }
 
     if (statsSkippingEnabled && partitionFilterResult && columnStatsFilter.isDefined) {
-      // Evaluate the column stats filter when feature flag is true, partition filter passed, and
-      // column stats filter is not empty.
+      // Evaluate the column stats filter when stats skipping is enabled, partition filter is
+      // passed, and column stats filter is not empty.
 
       // Get stats value from each AddFile.
       val (fileStats, columnStats) = try {

--- a/standalone/src/main/scala/io/delta/standalone/internal/sources/StandaloneHadoopConf.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/sources/StandaloneHadoopConf.scala
@@ -31,8 +31,8 @@ private[internal] object StandaloneHadoopConf {
   val LOG_STORE_CLASS_KEY = "delta.logStore.class"
 
   /**
-   * Key for the feature flag of column stats based file pruning in `FilteredDeltaScan`, `true` to
-   * enable this feature, `false` to disable the feature. This key is set to `false` by default.
+   * If enabled, per-column statistics will be used to perform file pruning (aka data skipping) in
+   * `DeltaScan::getFiles`. By default, this feature is enabled. Set to `false` to disable.
    */
-  val STATS_SKIPPING_KEY = "io.delta.standalone.STATS_SKIPPING_KEY"
+  val STATS_SKIPPING_KEY = "io.delta.standalone.statsSkipping.enabled"
 }

--- a/standalone/src/main/scala/io/delta/standalone/internal/sources/StandaloneHadoopConf.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/sources/StandaloneHadoopConf.scala
@@ -29,4 +29,10 @@ private[internal] object StandaloneHadoopConf {
 
   /** Key for the class name of the desired [[LogStore]] implementation to be used. */
   val LOG_STORE_CLASS_KEY = "delta.logStore.class"
+
+  /**
+   * Key for the feature flag of column stats based file pruning in `FilteredDeltaScan`, `true` to
+   * enable this feature, `false` to disable the feature. This key is set to `false` by default.
+   */
+  val STATS_SKIPPING_KEY = "io.delta.standalone.STATS_SKIPPING_KEY"
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DataSkippingSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DataSkippingSuite.scala
@@ -187,7 +187,7 @@ class DataSkippingSuite extends FunSuite {
   }
 
   /**
-   * Query: (col1 == 1 && col2 == 1) (1 <= i <= 20)
+   * Query filter: (col1 == 1 && col2 == 1) (1 <= i <= 20)
    * Column stats filter: (MIN.col1 <= 1 && MAX.col1 >= 1 && MIN.col2 <= 1 && MAX.col2 >= 1)
    */
   test("integration test: column stats filter on 2 non-partition column") {
@@ -207,7 +207,7 @@ class DataSkippingSuite extends FunSuite {
   }
 
   /**
-   * Filter: (col2 == 1 && col2 == 1) (1 <= i <= 20)
+   * Query filter: (col2 == 1 && col2 == 1) (1 <= i <= 20)
    * Column stats filter: (MIN.col2 <= 1 && MAX.col2 >= 1 && MIN.col2 <= 1 && MAX.col2 >= 1)
    */
   test("integration test: multiple filter on 1 non-partition column - duplicate") {
@@ -225,7 +225,7 @@ class DataSkippingSuite extends FunSuite {
   }
 
   /**
-   * Filter: (col2 == 1 AND col2 == 2) (1 <= i <= 20)
+   * Query filter: (col2 == 1 AND col2 == 2) (1 <= i <= 20)
    * Column stats filter: (MIN.col2 <= 1 && MAX.col2 >= 1 && MIN.col2 <= 2 && MAX.col2 >= 2)
    */
   test("integration test: multiple filter on 1 non-partition column - conflict") {
@@ -245,7 +245,7 @@ class DataSkippingSuite extends FunSuite {
   }
 
   /**
-   * Filter: (col1 == 2)
+   * Query filter: (col1 == 2)
    * Column stats filter: (MIN.col1 <= 2 && MAX.col1 >= 2)
    * Output: Return all files. (Column stats filter not work)
    * Reason: Because MIN.col2 and MAX.col2 is used in column stats predicate while not exists in
@@ -261,7 +261,7 @@ class DataSkippingSuite extends FunSuite {
   }
 
   /**
-   * Filter: (col1 == 1 AND col2 == 1)
+   * Query filter: (col1 == 1 AND col2 == 1)
    * Column stats filter: (MIN.col1 <= 1 && MAX.col1 >= 1 && MIN.col2 <= 1 && MAX.col2 >= 1)
    * Output: All files. (Column stats filter not work)
    * Reason: Because MIN.col2 and MAX.col2 is used in column stats predicate while not exists in
@@ -294,7 +294,7 @@ class DataSkippingSuite extends FunSuite {
   }
 
   /**
-   * Filter: (col1 == 1)
+   * Query filter: (col1 == 1)
    * Column stats filter: (MIN.col1 <= 1 && MAX.col1 >= 1)
    * Output: All files. (Column stats filter not work)
    * Reason: Because stats string is empty, we can't evaluate column stats predicate and will skip
@@ -307,7 +307,7 @@ class DataSkippingSuite extends FunSuite {
   }
 
   /**
-   * Filter: (col2 == 1)
+   * Query filter: (col2 == 1)
    * Column stats filter: (MIN.col2 <= 1 && MAX.col2 >= 1)
    * Output: All files. (Column stats filter not work)
    * Reason: Because stats string is broken, we can't evaluate column stats predicate and will skip
@@ -328,7 +328,7 @@ class DataSkippingSuite extends FunSuite {
   }
 
   /**
-   * Filter: (stringCol == "a")
+   * Query filter: (stringCol == "a")
    * Column stats filter: None
    * Output: All files.
    * Reason: Because string type is currently unsupported, we can't evaluate column stats
@@ -341,7 +341,7 @@ class DataSkippingSuite extends FunSuite {
   }
 
   /**
-   * Filter: (col1 <= 1)
+   * Query filter: (col1 <= 1)
    * Column stats filter: None
    * Output: All files.
    * Reason: Because LessThanOrEqual is currently unsupported in building column stats predicate,
@@ -354,7 +354,7 @@ class DataSkippingSuite extends FunSuite {
   }
 
   /**
-   * Filter: (normalCol == 5)
+   * Query filter: (normalCol == 5)
    * Column stats filter: empty
    * Output: All files.
    * Reason: The nested table will not filtered by column stats predicate, because they are not
@@ -507,7 +507,7 @@ class DataSkippingSuite extends FunSuite {
   }
 
   /**
-   * Filter: (col1 == 1 AND col2 == 1)
+   * Query filter: (col1 == 1 AND col2 == 1)
    * Column stats filter: (MIN.col1 <= 1 && MAX.col1 >= 1 && MIN.col2 <= 1 && MAX.col2 >= 1)
    * First Output: (MIN.col1 <= 1 && MAX.col1 >= 1 && MIN.col2 <= 1 && MAX.col2 >= 1)
    * Second Output: All files.

--- a/standalone/src/test/scala/io/delta/standalone/internal/DataSkippingSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DataSkippingSuite.scala
@@ -100,10 +100,7 @@ class DataSkippingSuite extends FunSuite {
       m: Option[Metadata] = None,
       conf: Option[Configuration] = None) (f: DeltaLog => Unit): Unit = {
     withTempDir { dir =>
-      val newConf = new Configuration()
-      newConf.setBoolean(StandaloneHadoopConf.STATS_SKIPPING_KEY, true)
-
-      val log = DeltaLog.forTable(conf.getOrElse(newConf), dir.getCanonicalPath)
+      val log = DeltaLog.forTable(conf.getOrElse(new Configuration()), dir.getCanonicalPath)
       log.startTransaction().commit(m.getOrElse(metadata) :: Nil, op, "engineInfo")
       log.startTransaction().commit(actions, op, "engineInfo")
       f(log)
@@ -528,9 +525,7 @@ class DataSkippingSuite extends FunSuite {
       }
       .map(_.toString)
 
-    // Stats skipping is enabled by default in this suite. However, this feature will be disabled by
-    // default in other conditions.
-
+    // Stats skipping is enabled by default.
     // Testing with stats skipping.
     columnStatsBasedFilePruningTest(expr, expectedResultWithStatsSkipping)
 

--- a/standalone/src/test/scala/io/delta/standalone/internal/DataSkippingSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DataSkippingSuite.scala
@@ -530,6 +530,7 @@ class DataSkippingSuite extends FunSuite {
 
     // Stats skipping is enabled by default in this suite. However, this feature will be disabled by
     // default in other conditions.
+
     // Testing with stats skipping.
     columnStatsBasedFilePruningTest(expr, expectedResultWithStatsSkipping)
 
@@ -539,7 +540,7 @@ class DataSkippingSuite extends FunSuite {
 
     val expectedResultWithoutStatsSkipping = (1 to 20).map(_.toString)
 
-    // Testing with stats skipping.
+    // Testing without stats skipping.
     columnStatsBasedFilePruningTest(
       expr,
       expectedResultWithoutStatsSkipping,

--- a/standalone/src/test/scala/io/delta/standalone/internal/DataSkippingSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DataSkippingSuite.scala
@@ -520,7 +520,8 @@ class DataSkippingSuite extends FunSuite {
       .map(_.toString)
 
     // Stats skipping is enabled by default.
-    // Testing with stats skipping: The files will be filtered by `expectedResultWithStatsSkipping`.
+    // Testing with stats filter, the files are filtered by
+    // `min.col1 <= 1 && max.col1 >= 1 && min.col2 <= 1 && max.col2 >= 1`.
     columnStatsBasedFilePruningTest(expr, expectedResultWithStatsSkipping)
 
     // Disable stats skipping.
@@ -529,7 +530,7 @@ class DataSkippingSuite extends FunSuite {
 
     val expectedResultWithoutStatsSkipping = (1 to 20).map(_.toString)
 
-    // Testing without stats skipping: This will return all the files.
+    // Testing without stats filter, so it will return all the files.
     columnStatsBasedFilePruningTest(
       expr,
       expectedResultWithoutStatsSkipping,

--- a/standalone/src/test/scala/io/delta/standalone/internal/DataSkippingSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DataSkippingSuite.scala
@@ -509,10 +509,10 @@ class DataSkippingSuite extends FunSuite {
   /**
    * Query filter: (col1 == 1 AND col2 == 1)
    * Column stats filter: (MIN.col1 <= 1 && MAX.col1 >= 1 && MIN.col2 <= 1 && MAX.col2 >= 1)
-   * First Output: (MIN.col1 <= 1 && MAX.col1 >= 1 && MIN.col2 <= 1 && MAX.col2 >= 1)
+   * First Output: Files pass the column stats filter.
    * Second Output: All files.
-   * Reason: The first test enabled column stats filter the files are filtered, and the second one
-   * disabled the filter and it returns all the files.
+   * Reason: The first test enabled column stats filter and the output is filtered, but the second
+   * test disabled the filter and it returns all the files.
    */
   test("integration test: feature flag") {
     val expr = new And(

--- a/standalone/src/test/scala/io/delta/standalone/internal/DataSkippingSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DataSkippingSuite.scala
@@ -503,19 +503,13 @@ class DataSkippingSuite extends FunSuite {
     columnStatsDataTypeTest(hits, misses)
   }
 
-  /**
-   * Query filter: (col1 == 1 AND col2 == 1)
-   * Column stats filter: (MIN.col1 <= 1 && MAX.col1 >= 1 && MIN.col2 <= 1 && MAX.col2 >= 1)
-   * First Output: Files pass the column stats filter.
-   * Second Output: All files.
-   * Reason: The first test enabled column stats filter and the output is filtered, but the second
-   * test disabled the filter and it returns all the files.
-   */
   test("integration test: feature flag") {
+    // Query filter: (col1 == 1 AND col2 == 1)
     val expr = new And(
       new EqualTo(schema.column("col1"), Literal.of(1L)),
       new EqualTo(schema.column("col2"), Literal.of(1L)))
 
+    // Column stats filter: (MIN.col1 <= 1 && MAX.col1 >= 1 && MIN.col2 <= 1 && MAX.col2 >= 1)
     val expectedResultWithStatsSkipping = (1 to 20)
       .filter { i =>
         col1Min(i) <= 1 &&
@@ -526,7 +520,7 @@ class DataSkippingSuite extends FunSuite {
       .map(_.toString)
 
     // Stats skipping is enabled by default.
-    // Testing with stats skipping.
+    // Testing with stats skipping: The files will be filtered by `expectedResultWithStatsSkipping`.
     columnStatsBasedFilePruningTest(expr, expectedResultWithStatsSkipping)
 
     // Disable stats skipping.
@@ -535,7 +529,7 @@ class DataSkippingSuite extends FunSuite {
 
     val expectedResultWithoutStatsSkipping = (1 to 20).map(_.toString)
 
-    // Testing without stats skipping.
+    // Testing without stats skipping: This will return all the files.
     columnStatsBasedFilePruningTest(
       expr,
       expectedResultWithoutStatsSkipping,

--- a/standalone/src/test/scala/io/delta/standalone/internal/DataSkippingSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DataSkippingSuite.scala
@@ -520,8 +520,7 @@ class DataSkippingSuite extends FunSuite {
       .map(_.toString)
 
     // Stats skipping is enabled by default.
-    // Testing with stats filter, the files are filtered by
-    // `min.col1 <= 1 && max.col1 >= 1 && min.col2 <= 1 && max.col2 >= 1`.
+    // Testing with stats filter.
     columnStatsBasedFilePruningTest(expr, expectedResultWithStatsSkipping)
 
     // Disable stats skipping.


### PR DESCRIPTION
Add a feature flag `DeltaConfigs.ENABLE_STATS_SKIPPING` to Delta Standalone.
This flag is in Boolean format and its default value is `false`.
When the flag is `true`, column stats based file pruning is enabled in `FilteredDeltaScan`.
When the flag is `false`, column stats based file pruning is disabled in `FilteredDeltaScan`.
