### PR TITLE
PR-01: Add Flink Connector end-to-end tests framework - project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,19 @@ spark-warehouse/
 /.vs
 /obj
 /bin
+
+# For Terraform
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+*.terraform.lock*
+crash.log
+crash.*.log
+*.tfvars
+*.tfvars.json
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+.terraform.rc

--- a/build.sbt
+++ b/build.sbt
@@ -829,7 +829,7 @@ lazy val flinkEndToEndTests = (project in file("flink/end-to-end-tests"))
       "org.apache.flink" % "flink-s3-fs-hadoop" % flinkVersion % "test",
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "test",
       "org.apache.flink" % "flink-table-common" % flinkVersion % "test",
-      "org.apache.flink" % ("flink-table-runtime-blink_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "test",
+      "org.apache.flink" % ("flink-table-runtime_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "provided",
       "org.apache.hadoop" % "hadoop-aws" % hadoopVersion % "test",
       "org.junit.vintage" % "junit-vintage-engine" % "5.8.2" % "test",
       "org.junit.jupiter" % "junit-jupiter-params" % "5.8.2" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -801,7 +801,7 @@ lazy val flinkEndToEndTestsFatJar = (project in file("flink/end-to-end-tests-fat
     libraryDependencies ++= Seq(
       "org.apache.flink" % ("flink-clients_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "provided",
       "org.apache.flink" % "flink-table-common" % flinkVersion % "provided",
-      "org.apache.flink" % ("flink-table-runtime-blink_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "provided",
+      "org.apache.flink" % ("flink-table-runtime_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "provided",
       "org.apache.flink" % ("flink-parquet_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion,
       "org.apache.flink" % "flink-s3-fs-hadoop" % flinkVersion,
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -786,13 +786,18 @@ lazy val flink = (project in file("flink"))
     (Test / test) := ((Test / test) dependsOn (Compile / unidoc)).value
   )
 
+/**
+ * This module contains the definitions of the Flink jobs that are necessary to perform end-to-end testing.
+ * When running end-to-end tests, the jar file is uploaded to the Flink cluster and the jobs contained in this
+ * module are executed.
+ */
 lazy val flinkEndToEndTestsFatJar = (project in file("flink/end-to-end-tests-fatjar"))
   .dependsOn(flink)
   .dependsOn(standalone)
   .settings(
     name := "flink-end-to-end-tests-fatjar",
     commonSettings,
-    releaseSettings,
+    skipReleaseSettings,
     libraryDependencies ++= Seq(
       "org.apache.flink" % ("flink-clients_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "provided",
       "org.apache.flink" % "flink-table-common" % flinkVersion % "provided",
@@ -807,6 +812,10 @@ lazy val flinkEndToEndTestsFatJar = (project in file("flink/end-to-end-tests-fat
     }
   )
 
+/**
+ * This module contains the test cases. During test execution, it uploads the jar file containing job
+ * definitions to Flink cluster, schedules Flink jobs and coordinates their work.
+ */
 lazy val flinkEndToEndTests = (project in file("flink/end-to-end-tests"))
   .dependsOn(standalone)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -785,3 +785,48 @@ lazy val flink = (project in file("flink"))
     // Ensure unidoc is run with tests. Must be cleaned before test for unidoc to be generated.
     (Test / test) := ((Test / test) dependsOn (Compile / unidoc)).value
   )
+
+lazy val flinkEndToEndTestsFatJar = (project in file("flink/end-to-end-tests-fatjar"))
+  .dependsOn(flink)
+  .dependsOn(standalone)
+  .settings(
+    name := "flink-end-to-end-tests-fatjar",
+    commonSettings,
+    releaseSettings,
+    libraryDependencies ++= Seq(
+      "org.apache.flink" % ("flink-clients_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "provided",
+      "org.apache.flink" % "flink-table-common" % flinkVersion % "provided",
+      "org.apache.flink" % ("flink-table-runtime-blink_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "provided",
+      "org.apache.flink" % ("flink-parquet_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion,
+      "org.apache.flink" % "flink-s3-fs-hadoop" % flinkVersion,
+      "org.apache.hadoop" % "hadoop-client" % hadoopVersion,
+    ),
+    assembly / assemblyMergeStrategy := {
+      case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+      case x => MergeStrategy.first
+    }
+  )
+
+lazy val flinkEndToEndTests = (project in file("flink/end-to-end-tests"))
+  .dependsOn(standalone)
+  .settings(
+    name := "flink-end-to-end-tests",
+    commonSettings,
+    skipReleaseSettings,
+    fork := false,
+    libraryDependencies ++= Seq(
+      "org.apache.flink" % ("flink-clients_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "test",
+      "org.apache.flink" % ("flink-parquet_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "test",
+      "org.apache.flink" % "flink-s3-fs-hadoop" % flinkVersion % "test",
+      "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "test",
+      "org.apache.flink" % "flink-table-common" % flinkVersion % "test",
+      "org.apache.flink" % ("flink-table-runtime-blink_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "test",
+      "org.apache.hadoop" % "hadoop-aws" % hadoopVersion % "test",
+      "org.junit.vintage" % "junit-vintage-engine" % "5.8.2" % "test",
+      "org.junit.jupiter" % "junit-jupiter-params" % "5.8.2" % "test",
+      "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,
+      "io.github.artsok" % "rerunner-jupiter" % "2.1.6" % "test",
+      "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.12.1" % "test",
+    ),
+    Test / logBuffered := false
+  )

--- a/flink/end-to-end-tests/README.md
+++ b/flink/end-to-end-tests/README.md
@@ -1,39 +1,5 @@
 # Flink Delta Connector end-to-end tests
 
-## Implementation plan
-In order to make code review easier, the implementation of end-to-end tests should be divided into multiple pull requests. We plan to do it in the following steps (some of them can be done in parallel):
-
-PR-01: Project skeleton.
-- Shows how the project structure looks like.
-- Add sbt modules (tests + fatjar).
-- Add a smoke test (does not schedule any flink job actually).
-- Add terraform skeleton (almost empty).
-- Add run-end-to-end-tests.sh script.
-
-PR-02-A: Terraform.
-- Add terraform creating all necessary infrastructure in AWS.
-
-PR-02-B: Flink REST Client.
-- Java implementation of a client for job scheduling.
-
-PR-03-A: Add bounded reader test scenarios.
-- Add corresponding Flink job.
-- Implement job scenarios. Create multiple pull requests if there are lots of test scenarios.
-
-PR-03-B: Add bounded writer test scenarios.
-- Add corresponding Flink job.
-- Implement job scenarios. Create multiple pull requests if there are lots of test scenarios.
-
-PR-04-A: Add unbounded reader test scenarios.
-- Add corresponding Flink job.
-- Implement job scenarios. Create multiple pull requests if there are lots of test scenarios.
-
-PR-04-B: Add unbounded writer test scenarios.
-- Add corresponding Flink job.
-- Implement job scenarios. Create multiple pull requests if there are lots of test scenarios.
-
-PR-05: Enable to run tests in parallel.
-
 ## Design
 
 Connector end-to-end tests are executed on AWS infrastructure in order to identify potential bugs automatically at the
@@ -63,7 +29,6 @@ Tests are triggered with `run-end-to-end-tests.sh` script. The script covers all
 3. Batch job successfully writes records to a \[partitioned / non-partitioned] Delta Lake even if the job has recovered after a failure.
 4. Streaming job successfully writes records to a \[partitioned / non-partitioned] Delta Lake even if the job has recovered after a failure from a checkpoint.
 5. Streaming job creates Delta Lake checkpoint successfully.
-
 
 ### Source
 1. Batch job correctly reads the latest Delta Lake snapshot.

--- a/flink/end-to-end-tests/README.md
+++ b/flink/end-to-end-tests/README.md
@@ -1,0 +1,146 @@
+# Flink Delta Connector end-to-end tests
+
+## Implementation plan
+In order to make code review easier, the implementation of end-to-end tests should be divided into multiple pull requests. We plan to do it in the following steps (some of them can be done in parallel):
+
+PR-01: Project skeleton.
+- Shows how the project structure looks like.
+- Add sbt modules (tests + fatjar).
+- Add a smoke test (does not schedule any flink job actually).
+- Add terraform skeleton (almost empty).
+- Add run-end-to-end-tests.sh script.
+
+PR-02-A: Terraform.
+- Add terraform creating all necessary infrastructure in AWS.
+
+PR-02-B: Flink REST Client.
+- Java implementation of a client for job scheduling.
+
+PR-03-A: Add bounded reader test scenarios.
+- Add corresponding Flink job.
+- Implement job scenarios. Create multiple pull requests if there are lots of test scenarios.
+
+PR-03-B: Add bounded writer test scenarios.
+- Add corresponding Flink job.
+- Implement job scenarios. Create multiple pull requests if there are lots of test scenarios.
+
+PR-04-A: Add unbounded reader test scenarios.
+- Add corresponding Flink job.
+- Implement job scenarios. Create multiple pull requests if there are lots of test scenarios.
+
+PR-04-B: Add unbounded writer test scenarios.
+- Add corresponding Flink job.
+- Implement job scenarios. Create multiple pull requests if there are lots of test scenarios.
+
+PR-05: Enable to run tests in parallel.
+
+## Design
+
+Connector end-to-end tests are executed on AWS infrastructure in order to identify potential bugs automatically at the
+early development stage. The test infrastructure is created with Terraform:
+
+* An S3 bucket containing test Delta tables.
+* An AWS EKS service.
+
+The Flink cluster runs
+in [Session Mode](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/overview/#session-mode),
+that is, there is a standalone cluster which can accept multiple jobs during its lifecycle. The infrastructure is
+created once before running the tests, and destroyed when the tests finish.
+
+Tests are triggered with `run-end-to-end-tests.sh` script. The script covers all steps, including:
+
+1. Builds test artifact. `flink/end-to-end-tests-fatjar` module contains test jobs definitions.
+2. Creates AWS infrastructure with Terraform.
+3. Creates Kubernetes infrastructure.
+4. Deploys Flink Kubernetes Operator
+5. Runs tests. Test implementations are located in `flink/end-to-end-tests` module.
+6. Destroys infrastructure after tests finish.
+
+## Test scenarios
+### Sink
+1. Batch job successfully writes records to a \[partitioned / non-partitioned] Delta Lake table.
+2. Streaming job successfully writes records to a \[partitioned / non-partitioned] Delta Lake table.
+3. Batch job successfully writes records to a \[partitioned / non-partitioned] Delta Lake even if the job has recovered after a failure.
+4. Streaming job successfully writes records to a \[partitioned / non-partitioned] Delta Lake even if the job has recovered after a failure from a checkpoint.
+5. Streaming job creates Delta Lake checkpoint successfully.
+
+
+### Source
+1. Batch job correctly reads the latest Delta Lake snapshot.
+2. Batch job correctly reads specified Delta Lake snapshot version (startingVersion()).
+3. Batch job reads correctly the latest Delta Lake snapshot created before a given timestamp (startingTimestamp()).
+4. Batch job correctly reads partitioned Delta Lake table.
+5. Batch job correctly reads only selected column names (columnNames()).
+6. Batch job correctly reads Delta Lake snapshot even if the job recovered from a failure.
+7. Streaming job reads head snapshot and subsequent new changes to the Delta Lake table.
+8. Streaming job reads given snapshot version (startingVersion()) and subsequent new changes to the Delta Lake table.
+9. Streaming job reads the earliest Delta Lake snapshot created after a given timestamp (startingTimestamp()) and subsequent new changes to the Delta Lake table.
+10. Streaming job correctly reads a partitioned Delta Lake table.
+11. Streaming job correctly reads only selected column names (columnNames()).
+12. Streaming job fails when ignoreDeletes(false) and there were deletes in the Delta Lake table.
+13. Streaming job fails when ignoreChanges(false) and there were deletes or updates in the Delta Lake table.
+14. Streaming job correctly reads Delta Lake table when ignoreDeletes(true) and there were deletes in the Delta Lake table.
+15. Streaming job fails when ignoreChanges(true) and there were deletes or updates in the Delta Lake table.
+16. Streaming job correctly reads Delta Lake snapshot and subsequent new changes even if the job recovered from a failure.
+17. \[Streaming/Batch] job fails when reading the Delta Lake table if startingVersion was previously removed using vacuum.
+
+## Manual run
+
+1. Install [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/aws-get-started). 
+
+2. Install [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl).
+
+3. Add permissions for the IAM user. You can either assign `AdministratorAccess` AWS managed policy (discouraged)
+      or assign AWS managed policies in a more granular way:
+   * `IAMFullAccess`
+   * `AmazonVPCFullAccess`
+   * `AmazonS3FullAccess`
+   * `AmazonEC2FullAccess`
+   * `AmazonEC2ContainerRegistryFullAccess`
+   * Allow all `eks:*` actions.
+ 
+4. Ensure that your AWS CLI is configured. You should either have valid credentials in shared credentials file (
+   e.g. `~/.aws/credentials`)
+   ```
+   [default]
+   aws_access_key_id = anaccesskey
+   aws_secret_access_key = asecretkey
+   ```
+   or export keys as environment variables:
+   ```bash
+   export AWS_ACCESS_KEY_ID="anaccesskey"
+   export AWS_SECRET_ACCESS_KEY="asecretkey"
+   ```
+
+5. Create Terraform variable file `flink/end-to-end-tests/terraform/terraform.tfvars` and fill in variable values.
+   For example:
+   ```tf
+   region                = "us-west-2"
+   availability_zone1    = "us-west-2a"
+   availability_zone2    = "us-west-2b"
+   test_data_bucket_name = "delta-flink-connector-e2e"
+   eks_workers           = 1
+   tags                  = {
+     key1 = "value1"
+     key2 = "value2"
+   }
+   ```
+   Please check `variables.tf` to learn more about each parameter.
+
+6. Run `run-end-to-end-tests.sh` from project root directory. Sample run command:
+   ```bash 
+   ./flink/end-to-end-tests/run-end-to-end-tests.sh \
+       --scala-version 2.12.8
+   ```
+   By default, the script removes all infrastructure components, including test Delta Lake table in S3.
+   If you would like to preserve them, you can specify additional flags:
+   ```bash
+   ./flink/end-to-end-tests/run-end-to-end-tests.sh \
+       --scala-version 2.12.8 \
+       --preserve-s3-data
+   ```
+   You can still delete them by removing S3 bucket contents manually and then running:
+   ```bash
+   cd flink/end-to-end-tests/terraform/
+   terraform destroy -auto-approve
+   ```

--- a/flink/end-to-end-tests/run-end-to-end-tests.sh
+++ b/flink/end-to-end-tests/run-end-to-end-tests.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (2021) The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+RELATIVE_SCRIPT_PATH=$(dirname -- "${BASH_SOURCE[0]:-$0}")
+WORKDIR=$(realpath "$RELATIVE_SCRIPT_PATH")
+PROJECT_ROOT_DIR="$WORKDIR/../../"
+TERRAFORM_DIR="$WORKDIR/terraform/"
+KUBERNETES_DIR="$TERRAFORM_DIR/kubernetes/"
+
+build_artifact() {
+  cd "$PROJECT_ROOT_DIR" || exit
+  build/sbt "++ $SCALA_VERSION" flinkEndToEndTestsFatJar/assembly
+  local return_code=$?
+  cd "$WORKDIR" || exit
+  return $return_code
+}
+
+export_fat_jar_path() {
+  echo "Export fat jar path."
+  # FIXME export jar path to JAR_PATH environment variable
+  echo "It will be implemented in the PR-03"
+}
+
+create_terraform_infrastructure() {
+  echo "Creating terraform infrastructure."
+  # FIXME terraform init, validate and apply
+  echo "It will be implemented in the PR-02-A"
+}
+
+destroy_terraform_infrastructure() {
+  echo "Destroying terraform infrastructure."
+  # FIXME terraform destroy
+  echo "It will be implemented in the PR-02-A"
+}
+
+kubernetes_cleanup(){
+  echo "Kubernetes cleanup."
+  # FIXME: uninstall flink-kubernetes-operator, close port-forward, unset kubernetes context
+  echo "It will be implemented in the PR-02-A"
+}
+
+export_terraform_outputs() {
+  export ACCOUNT_ID=$(terraform -chdir="$TERRAFORM_DIR" output account_id | tr -d '"')
+  export AWS_REGION=$(terraform -chdir="$TERRAFORM_DIR" output region | tr -d '"')
+  export SERVICE_ACCOUNT_ROLE_NAME=$(terraform -chdir="$TERRAFORM_DIR" output service_account_role_name | tr -d '"')
+  export EKS_CLUSTER_NAME=$(terraform -chdir="$TERRAFORM_DIR" output eks_cluster_name | tr -d '"')
+  export TEST_DATA_BUCKET_NAME=$(terraform -chdir="$TERRAFORM_DIR" output test_data_bucket_name | tr -d '"')
+  export CREDENTIALS_ACCESS_KEY_ID=$(terraform -chdir="$TERRAFORM_DIR" output access_key | tr -d '"' | base64)
+  export CREDENTIALS_SECRET_KEY=$(terraform -chdir="$TERRAFORM_DIR" output secret_key | tr -d '"' | base64)
+}
+
+create_kubernetes_infrastructure() {
+  echo "Creating kubernetes infrastructure."
+  # FIXME: installing cert-manager and kubernetes-flink-operator, apply kubernetes configuration
+  echo "It will be implemented in the PR-02-A"
+}
+
+jobmanager_port_forward() {
+  echo "Run port forward"
+  # FIXME: wait until pod is created & ready and then run port forward
+  echo "It will be implemented in the PR-02-A"
+}
+
+run_end_to_end_tests() {
+  echo "Running tests..."
+  cd "$PROJECT_ROOT_DIR" || exit
+
+  build/sbt "++ $SCALA_VERSION" \
+    flinkEndToEndTests/test
+  local return_code=$?
+  cd "$WORKDIR" || exit
+  return $return_code
+}
+
+main() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+    --preserve-s3-data)
+      PRESERVE_S3_DATA="yes"
+      shift # past argument
+      ;;
+    --scala-version)
+      SCALA_VERSION="$2"
+      # Take only the first four characters (e.g. 2.12).
+      SHORT_SCALA_VERSION="${SCALA_VERSION:0:4}"
+      shift # past argument
+      shift # past value
+      ;;
+    -* | --*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      shift # past argument
+      ;;
+    esac
+  done
+
+  if ! build_artifact; then
+    echo "[ERROR] Failed to build artifact."
+    exit 1
+  fi
+
+  if ! export_fat_jar_path; then
+    echo "[ERROR] Failed to find the test artifact path."
+    exit 1
+  fi
+
+  if ! create_terraform_infrastructure; then
+    echo "[ERROR] Failed to create test infrastructure."
+    exit 1
+  fi
+
+  if ! export_terraform_outputs; then
+    echo "[ERROR] Failed to extract variables."
+    exit 1
+  fi
+
+  if ! create_kubernetes_infrastructure; then
+    echo "[ERROR] Failed to create kubernetes infrastructure."
+    exit 1
+  fi
+
+  if ! jobmanager_port_forward; then
+    echo "[ERROR] Failed to extract Flink JobManager address."
+    exit 1
+  fi
+
+  if ! run_end_to_end_tests; then
+    echo "[ERROR] Failed to run tests."
+    exit 1
+  fi
+}
+
+cleanup() {
+  echo "Clean up..."
+  kubernetes_cleanup
+  cd "$WORKDIR" || exit 1
+  destroy_terraform_infrastructure
+}
+
+trap cleanup EXIT
+main "$@"

--- a/flink/end-to-end-tests/run-end-to-end-tests.sh
+++ b/flink/end-to-end-tests/run-end-to-end-tests.sh
@@ -23,6 +23,7 @@ TERRAFORM_DIR="$WORKDIR/terraform/"
 KUBERNETES_DIR="$TERRAFORM_DIR/kubernetes/"
 
 build_artifact() {
+  echo "Building artifact."
   cd "$PROJECT_ROOT_DIR" || exit
   build/sbt "++ $SCALA_VERSION" flinkEndToEndTestsFatJar/assembly
   local return_code=$?
@@ -31,9 +32,17 @@ build_artifact() {
 }
 
 export_fat_jar_path() {
-  echo "Export fat jar path."
-  # FIXME export jar path to JAR_PATH environment variable
-  echo "It will be implemented in the PR-03"
+  echo "Exporting fat jar path."
+  local matching_jar
+  matching_jar=$(find "$WORKDIR"/../end-to-end-tests-fatjar/target/scala-"$SHORT_SCALA_VERSION"/ -iname 'flink-end-to-end-tests-fatjar-assembly-*.jar' -type f)
+
+  if [ -z "$matching_jar" ]; then
+    echo "Cannot find artifact containing test jobs."
+    exit 1
+  else
+    echo "Artifact found at path ${matching_jar[0]}."
+    export JAR_PATH="${matching_jar[0]}"
+  fi
 }
 
 create_terraform_infrastructure() {
@@ -48,7 +57,13 @@ destroy_terraform_infrastructure() {
   echo "It will be implemented in the PR-02-A"
 }
 
-kubernetes_cleanup(){
+create_kubernetes_infrastructure() {
+  echo "Creating kubernetes infrastructure."
+  # FIXME: installing cert-manager and kubernetes-flink-operator, apply kubernetes configuration
+  echo "It will be implemented in the PR-02-A"
+}
+
+kubernetes_cleanup() {
   echo "Kubernetes cleanup."
   # FIXME: uninstall flink-kubernetes-operator, close port-forward, unset kubernetes context
   echo "It will be implemented in the PR-02-A"
@@ -62,12 +77,6 @@ export_terraform_outputs() {
   export TEST_DATA_BUCKET_NAME=$(terraform -chdir="$TERRAFORM_DIR" output test_data_bucket_name | tr -d '"')
   export CREDENTIALS_ACCESS_KEY_ID=$(terraform -chdir="$TERRAFORM_DIR" output access_key | tr -d '"' | base64)
   export CREDENTIALS_SECRET_KEY=$(terraform -chdir="$TERRAFORM_DIR" output secret_key | tr -d '"' | base64)
-}
-
-create_kubernetes_infrastructure() {
-  echo "Creating kubernetes infrastructure."
-  # FIXME: installing cert-manager and kubernetes-flink-operator, apply kubernetes configuration
-  echo "It will be implemented in the PR-02-A"
 }
 
 jobmanager_port_forward() {

--- a/flink/end-to-end-tests/src/test/java/io/delta/flink/e2e/SmokeTest.java
+++ b/flink/end-to-end-tests/src/test/java/io/delta/flink/e2e/SmokeTest.java
@@ -1,0 +1,11 @@
+package io.delta.flink.e2e;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SmokeTest {
+    @Test
+    void shouldSucceed() {
+        assertTrue(true);
+    }
+}

--- a/flink/end-to-end-tests/src/test/resources/log4j2-test.properties
+++ b/flink/end-to-end-tests/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+rootLogger.level = WARN
+rootLogger.appenderRef.console.ref = ConsoleAppender
+
+logger.delta.name = io.delta
+logger.delta.level = DEBUG
+
+appender.console.name = ConsoleAppender
+appender.console.type = CONSOLE
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss,SSS} %-5p %C{1.} %x - %m%n

--- a/flink/end-to-end-tests/terraform/kubernetes/kubernetes.yaml
+++ b/flink/end-to-end-tests/terraform/kubernetes/kubernetes.yaml
@@ -1,0 +1,1 @@
+# It will be implemented in the PR-02-A

--- a/flink/end-to-end-tests/terraform/main.tf
+++ b/flink/end-to-end-tests/terraform/main.tf
@@ -1,0 +1,1 @@
+# It will be implemented in the PR-02-A.

--- a/flink/end-to-end-tests/terraform/outputs.tf
+++ b/flink/end-to-end-tests/terraform/outputs.tf
@@ -1,0 +1,33 @@
+output "eks_cluster_name" {
+  value = "It will be implemented in the PR-02-A"
+}
+
+output "eks_cluster_endpoint" {
+  value = "It will be implemented in the PR-02-A"
+}
+
+output "account_id" {
+  value = "It will be implemented in the PR-02-A"
+}
+
+output "region" {
+  value = "It will be implemented in the PR-02-A"
+}
+
+output "service_account_role_name" {
+  value = "It will be implemented in the PR-02-A"
+}
+
+output "secret_key" {
+  value     = "It will be implemented in the PR-02-A"
+  sensitive = true
+}
+
+output "access_key" {
+  value     = "It will be implemented in the PR-02-A"
+  sensitive = true
+}
+
+output "test_data_bucket_name" {
+  value = "It will be implemented in the PR-02-A"
+}

--- a/flink/end-to-end-tests/terraform/variables.tf
+++ b/flink/end-to-end-tests/terraform/variables.tf
@@ -1,0 +1,33 @@
+variable "region" {
+  description = "The default region to manage resources in."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "availability_zone1" {
+  description = "The default availability zone to manage resources in."
+  type        = string
+  default     = "us-west-2a"
+}
+
+variable "availability_zone2" {
+  description = "The default availability zone to manage resources in."
+  type        = string
+  default     = "us-west-2b"
+}
+
+variable "test_data_bucket_name" {
+  description = "The name of the AWS S3 bucket that will be used to store test data."
+  type        = string
+}
+
+variable "eks_workers" {
+  description = "The number of worker nodes in EKS cluster."
+  type        = number
+}
+
+variable "tags" {
+  description = "Common tags assigned to each resource."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
You can test it by running:   
   
```bash
   ./flink/end-to-end-tests/run-end-to-end-tests.sh \
       --scala-version 2.12.8 \
       --preserve-s3-data
```
   
Expected Output:
```
Building artifact.
(sbt output...)
[success] Total time: 30 s, completed Sep 12, 2022 1:17:10 PM
Exporting fat jar path.
Artifact found at path /Users/radoslaw.dziadosz/IdeaProjects/connectors/flink/end-to-end-tests/../end-to-end-tests-fatjar/target/scala-2.12//flink-end-to-end-tests-fatjar-assembly-0.5.1-SNAPSHOT.jar.
Creating terraform infrastructure.
It will be implemented in the PR-02-A
Creating kubernetes infrastructure.
It will be implemented in the PR-02-A
Run port forward
It will be implemented in the PR-02-A
Running tests...
(sbt output...)
[info] Test run started (JUnit Jupiter)
[info] Test io.delta.flink.e2e.SmokeTest#shouldSucceed() started
[info] Test run finished: 0 failed, 0 ignored, 1 total, 0.053s
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[success] Total time: 10 s, completed Sep 12, 2022 1:17:42 PM
Clean up...
Kubernetes cleanup.
It will be implemented in the PR-02-A
Destroying terraform infrastructure.
It will be implemented in the PR-02-A
```