### PR TITLE
PR-02-A: Flink Connector end-to-end tests framework: add terraform

### DIFF
--- a/flink/end-to-end-tests/run-end-to-end-tests.sh
+++ b/flink/end-to-end-tests/run-end-to-end-tests.sh
@@ -47,26 +47,50 @@ export_fat_jar_path() {
 
 create_terraform_infrastructure() {
   echo "Creating terraform infrastructure."
-  # FIXME terraform init, validate and apply
-  echo "It will be implemented in the PR-02-A"
+  terraform -chdir="$TERRAFORM_DIR" init &&
+    terraform -chdir="$TERRAFORM_DIR" validate &&
+    terraform -chdir="$TERRAFORM_DIR" apply -auto-approve
 }
 
 destroy_terraform_infrastructure() {
   echo "Destroying terraform infrastructure."
-  # FIXME terraform destroy
-  echo "It will be implemented in the PR-02-A"
+  local targets
+  targets="-target=module.networking -target=module.flink-session-cluster"
+  if [ "$PRESERVE_S3_DATA" != "yes" ]; then
+    targets="$targets -target=module.storage"
+  fi
+  terraform -chdir="$TERRAFORM_DIR" destroy -auto-approve $targets
 }
 
 create_kubernetes_infrastructure() {
   echo "Creating kubernetes infrastructure."
-  # FIXME: installing cert-manager and kubernetes-flink-operator, apply kubernetes configuration
-  echo "It will be implemented in the PR-02-A"
+  aws eks --region $AWS_REGION update-kubeconfig --name $EKS_CLUSTER_NAME
+  kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
+
+  # First wait until kubernetes pod is created, and then until it is ready.
+  until kubectl -n cert-manager get pods -o go-template='{{.items | len}}' | grep -qxF 3; do
+    echo "Wait for pods (cert-manager)"
+    sleep 1
+  done
+  kubectl wait -n cert-manager --for=condition=ready pods --all --timeout=300s
+
+  helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.1.0/
+  helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator --replace
+
+  until kubectl -n default get pods -l app.kubernetes.io/name=flink-kubernetes-operator -o go-template='{{.items | len}}' | grep -qxF 1; do
+    echo "Wait for pod (flink-kubernetes-operator)"
+    sleep 1
+  done
+  kubectl wait -n default --for=condition=ready pods --all -l app.kubernetes.io/name=flink-kubernetes-operator
+
+  envsubst <"$KUBERNETES_DIR"/kubernetes.yaml | kubectl apply -f -
 }
 
 kubernetes_cleanup() {
   echo "Kubernetes cleanup."
-  # FIXME: uninstall flink-kubernetes-operator, close port-forward, unset kubernetes context
-  echo "It will be implemented in the PR-02-A"
+  kill $PORT_FORWARD_PID || echo "Port forward is not running"
+  helm uninstall flink-kubernetes-operator
+  kubectl config unset current-context
 }
 
 export_terraform_outputs() {
@@ -81,13 +105,27 @@ export_terraform_outputs() {
 
 jobmanager_port_forward() {
   echo "Run port forward"
-  # FIXME: wait until pod is created & ready and then run port forward
-  echo "It will be implemented in the PR-02-A"
+  export JOBMANAGER_HOSTNAME=localhost
+  export JOBMANAGER_PORT=8081
+
+  until kubectl -n flink-tests get pod -l app=basic-session -o go-template='{{.items | len}}' | grep -qxF 1; do
+    echo "Wait for pod"
+    sleep 1
+  done
+  kubectl wait -n flink-tests --for=condition=ready pod -l app=basic-session --timeout=300s
+  (kubectl -n flink-tests port-forward svc/basic-session-rest 8081) &
+  export PORT_FORWARD_PID=$!
 }
 
 run_end_to_end_tests() {
   echo "Running tests..."
   cd "$PROJECT_ROOT_DIR" || exit
+
+  echo "S3_BUCKET_NAME=$TEST_DATA_BUCKET_NAME"
+  echo "PRESERVE_S3_DATA=$PRESERVE_S3_DATA"
+  echo "AWS_REGION=$AWS_REGION"
+  echo "JOBMANAGER_HOSTNAME=$JOBMANAGER_HOSTNAME"
+  echo "JOBMANAGER_PORT=$JOBMANAGER_PORT"
 
   build/sbt "++ $SCALA_VERSION" \
     flinkEndToEndTests/test

--- a/flink/end-to-end-tests/run-end-to-end-tests.sh
+++ b/flink/end-to-end-tests/run-end-to-end-tests.sh
@@ -96,7 +96,6 @@ kubernetes_cleanup() {
 export_terraform_outputs() {
   export ACCOUNT_ID=$(terraform -chdir="$TERRAFORM_DIR" output account_id | tr -d '"')
   export AWS_REGION=$(terraform -chdir="$TERRAFORM_DIR" output region | tr -d '"')
-  export SERVICE_ACCOUNT_ROLE_NAME=$(terraform -chdir="$TERRAFORM_DIR" output service_account_role_name | tr -d '"')
   export EKS_CLUSTER_NAME=$(terraform -chdir="$TERRAFORM_DIR" output eks_cluster_name | tr -d '"')
   export TEST_DATA_BUCKET_NAME=$(terraform -chdir="$TERRAFORM_DIR" output test_data_bucket_name | tr -d '"')
   export CREDENTIALS_ACCESS_KEY_ID=$(terraform -chdir="$TERRAFORM_DIR" output access_key | tr -d '"' | base64)

--- a/flink/end-to-end-tests/terraform/kubernetes/kubernetes.yaml
+++ b/flink/end-to-end-tests/terraform/kubernetes/kubernetes.yaml
@@ -14,15 +14,13 @@ type: Opaque
 data:
   id: ${CREDENTIALS_ACCESS_KEY_ID}
   key: ${CREDENTIALS_SECRET_KEY}
+
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: flink-tests
   name: flink-tests-sa
-  annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::${ACCOUNT_ID}:role/${SERVICE_ACCOUNT_ROLE_NAME}"
-automountServiceAccountToken: true
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/flink/end-to-end-tests/terraform/kubernetes/kubernetes.yaml
+++ b/flink/end-to-end-tests/terraform/kubernetes/kubernetes.yaml
@@ -1,1 +1,114 @@
-# It will be implemented in the PR-02-A
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flink-tests
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: flink-tests
+  name: aws-credentials
+type: Opaque
+data:
+  id: ${CREDENTIALS_ACCESS_KEY_ID}
+  key: ${CREDENTIALS_SECRET_KEY}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: flink-tests
+  name: flink-tests-sa
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::${ACCOUNT_ID}:role/${SERVICE_ACCOUNT_ROLE_NAME}"
+automountServiceAccountToken: true
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: flink-tests
+  name: flink-tests
+rules:
+  - apiGroups: ["", "apps"]
+    resources: ["pods", "services", "configmaps", "persistentvolumeclaims", "deployments"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: flink-tests
+  name: flink-tests-role-binding
+roleRef:
+  kind: Role
+  name: flink-tests
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: flink-tests-sa
+  namespace: flink-tests
+
+---
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  name: basic-session
+  namespace: flink-tests
+spec:
+  image: flink:1.14.0
+  flinkVersion: v1_14
+  flinkConfiguration:
+    taskmanager.numberOfTaskSlots: "2"
+  serviceAccount: flink-tests-sa
+  jobManager:
+    replicas: 1
+    resource:
+      memory: "2048m"
+      cpu: 1
+    podTemplate:
+      spec:
+        containers:
+          # Do not change the main container name
+          - name: flink-main-container
+            env:
+              - name: ENABLE_BUILT_IN_PLUGINS
+                value: flink-s3-fs-hadoop-1.14.0.jar
+              - name: AWS_ACCESS_KEY_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: aws-credentials
+                    key: id
+                    optional: false
+              - name: AWS_SECRET_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: aws-credentials
+                    key: key
+                    optional: false
+  taskManager:
+    replicas: 2
+    resource:
+      memory: "2048m"
+      cpu: 1
+    podTemplate:
+      spec:
+        containers:
+          # Do not change the main container name
+          - name: flink-main-container
+            env:
+              - name: ENABLE_BUILT_IN_PLUGINS
+                value: flink-s3-fs-hadoop-1.14.0.jar
+              - name: AWS_ACCESS_KEY_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: aws-credentials
+                    key: id
+                    optional: false
+              - name: AWS_SECRET_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: aws-credentials
+                    key: key
+                    optional: false

--- a/flink/end-to-end-tests/terraform/main.tf
+++ b/flink/end-to-end-tests/terraform/main.tf
@@ -1,1 +1,38 @@
-# It will be implemented in the PR-02-A.
+resource "random_string" "run_id" {
+  length  = 6
+  special = false
+  numeric = false
+  lower   = true
+  upper   = false
+}
+
+module "networking" {
+  source = "./modules/networking"
+
+  availability_zone1 = var.availability_zone1
+  availability_zone2 = var.availability_zone2
+}
+
+module "storage" {
+  source = "./modules/storage"
+
+  test_data_bucket_name = var.test_data_bucket_name
+}
+
+module "flink_session_cluster" {
+  source = "./modules/processing-eks"
+
+  run_id = random_string.run_id.result
+
+  vpc_id     = module.networking.vpc_id
+  subnet1_id = module.networking.subnet1_id
+  subnet2_id = module.networking.subnet2_id
+
+  region                = var.region
+  test_data_bucket_name = var.test_data_bucket_name
+  eks_workers           = var.eks_workers
+
+  tags = var.tags
+
+  depends_on = [module.networking, module.storage]
+}

--- a/flink/end-to-end-tests/terraform/modules/networking/main.tf
+++ b/flink/end-to-end-tests/terraform/modules/networking/main.tf
@@ -1,0 +1,30 @@
+resource "aws_vpc" "this" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "subnet_1" {
+  vpc_id            = aws_vpc.this.id
+  availability_zone = var.availability_zone1
+  cidr_block        = "10.0.0.0/17"
+  map_public_ip_on_launch = true
+}
+
+resource "aws_subnet" "subnet_2" {
+  vpc_id            = aws_vpc.this.id
+  availability_zone = var.availability_zone2
+  cidr_block        = "10.0.128.0/17"
+  map_public_ip_on_launch = true
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+}
+
+resource "aws_default_route_table" "public" {
+  default_route_table_id = aws_vpc.this.default_route_table_id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+}

--- a/flink/end-to-end-tests/terraform/modules/networking/main.tf
+++ b/flink/end-to-end-tests/terraform/modules/networking/main.tf
@@ -3,16 +3,16 @@ resource "aws_vpc" "this" {
 }
 
 resource "aws_subnet" "subnet_1" {
-  vpc_id            = aws_vpc.this.id
-  availability_zone = var.availability_zone1
-  cidr_block        = "10.0.0.0/17"
+  vpc_id                  = aws_vpc.this.id
+  availability_zone       = var.availability_zone1
+  cidr_block              = "10.0.0.0/17"
   map_public_ip_on_launch = true
 }
 
 resource "aws_subnet" "subnet_2" {
-  vpc_id            = aws_vpc.this.id
-  availability_zone = var.availability_zone2
-  cidr_block        = "10.0.128.0/17"
+  vpc_id                  = aws_vpc.this.id
+  availability_zone       = var.availability_zone2
+  cidr_block              = "10.0.128.0/17"
   map_public_ip_on_launch = true
 }
 

--- a/flink/end-to-end-tests/terraform/modules/networking/outputs.tf
+++ b/flink/end-to-end-tests/terraform/modules/networking/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "subnet1_id" {
+  value = aws_subnet.subnet_1.id
+}
+
+output "subnet2_id" {
+  value = aws_subnet.subnet_2.id
+}

--- a/flink/end-to-end-tests/terraform/modules/networking/variables.tf
+++ b/flink/end-to-end-tests/terraform/modules/networking/variables.tf
@@ -1,0 +1,7 @@
+variable "availability_zone1" {
+  type = string
+}
+
+variable "availability_zone2" {
+  type = string
+}

--- a/flink/end-to-end-tests/terraform/modules/processing-eks/data.tf
+++ b/flink/end-to-end-tests/terraform/modules/processing-eks/data.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_eks_cluster_auth" "cluster_auth" {
+  name = "token"
+}

--- a/flink/end-to-end-tests/terraform/modules/processing-eks/locals.tf
+++ b/flink/end-to-end-tests/terraform/modules/processing-eks/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  namespace = "flink-tests"
+  service_account = "flink-tests-sa"
+}

--- a/flink/end-to-end-tests/terraform/modules/processing-eks/main.tf
+++ b/flink/end-to-end-tests/terraform/modules/processing-eks/main.tf
@@ -1,0 +1,275 @@
+/* ========== EKS ========== */
+
+resource "aws_eks_cluster" "flink-tests" {
+  name     = "flink-tests-eks-cluster-${var.run_id}"
+  role_arn = aws_iam_role.flink-tests.arn
+
+  vpc_config {
+    subnet_ids = [var.subnet1_id, var.subnet2_id]
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Cluster handling.
+  # Otherwise, EKS will not be able to properly delete EKS managed EC2 infrastructure such as Security Groups.
+  depends_on = [
+    aws_iam_role.flink-tests,
+    aws_iam_role_policy_attachment.flink-tests-AmazonEKSClusterPolicy,
+    aws_iam_role_policy_attachment.flink-tests-AmazonEKSVPCResourceController,
+  ]
+}
+
+resource "aws_eks_node_group" "flink-tests" {
+  cluster_name    = aws_eks_cluster.flink-tests.name
+  node_group_name = "flink-tests-node-group-${var.run_id}"
+  subnet_ids      = [var.subnet1_id]
+  instance_types  = []
+  node_role_arn   = aws_iam_role.flink-tests_node_group.arn
+  labels          = {
+    "spark/component" = "executor"
+    "role" = "spark"
+  }
+
+  launch_template {
+    name    = aws_launch_template.flink-tests.name
+    version = "$Latest"
+  }
+
+  scaling_config {
+    desired_size = var.eks_workers
+    max_size     = var.eks_workers
+    min_size     = var.eks_workers
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    aws_iam_role_policy_attachment.flink-tests-AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.flink-tests-AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.flink-tests-AmazonEC2ContainerRegistryReadOnly,
+  ]
+}
+
+resource "aws_launch_template" "flink-tests" {
+  instance_type = "i3.2xlarge"
+  name          = "flink-tests-lt-${var.run_id}"
+  lifecycle {
+    create_before_destroy = true
+  }
+  tag_specifications {
+    resource_type = "instance"
+    tags          = var.tags
+  }
+}
+
+resource "aws_eks_node_group" "egde_node" {
+  cluster_name    = aws_eks_cluster.flink-tests.name
+  node_group_name = "flink-tests-edge-node-node-group-${var.run_id}"
+  subnet_ids      = [var.subnet1_id]
+  instance_types  = []
+  node_role_arn   = aws_iam_role.flink-tests_node_group.arn
+  labels          = {
+    "spark/component" = "driver"
+    "role" = "edge-node"
+  }
+
+  launch_template {
+    name    = aws_launch_template.egde_node.name
+    version = "$Latest"
+  }
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    aws_iam_role_policy_attachment.flink-tests-AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.flink-tests-AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.flink-tests-AmazonEC2ContainerRegistryReadOnly,
+  ]
+}
+
+resource "aws_launch_template" "egde_node" {
+  instance_type = "m5.xlarge"
+  name          = "flink-tests-edge-node-lt-${var.run_id}"
+  lifecycle {
+    create_before_destroy = true
+  }
+  tag_specifications {
+    resource_type = "instance"
+    tags          = var.tags
+  }
+}
+
+/* ========== IAM ========== */
+
+resource "aws_iam_access_key" "user" {
+  user    = aws_iam_user.user.name
+}
+
+resource "aws_iam_user" "user" {
+  name = "flink-tests-user"
+  path = "/"
+}
+
+resource "aws_iam_user_policy" "user_policy" {
+  name = "flink-tests-user-policy"
+  user = aws_iam_user.user.name
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::${var.test_data_bucket_name}"
+            ],
+            "Action": [
+                "s3:ListBucket"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Resource": "arn:aws:s3:::${var.test_data_bucket_name}/*",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+
+resource "aws_iam_role" "flink-tests" {
+  name = "flink-tests-eks-cluster-role-${var.run_id}"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "flink-tests-AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.flink-tests.name
+}
+
+resource "aws_iam_role_policy_attachment" "flink-tests-AmazonEKSVPCResourceController" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
+  role       = aws_iam_role.flink-tests.name
+}
+
+resource "aws_iam_role" "flink-tests_node_group" {
+  name = "flink-tests-eks-node-group-role-${var.run_id}"
+
+  assume_role_policy = jsonencode({
+    Statement = [
+      {
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "flink-tests-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.flink-tests_node_group.name
+}
+
+resource "aws_iam_role_policy_attachment" "flink-tests-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.flink-tests_node_group.name
+}
+
+resource "aws_iam_role_policy_attachment" "flink-tests-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.flink-tests_node_group.name
+}
+
+data "tls_certificate" "flink-tests" {
+  url = aws_eks_cluster.flink-tests.identity[0].oidc[0].issuer
+}
+
+resource "aws_iam_openid_connect_provider" "flink-tests" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.flink-tests.certificates[0].sha1_fingerprint]
+  url             = aws_eks_cluster.flink-tests.identity[0].oidc[0].issuer
+}
+
+data "aws_iam_policy_document" "flink-tests_assume_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      identifiers = [aws_iam_openid_connect_provider.flink-tests.arn]
+      type        = "Federated"
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.flink-tests.url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:${local.namespace}:${local.service_account}"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.flink-tests.url, "https://", "")}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+
+  depends_on = [aws_iam_openid_connect_provider.flink-tests]
+}
+
+resource "aws_iam_role" "container_role" {
+  assume_role_policy = data.aws_iam_policy_document.flink-tests_assume_role_policy.json
+  name               = "flink-tests-container-role-${var.run_id}"
+}
+
+resource "aws_iam_role_policy" "flink-tests_container_role_policy" {
+  name   = "flink-tests_container_role_policy_${var.run_id}"
+  role   = aws_iam_role.container_role.id
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::${var.test_data_bucket_name}"
+            ],
+            "Action": [
+                "s3:ListBucket"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Resource": "arn:aws:s3:::${var.test_data_bucket_name}/*",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject"
+            ]
+        }
+    ]
+}
+EOF
+}

--- a/flink/end-to-end-tests/terraform/modules/processing-eks/main.tf
+++ b/flink/end-to-end-tests/terraform/modules/processing-eks/main.tf
@@ -23,10 +23,6 @@ resource "aws_eks_node_group" "flink-tests" {
   subnet_ids      = [var.subnet1_id]
   instance_types  = []
   node_role_arn   = aws_iam_role.flink-tests_node_group.arn
-  labels          = {
-    "spark/component" = "executor"
-    "role" = "spark"
-  }
 
   launch_template {
     name    = aws_launch_template.flink-tests.name
@@ -60,49 +56,14 @@ resource "aws_launch_template" "flink-tests" {
   }
 }
 
-resource "aws_eks_node_group" "egde_node" {
-  cluster_name    = aws_eks_cluster.flink-tests.name
-  node_group_name = "flink-tests-edge-node-node-group-${var.run_id}"
-  subnet_ids      = [var.subnet1_id]
-  instance_types  = []
-  node_role_arn   = aws_iam_role.flink-tests_node_group.arn
-  labels          = {
-    "spark/component" = "driver"
-    "role" = "edge-node"
-  }
-
-  launch_template {
-    name    = aws_launch_template.egde_node.name
-    version = "$Latest"
-  }
-
-  scaling_config {
-    desired_size = 1
-    max_size     = 1
-    min_size     = 1
-  }
-  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
-  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
-  depends_on = [
-    aws_iam_role_policy_attachment.flink-tests-AmazonEKSWorkerNodePolicy,
-    aws_iam_role_policy_attachment.flink-tests-AmazonEKS_CNI_Policy,
-    aws_iam_role_policy_attachment.flink-tests-AmazonEC2ContainerRegistryReadOnly,
-  ]
-}
-
-resource "aws_launch_template" "egde_node" {
-  instance_type = "m5.xlarge"
-  name          = "flink-tests-edge-node-lt-${var.run_id}"
-  lifecycle {
-    create_before_destroy = true
-  }
-  tag_specifications {
-    resource_type = "instance"
-    tags          = var.tags
-  }
-}
-
 /* ========== IAM ========== */
+
+# In order to provide fine-grained permissions, IAM roles for service accounts feature should be used:
+# https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
+# Currently S3A connector is configured to use EnvironmentVariableCredentialsProvider, because
+# WebIdentityTokenCredentialsProvider is supported by aws-java-sdk as of version 1.11.704
+# Currently com.amazonaws:aws-java-sdk-bundle:1.11.271 is used (hadoop-aws:3.1.0 dependency),
+# which does not support WebIdentityTokenCredentialsProvider.
 
 resource "aws_iam_access_key" "user" {
   user    = aws_iam_user.user.name
@@ -204,72 +165,4 @@ resource "aws_iam_role_policy_attachment" "flink-tests-AmazonEC2ContainerRegistr
 resource "aws_iam_role_policy_attachment" "flink-tests-AmazonEKS_CNI_Policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
   role       = aws_iam_role.flink-tests_node_group.name
-}
-
-data "tls_certificate" "flink-tests" {
-  url = aws_eks_cluster.flink-tests.identity[0].oidc[0].issuer
-}
-
-resource "aws_iam_openid_connect_provider" "flink-tests" {
-  client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = [data.tls_certificate.flink-tests.certificates[0].sha1_fingerprint]
-  url             = aws_eks_cluster.flink-tests.identity[0].oidc[0].issuer
-}
-
-data "aws_iam_policy_document" "flink-tests_assume_role_policy" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRoleWithWebIdentity"]
-    principals {
-      identifiers = [aws_iam_openid_connect_provider.flink-tests.arn]
-      type        = "Federated"
-    }
-    condition {
-      test     = "StringEquals"
-      variable = "${replace(aws_iam_openid_connect_provider.flink-tests.url, "https://", "")}:sub"
-      values   = ["system:serviceaccount:${local.namespace}:${local.service_account}"]
-    }
-    condition {
-      test     = "StringEquals"
-      variable = "${replace(aws_iam_openid_connect_provider.flink-tests.url, "https://", "")}:aud"
-      values   = ["sts.amazonaws.com"]
-    }
-  }
-
-  depends_on = [aws_iam_openid_connect_provider.flink-tests]
-}
-
-resource "aws_iam_role" "container_role" {
-  assume_role_policy = data.aws_iam_policy_document.flink-tests_assume_role_policy.json
-  name               = "flink-tests-container-role-${var.run_id}"
-}
-
-resource "aws_iam_role_policy" "flink-tests_container_role_policy" {
-  name   = "flink-tests_container_role_policy_${var.run_id}"
-  role   = aws_iam_role.container_role.id
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Resource": [
-                "arn:aws:s3:::${var.test_data_bucket_name}"
-            ],
-            "Action": [
-                "s3:ListBucket"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Resource": "arn:aws:s3:::${var.test_data_bucket_name}/*",
-            "Action": [
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:DeleteObject"
-            ]
-        }
-    ]
-}
-EOF
 }

--- a/flink/end-to-end-tests/terraform/modules/processing-eks/outputs.tf
+++ b/flink/end-to-end-tests/terraform/modules/processing-eks/outputs.tf
@@ -1,0 +1,33 @@
+output "region" {
+  value = var.region
+}
+
+output "account_id" {
+  value = data.aws_caller_identity.current.account_id
+}
+
+output "cluster_name" {
+  value = aws_eks_cluster.flink-tests.name
+}
+
+output "cluster_endpoint" {
+  value = aws_eks_cluster.flink-tests.endpoint
+}
+
+output "certificate_authority_data" {
+  value     = aws_eks_cluster.flink-tests.certificate_authority[0].data
+  sensitive = true
+}
+
+output "container_role" {
+  value = aws_iam_role.container_role.name
+}
+
+output "secret_key" {
+  value = aws_iam_access_key.user.secret
+  sensitive   = true
+}
+
+output "access_key" {
+  value = aws_iam_access_key.user.id
+}

--- a/flink/end-to-end-tests/terraform/modules/processing-eks/outputs.tf
+++ b/flink/end-to-end-tests/terraform/modules/processing-eks/outputs.tf
@@ -19,10 +19,6 @@ output "certificate_authority_data" {
   sensitive = true
 }
 
-output "container_role" {
-  value = aws_iam_role.container_role.name
-}
-
 output "secret_key" {
   value = aws_iam_access_key.user.secret
   sensitive   = true

--- a/flink/end-to-end-tests/terraform/modules/processing-eks/variables.tf
+++ b/flink/end-to-end-tests/terraform/modules/processing-eks/variables.tf
@@ -1,0 +1,31 @@
+variable "run_id" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "subnet1_id" {
+  type = string
+}
+
+variable "subnet2_id" {
+  type = string
+}
+
+variable "test_data_bucket_name" {
+  type = string
+}
+
+variable "eks_workers" {
+  type = number
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/flink/end-to-end-tests/terraform/modules/storage/main.tf
+++ b/flink/end-to-end-tests/terraform/modules/storage/main.tf
@@ -1,0 +1,10 @@
+resource "aws_s3_bucket" "test_data" {
+  bucket = var.test_data_bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "test_data" {
+  bucket = aws_s3_bucket.test_data.id
+  versioning_configuration {
+    status = "Disabled"
+  }
+}

--- a/flink/end-to-end-tests/terraform/modules/storage/outputs.tf
+++ b/flink/end-to-end-tests/terraform/modules/storage/outputs.tf
@@ -1,0 +1,3 @@
+output "test_data_bucket_name" {
+  value = aws_s3_bucket.test_data.bucket
+}

--- a/flink/end-to-end-tests/terraform/modules/storage/variables.tf
+++ b/flink/end-to-end-tests/terraform/modules/storage/variables.tf
@@ -1,0 +1,3 @@
+variable "test_data_bucket_name" {
+  type = string
+}

--- a/flink/end-to-end-tests/terraform/outputs.tf
+++ b/flink/end-to-end-tests/terraform/outputs.tf
@@ -14,10 +14,6 @@ output "region" {
   value = module.flink_session_cluster.region
 }
 
-output "service_account_role_name" {
-  value = module.flink_session_cluster.container_role
-}
-
 output "secret_key" {
   value     = module.flink_session_cluster.secret_key
   sensitive = true

--- a/flink/end-to-end-tests/terraform/outputs.tf
+++ b/flink/end-to-end-tests/terraform/outputs.tf
@@ -1,33 +1,33 @@
 output "eks_cluster_name" {
-  value = "It will be implemented in the PR-02-A"
+  value = module.flink_session_cluster.cluster_name
 }
 
 output "eks_cluster_endpoint" {
-  value = "It will be implemented in the PR-02-A"
+  value = module.flink_session_cluster.cluster_endpoint
 }
 
 output "account_id" {
-  value = "It will be implemented in the PR-02-A"
+  value = module.flink_session_cluster.account_id
 }
 
 output "region" {
-  value = "It will be implemented in the PR-02-A"
+  value = module.flink_session_cluster.region
 }
 
 output "service_account_role_name" {
-  value = "It will be implemented in the PR-02-A"
+  value = module.flink_session_cluster.container_role
 }
 
 output "secret_key" {
-  value     = "It will be implemented in the PR-02-A"
+  value     = module.flink_session_cluster.secret_key
   sensitive = true
 }
 
 output "access_key" {
-  value     = "It will be implemented in the PR-02-A"
+  value     = module.flink_session_cluster.access_key
   sensitive = true
 }
 
 output "test_data_bucket_name" {
-  value = "It will be implemented in the PR-02-A"
+  value = module.storage.test_data_bucket_name
 }

--- a/flink/end-to-end-tests/terraform/providers.tf
+++ b/flink/end-to-end-tests/terraform/providers.tf
@@ -1,0 +1,6 @@
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = var.tags
+  }
+}

--- a/flink/end-to-end-tests/terraform/versions.tf
+++ b/flink/end-to-end-tests/terraform/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.15.1"
+    }
+  }
+}


### PR DESCRIPTION
See the project plan at https://github.com/delta-io/connectors/issues/439.

You can test it by running (ensure that your AWS CLI is configured, terraform and kubectl installed and Terraform variable file exists - for more details see README):
```
   ./flink/end-to-end-tests/run-end-to-end-tests.sh \
       --scala-version 2.12.8 \
       --preserve-s3-data
```
Expected Output:
```
Building artifact.
(sbt output...)
[success] Total time: 12 s, completed Sep 20, 2022 10:54:58 AM
Exporting fat jar path.
Artifact found at path /Users/radoslaw.dziadosz/IdeaProjects/connectors/flink/end-to-end-tests/../end-to-end-tests-fatjar/target/scala-2.12//flink-end-to-end-tests-fatjar-assembly-0.5.1-SNAPSHOT.jar.
Creating terraform infrastructure.
(terraform output...)
Terraform has been successfully initialized!
(terraform output...)
Success! The configuration is valid.
(terraform output...)
Apply complete! Resources: 25 added, 0 changed, 0 destroyed.

Outputs:

access_key = <sensitive>
account_id = "..."
eks_cluster_endpoint = "https://A5DD3233EDC03BC31654F531920EC49B.sk1.eu-central-1.eks.amazonaws.com"
eks_cluster_name = "flink-tests-eks-cluster-wlljxk"
region = "eu-central-1"
secret_key = <sensitive>
service_account_role_name = "flink-tests-container-role-wlljxk"
test_data_bucket_name = "..."

Creating kubernetes infrastructure.
Added new context arn:aws:eks:eu-central-1:781336771001:cluster/flink-tests-eks-cluster-wlljxk to /Users/radoslaw.dziadosz/.kube/config
namespace/cert-manager created
(... cert manager ...)
pod/cert-manager-66b646d76-dx4vg condition met
pod/cert-manager-cainjector-59dc9659c7-cvc24 condition met
pod/cert-manager-webhook-7d8f555998-rw6hz condition met
"flink-operator-repo" already exists with the same configuration, skipping
NAME: flink-kubernetes-operator
LAST DEPLOYED: Tue Sep 20 11:08:23 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
pod/flink-kubernetes-operator-67f5896956-8q8xk condition met
namespace/flink-tests created
secret/aws-credentials created
serviceaccount/flink-tests-sa created
role.rbac.authorization.k8s.io/flink-tests created
rolebinding.rbac.authorization.k8s.io/flink-tests-role-binding created
flinkdeployment.flink.apache.org/basic-session created
Run port forward
pod/basic-session-cb75df6c-cg58z condition met
Running tests...
S3_BUCKET_NAME=delta-flink-connector-e2e-rado
PRESERVE_S3_DATA=yes
AWS_REGION=eu-central-1
JOBMANAGER_HOSTNAME=localhost
JOBMANAGER_PORT=8081
(sbt output...)
[info] Test run started (JUnit Jupiter)
[info] Test io.delta.flink.e2e.SmokeTest#shouldSucceed() started
[info] Test run finished: 0 failed, 0 ignored, 1 total, 0.044s
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[success] Total time: 8 s, completed Sep 20, 2022 11:10:35 AM

Clean up...
Kubernetes cleanup.
These resources were kept due to the resource policy:
[RoleBinding] flink-role-binding
[Role] flink
[ServiceAccount] flink
release "flink-kubernetes-operator" uninstalled
./run-end-to-end-tests.sh: line 89: 35349 Terminated: 15          ( kubectl -n flink-tests port-forward svc/basic-session-rest 8081 )
Property "current-context" unset.
Destroying terraform infrastructure.
(terraform output...)
Destroy complete! Resources: 23 destroyed.
```
