### PR TITLE
use complete directory path after filesystem to list files Signed-off…

### DIFF
--- a/powerbi/CustomConnector/DeltaLake/DeltaLake.pq
+++ b/powerbi/CustomConnector/DeltaLake/DeltaLake.pq
@@ -109,8 +109,7 @@ DeltaLakeContentBlob = (Folder as text) as table =>
 DeltaLakeContentADLSGen2 = (Folder as text) as table =>
     let
         filesystem = Text.BeforeDelimiter(Folder, "/", 3),
-        directoryCheck = Text.AfterDelimiter(Folder, "/", 3),
-        directory = if directoryCheck = "" then "" else Text.AfterDelimiter(Folder, "/", {0, RelativePosition.FromEnd}),
+        directory = Text.AfterDelimiter(Folder, "/", 3),
         url = filesystem & "?recursive=true&resource=filesystem&directory=" & directory,
         headers = if Extension.CurrentCredential()[AuthenticationKind] = "Implicit" then [] else [Headers=SignRequest(url,directory)],
         response =


### PR DESCRIPTION
{0, RelativePosition.FromEnd}) is empty when pasting the URL with a '/' in the end (e.g. https://test.dfs.core.windows.net/test/foo/bar.delta/) or else 'bar.delta'. But don't we need the whole path here, like 'foo/bar.delta', including 'foo'?

How is the "directoryCheck" supposed to work/ what should it do? Can't we use directoryCheck directly as directory since we check for "" and return ""? Else Text.AfterDelimiter(Folder, "/", 3) gives the whole directory path which is fine I guess?

Best regards
-by: Jonas vom Stein <jonasvomstein97@gmail.com>
