### PR TITLE
Add 'equivalent' for type comparison

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/expressions/BinaryOperator.java
+++ b/standalone/src/main/java/io/delta/standalone/expressions/BinaryOperator.java
@@ -13,7 +13,7 @@ public abstract class BinaryOperator extends BinaryExpression {
         super(left, right);
         this.symbol = symbol;
 
-        if (!left.dataType().equals(right.dataType())) {
+        if (!left.dataType().equivalent(right.dataType())) {
             throw new IllegalArgumentException("BinaryOperator left and right DataTypes must be the"
                     + " same, found: " + left.dataType().getTypeName() + " " + symbol + " " +
                     right.dataType().getTypeName());

--- a/standalone/src/main/java/io/delta/standalone/expressions/In.java
+++ b/standalone/src/main/java/io/delta/standalone/expressions/In.java
@@ -51,7 +51,7 @@ public final class In implements Predicate {
 
         boolean allSameDataType = elems
             .stream()
-            .allMatch(x -> x.dataType().equals(value.dataType()));
+            .allMatch(x -> x.dataType().equivalent(value.dataType()));
 
         if (!allSameDataType) {
             throw new IllegalArgumentException(

--- a/standalone/src/main/java/io/delta/standalone/types/DataType.java
+++ b/standalone/src/main/java/io/delta/standalone/types/DataType.java
@@ -122,6 +122,10 @@ public abstract class DataType {
         return getTypeName().equals(that.getTypeName());
     }
 
+    public boolean equivalent(DataType dt) {
+        return this.equals(dt);
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(getTypeName());

--- a/standalone/src/main/java/io/delta/standalone/types/DecimalType.java
+++ b/standalone/src/main/java/io/delta/standalone/types/DecimalType.java
@@ -84,6 +84,11 @@ public final class DecimalType extends DataType {
     }
 
     @Override
+    public boolean equivalent(DataType dt) {
+        return dt instanceof DecimalType;
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), precision, scale);
     }

--- a/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
@@ -19,15 +19,12 @@ package io.delta.standalone.internal
 import java.math.{BigDecimal => BigDecimalJ}
 import java.sql.{Date => DateJ, Timestamp => TimestampJ}
 import java.util.{Arrays => ArraysJ, Objects}
-
 import scala.collection.JavaConverters._
-
 import org.scalatest.FunSuite
 
 import io.delta.standalone.data.RowRecord
 import io.delta.standalone.expressions.{Column, _}
 import io.delta.standalone.types._
-
 import io.delta.standalone.internal.actions.AddFile
 import io.delta.standalone.internal.data.PartitionRowRecord
 import io.delta.standalone.internal.util.PartitionUtils
@@ -185,6 +182,12 @@ class ExpressionSuite extends FunSuite {
         testPredicate(predicateCreator(Literal.of(small), Literal.of(small2)), smallSmall)
       }
     }
+
+    // TODO:
+    val decimalComparison = new EqualTo(
+      Literal.of(BigDecimalJ.valueOf(2).setScale(1)),
+      Literal.of(BigDecimalJ.valueOf(2).setScale(2))
+    )
   }
 
   test("null predicates") {
@@ -235,6 +238,21 @@ class ExpressionSuite extends FunSuite {
       (0 to 10).map{Literal.of}.asJava), false)
     testPredicate( new In(Literal.of(10),
       (0 to 10).map{Literal.of}.asJava), true)
+
+    testPredicate(
+      new In(
+        Literal.of(BigDecimalJ.valueOf(2).setScale(1)),
+        List(
+          Literal.of(BigDecimalJ.valueOf(1).setScale(1)),
+          Literal.of(BigDecimalJ.valueOf(2).setScale(1)),
+          Literal.of(BigDecimalJ.valueOf(3).setScale(1)),
+          Literal.of(BigDecimalJ.valueOf(4).setScale(1)),
+          Literal.of(BigDecimalJ.valueOf(5).setScale(1)),
+        ).asJava
+      ),
+        true
+      )
+
   }
 
   private def testLiteral(literal: Literal, expectedResult: Any) = {

--- a/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
@@ -183,11 +183,10 @@ class ExpressionSuite extends FunSuite {
       }
     }
 
-    // TODO:
-    val decimalComparison = new EqualTo(
-      Literal.of(BigDecimalJ.valueOf(2).setScale(1)),
+    testPredicate(new EqualTo(
+      Literal.of(BigDecimalJ.valueOf(1).setScale(2)),
       Literal.of(BigDecimalJ.valueOf(2).setScale(2))
-    )
+    ), false)
   }
 
   test("null predicates") {

--- a/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
@@ -19,12 +19,15 @@ package io.delta.standalone.internal
 import java.math.{BigDecimal => BigDecimalJ}
 import java.sql.{Date => DateJ, Timestamp => TimestampJ}
 import java.util.{Arrays => ArraysJ, Objects}
+
 import scala.collection.JavaConverters._
+
 import org.scalatest.FunSuite
 
 import io.delta.standalone.data.RowRecord
 import io.delta.standalone.expressions.{Column, _}
 import io.delta.standalone.types._
+
 import io.delta.standalone.internal.actions.AddFile
 import io.delta.standalone.internal.data.PartitionRowRecord
 import io.delta.standalone.internal.util.PartitionUtils
@@ -266,11 +269,7 @@ class ExpressionSuite extends FunSuite {
           Literal.of(BigDecimalJ.valueOf(3).setScale(1)),
           Literal.of(BigDecimalJ.valueOf(4).setScale(1)),
           Literal.of(BigDecimalJ.valueOf(5).setScale(1)),
-        ).asJava
-      ),
-        true
-      )
-
+        ).asJava),true)
   }
 
   private def testLiteral(literal: Literal, expectedResult: Any) = {

--- a/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
@@ -183,10 +183,29 @@ class ExpressionSuite extends FunSuite {
       }
     }
 
+    // test BigDecimal with diff value - same scale
     testPredicate(new EqualTo(
       Literal.of(BigDecimalJ.valueOf(1).setScale(2)),
       Literal.of(BigDecimalJ.valueOf(2).setScale(2))
     ), false)
+
+    // test BigDecimal with diff value - diff scale
+    testPredicate(new EqualTo(
+      Literal.of(BigDecimalJ.valueOf(1).setScale(1)),
+      Literal.of(BigDecimalJ.valueOf(2).setScale(2))
+    ), false)
+
+    // test BigDecimal with same value - diff scale
+    testPredicate(new EqualTo(
+      Literal.of(BigDecimalJ.valueOf(2).setScale(1)),
+      Literal.of(BigDecimalJ.valueOf(2).setScale(3))
+    ), true)
+
+    // test BigDecimal with same value - same scale
+    testPredicate(new EqualTo(
+      Literal.of(BigDecimalJ.valueOf(2).setScale(3)),
+      Literal.of(BigDecimalJ.valueOf(2).setScale(3))
+    ), true)
   }
 
   test("null predicates") {

--- a/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
@@ -119,8 +119,6 @@ class ExpressionSuite extends FunSuite {
       (Literal.of(1.0), Literal.of(2.0), Literal.of(1.0), Literal.ofNull(new DoubleType())),
       (Literal.of(1.toByte), Literal.of(2.toByte), Literal.of(1.toByte),
         Literal.ofNull(new ByteType())),
-      (Literal.of(new BigDecimalJ("123.45")), Literal.of(new BigDecimalJ("887.62")),
-        Literal.of(new BigDecimalJ("123.45")), Literal.ofNull(new DecimalType(5, 2))),
       (Literal.False, Literal.True, Literal.False, Literal.ofNull(new BooleanType())),
       (Literal.of(new TimestampJ(0)), Literal.of(new TimestampJ(1000000)),
       Literal.of(new TimestampJ(0)), Literal.ofNull(new TimestampType())),
@@ -132,10 +130,10 @@ class ExpressionSuite extends FunSuite {
         Literal.of("apples".getBytes()), Literal.ofNull(new BinaryType())),
       // same scales (should already be there actually)
       (Literal.of(BigDecimalJ.valueOf(1).setScale(2)), Literal.of(BigDecimalJ.valueOf(3).setScale(2)),
-        Literal.of(BigDecimalJ.valueOf(1).setScale(2)), Literal.ofNull(new DecimalType(5, 2))),
+        Literal.of(BigDecimalJ.valueOf(1).setScale(2)), Literal.ofNull(new DecimalType(1, 2))),
       // different scales
-      (Literal.of(BigDecimalJ.valueOf(1).setScale(1)), Literal.of(BigDecimalJ.valueOf(3).setScale(3)),
-        Literal.of(BigDecimalJ.valueOf(1).setScale(2)), Literal.ofNull(new DecimalType(5, 2))),
+      (Literal.of(BigDecimalJ.valueOf(1).setScale(2)), Literal.of(BigDecimalJ.valueOf(3).setScale(3)),
+        Literal.of(BigDecimalJ.valueOf(1).setScale(4)), Literal.ofNull(new DecimalType(1, 2)))
     )
 
     // Literal creation: (Literal, Literal) -> Expr(a, b) ,
@@ -252,7 +250,7 @@ class ExpressionSuite extends FunSuite {
           Literal.of(BigDecimalJ.valueOf(3).setScale(1)),
           Literal.of(BigDecimalJ.valueOf(4).setScale(1)),
           Literal.of(BigDecimalJ.valueOf(5).setScale(1)),
-        ).asJava),true)
+        ).asJava), true)
 
     // BigDecimal value in list, with different scale
     testPredicate(
@@ -264,7 +262,7 @@ class ExpressionSuite extends FunSuite {
           Literal.of(BigDecimalJ.valueOf(3).setScale(2)),
           Literal.of(BigDecimalJ.valueOf(4).setScale(2)),
           Literal.of(BigDecimalJ.valueOf(5).setScale(2)),
-        ).asJava),true)
+        ).asJava), true)
   }
 
   private def testLiteral(literal: Literal, expectedResult: Any) = {

--- a/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
@@ -129,11 +129,15 @@ class ExpressionSuite extends FunSuite {
       (Literal.of("apples".getBytes()), Literal.of("oranges".getBytes()),
         Literal.of("apples".getBytes()), Literal.ofNull(new BinaryType())),
       // same scales (should already be there actually)
-      (Literal.of(BigDecimalJ.valueOf(1).setScale(2)), Literal.of(BigDecimalJ.valueOf(3).setScale(2)),
-        Literal.of(BigDecimalJ.valueOf(1).setScale(2)), Literal.ofNull(new DecimalType(1, 2))),
+      (Literal.of(BigDecimalJ.valueOf(1).setScale(2)),
+        Literal.of(BigDecimalJ.valueOf(3).setScale(2)),
+        Literal.of(BigDecimalJ.valueOf(1).setScale(2)),
+        Literal.ofNull(new DecimalType(1, 2))),
       // different scales
-      (Literal.of(BigDecimalJ.valueOf(1).setScale(2)), Literal.of(BigDecimalJ.valueOf(3).setScale(3)),
-        Literal.of(BigDecimalJ.valueOf(1).setScale(4)), Literal.ofNull(new DecimalType(1, 2)))
+      (Literal.of(BigDecimalJ.valueOf(1).setScale(2)),
+        Literal.of(BigDecimalJ.valueOf(3).setScale(3)),
+        Literal.of(BigDecimalJ.valueOf(1).setScale(4)),
+        Literal.ofNull(new DecimalType(1, 2)))
     )
 
     // Literal creation: (Literal, Literal) -> Expr(a, b) ,
@@ -249,7 +253,7 @@ class ExpressionSuite extends FunSuite {
           Literal.of(BigDecimalJ.valueOf(2).setScale(1)),
           Literal.of(BigDecimalJ.valueOf(3).setScale(1)),
           Literal.of(BigDecimalJ.valueOf(4).setScale(1)),
-          Literal.of(BigDecimalJ.valueOf(5).setScale(1)),
+          Literal.of(BigDecimalJ.valueOf(5).setScale(1))
         ).asJava), true)
 
     // BigDecimal value in list, with different scale
@@ -261,7 +265,7 @@ class ExpressionSuite extends FunSuite {
           Literal.of(BigDecimalJ.valueOf(2).setScale(2)),
           Literal.of(BigDecimalJ.valueOf(3).setScale(2)),
           Literal.of(BigDecimalJ.valueOf(4).setScale(2)),
-          Literal.of(BigDecimalJ.valueOf(5).setScale(2)),
+          Literal.of(BigDecimalJ.valueOf(5).setScale(2))
         ).asJava), true)
   }
 

--- a/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
@@ -128,7 +128,6 @@ class ExpressionSuite extends FunSuite {
         Literal.ofNull(new StringType())),
       (Literal.of("apples".getBytes()), Literal.of("oranges".getBytes()),
         Literal.of("apples".getBytes()), Literal.ofNull(new BinaryType())),
-      // same scales (should already be there actually)
       (Literal.of(BigDecimalJ.valueOf(1).setScale(2)),
         Literal.of(BigDecimalJ.valueOf(3).setScale(2)),
         Literal.of(BigDecimalJ.valueOf(1).setScale(2)),
@@ -137,7 +136,7 @@ class ExpressionSuite extends FunSuite {
       (Literal.of(BigDecimalJ.valueOf(1).setScale(2)),
         Literal.of(BigDecimalJ.valueOf(3).setScale(3)),
         Literal.of(BigDecimalJ.valueOf(1).setScale(4)),
-        Literal.ofNull(new DecimalType(1, 2)))
+        Literal.ofNull(new DecimalType(2, 5)))
     )
 
     // Literal creation: (Literal, Literal) -> Expr(a, b) ,
@@ -244,7 +243,8 @@ class ExpressionSuite extends FunSuite {
     testPredicate( new In(Literal.of(10),
       (0 to 10).map{Literal.of}.asJava), true)
 
-    // BigDecimal value in list, with same scale
+    // Here we test In specifically with the BigDecimal data type to make sure we cover
+    // the different cases with values and elements of varying precision and scales
     testPredicate(
       new In(
         Literal.of(BigDecimalJ.valueOf(2).setScale(1)),
@@ -256,7 +256,6 @@ class ExpressionSuite extends FunSuite {
           Literal.of(BigDecimalJ.valueOf(5).setScale(1))
         ).asJava), true)
 
-    // BigDecimal value in list, with different scale
     testPredicate(
       new In(
         Literal.of(BigDecimalJ.valueOf(2).setScale(1)),

--- a/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
@@ -129,7 +129,13 @@ class ExpressionSuite extends FunSuite {
       (Literal.of("apples"), Literal.of("oranges"), Literal.of("apples"),
         Literal.ofNull(new StringType())),
       (Literal.of("apples".getBytes()), Literal.of("oranges".getBytes()),
-        Literal.of("apples".getBytes()), Literal.ofNull(new BinaryType()))
+        Literal.of("apples".getBytes()), Literal.ofNull(new BinaryType())),
+      // same scales (should already be there actually)
+      (Literal.of(BigDecimalJ.valueOf(1).setScale(2)), Literal.of(BigDecimalJ.valueOf(3).setScale(2)),
+        Literal.of(BigDecimalJ.valueOf(1).setScale(2)), Literal.ofNull(new DecimalType(5, 2))),
+      // different scales
+      (Literal.of(BigDecimalJ.valueOf(1).setScale(1)), Literal.of(BigDecimalJ.valueOf(3).setScale(3)),
+        Literal.of(BigDecimalJ.valueOf(1).setScale(2)), Literal.ofNull(new DecimalType(5, 2))),
     )
 
     // Literal creation: (Literal, Literal) -> Expr(a, b) ,
@@ -185,30 +191,6 @@ class ExpressionSuite extends FunSuite {
         testPredicate(predicateCreator(Literal.of(small), Literal.of(small2)), smallSmall)
       }
     }
-
-    // test BigDecimal with diff value - same scale
-    testPredicate(new EqualTo(
-      Literal.of(BigDecimalJ.valueOf(1).setScale(2)),
-      Literal.of(BigDecimalJ.valueOf(2).setScale(2))
-    ), false)
-
-    // test BigDecimal with diff value - diff scale
-    testPredicate(new EqualTo(
-      Literal.of(BigDecimalJ.valueOf(1).setScale(1)),
-      Literal.of(BigDecimalJ.valueOf(2).setScale(2))
-    ), false)
-
-    // test BigDecimal with same value - diff scale
-    testPredicate(new EqualTo(
-      Literal.of(BigDecimalJ.valueOf(2).setScale(1)),
-      Literal.of(BigDecimalJ.valueOf(2).setScale(3))
-    ), true)
-
-    // test BigDecimal with same value - same scale
-    testPredicate(new EqualTo(
-      Literal.of(BigDecimalJ.valueOf(2).setScale(3)),
-      Literal.of(BigDecimalJ.valueOf(2).setScale(3))
-    ), true)
   }
 
   test("null predicates") {
@@ -260,6 +242,7 @@ class ExpressionSuite extends FunSuite {
     testPredicate( new In(Literal.of(10),
       (0 to 10).map{Literal.of}.asJava), true)
 
+    // BigDecimal value in list, with same scale
     testPredicate(
       new In(
         Literal.of(BigDecimalJ.valueOf(2).setScale(1)),
@@ -269,6 +252,18 @@ class ExpressionSuite extends FunSuite {
           Literal.of(BigDecimalJ.valueOf(3).setScale(1)),
           Literal.of(BigDecimalJ.valueOf(4).setScale(1)),
           Literal.of(BigDecimalJ.valueOf(5).setScale(1)),
+        ).asJava),true)
+
+    // BigDecimal value in list, with different scale
+    testPredicate(
+      new In(
+        Literal.of(BigDecimalJ.valueOf(2).setScale(1)),
+        List(
+          Literal.of(BigDecimalJ.valueOf(1).setScale(2)),
+          Literal.of(BigDecimalJ.valueOf(2).setScale(2)),
+          Literal.of(BigDecimalJ.valueOf(3).setScale(2)),
+          Literal.of(BigDecimalJ.valueOf(4).setScale(2)),
+          Literal.of(BigDecimalJ.valueOf(5).setScale(2)),
         ).asJava),true)
   }
 

--- a/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ExpressionSuite.scala
@@ -128,6 +128,7 @@ class ExpressionSuite extends FunSuite {
         Literal.ofNull(new StringType())),
       (Literal.of("apples".getBytes()), Literal.of("oranges".getBytes()),
         Literal.of("apples".getBytes()), Literal.ofNull(new BinaryType())),
+      // same scales
       (Literal.of(BigDecimalJ.valueOf(1).setScale(2)),
         Literal.of(BigDecimalJ.valueOf(3).setScale(2)),
         Literal.of(BigDecimalJ.valueOf(1).setScale(2)),


### PR DESCRIPTION
Currently, comparison expressions fail with `IllegalArgumentException` for decimal type arguments that don’t have equal precision/scale. This should be valid (and is in Spark SQL). This impacts IN and all the binary comparison operators.

This change is to add `equivalent` method, to only be used internally by our code to compare data types.

Refer https://github.com/delta-io/connectors/issues/222 for detail.

Signed-off-by: Kwangin Jung <inylove82@gmail.com>