### PR TITLE
Internal API for higher protocol tables + CHECK constraints APIs

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/Constraint.java
+++ b/standalone/src/main/java/io/delta/standalone/Constraint.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (2020-present) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.standalone;
+
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Represents a constraint defined on a Delta table which writers must verify before writing.
+ * Constraints can come in one of two ways:
+ * - A CHECK constraint which is stored in {@code metadata.configuration}
+ * - A column invariant which is stored in a column's metadata
+ */
+// TODO: if we ever plan to support not-null constraints as a java class should we name this
+//  "CheckConstraint" even though we will also be presenting invariants in this form?
+public final class Constraint {
+
+    public static final String CHECK_CONSTRAINT_KEY_PREFIX = "delta.constraints.";
+    @Nonnull private final String name;
+    @Nonnull private final String expression;
+
+    public Constraint(
+            @Nonnull String name,
+            @Nonnull String expression) {
+        this.name = name;
+        this.expression = expression;
+    }
+
+    /**
+     * @return the name of this constraint
+     */
+    @Nonnull
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the expression to enforce of this constraint as a SQL string
+     */
+    @Nonnull
+    public String getExpression() {
+        return expression;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Constraint constraint = (Constraint) o;
+        return Objects.equals(name, constraint.name) &&
+                Objects.equals(expression, constraint.expression);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, expression);
+    }
+}

--- a/standalone/src/main/java/io/delta/standalone/Constraint.java
+++ b/standalone/src/main/java/io/delta/standalone/Constraint.java
@@ -20,14 +20,17 @@ import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
+import io.delta.standalone.actions.Metadata;
+import io.delta.standalone.types.StructField;
+
 // TODO: if we ever plan to support not-null constraints as a java class should we name this
 //  "CheckConstraint" even though we will also be presenting invariants in this form?
 
 /**
  * Represents a constraint defined on a Delta table which writers must verify before writing.
  * Constraints can come in one of two ways:
- * - A CHECK constraint which is stored in {@code metadata.configuration}
- * - A column invariant which is stored in a column's metadata
+ * - A CHECK constraint which is stored in {@link Metadata#getConfiguration()}
+ * - A column invariant which is stored in {@link StructField#getMetadata()}
  */
 public final class Constraint {
 

--- a/standalone/src/main/java/io/delta/standalone/Constraint.java
+++ b/standalone/src/main/java/io/delta/standalone/Constraint.java
@@ -20,14 +20,15 @@ import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
+// TODO: if we ever plan to support not-null constraints as a java class should we name this
+//  "CheckConstraint" even though we will also be presenting invariants in this form?
+
 /**
  * Represents a constraint defined on a Delta table which writers must verify before writing.
  * Constraints can come in one of two ways:
  * - A CHECK constraint which is stored in {@code metadata.configuration}
  * - A column invariant which is stored in a column's metadata
  */
-// TODO: if we ever plan to support not-null constraints as a java class should we name this
-//  "CheckConstraint" even though we will also be presenting invariants in this form?
 public final class Constraint {
 
     public static final String CHECK_CONSTRAINT_KEY_PREFIX = "delta.constraints.";

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -157,7 +157,8 @@ public final class Metadata implements Action {
     }
 
     /**
-     * Add the specified check constraint to the {@code configuration}
+     * Returns a new {@link Metadata} instance with the same properties as this instance but with
+     * the specified check constraint added to the {@code configuration}
      * @param name  the name of the check constraint
      * @param expression  the condition to enforce as a SQL string
      * @return a new {@link Metadata} instance with the same properties as this instance but with
@@ -175,7 +176,8 @@ public final class Metadata implements Action {
     }
 
     /**
-     * Removes the specified check constraint from the {@code configuration}
+     * Returns a new {@link Metadata} instance with the same properties as this instance but with
+     * the specified check constraint removed from the {@code configuration}
      * @param name  the name of the check constraint to remove
      * @return a new {@link Metadata} instance with the same properties as this instance but with
      *         the specified check constraint removed

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -98,6 +98,9 @@ private[internal] class DeltaLogImpl private(
   //  For now we use protocol version numbers to keep the same only supported protocol version at
   //  Protocol(1, 2).
 
+  // connectorReaderVersion and connectorWriterVersion are lazy because otherwise they are
+  // initialized after code in `SnapshotManagement` uses `protocolRead(..)` and `protocolWrite(..)`
+
   /** Max reader protocol version the connector engine can read */
   private lazy val connectorReaderVersion = 1
 

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -99,10 +99,10 @@ private[internal] class DeltaLogImpl private(
   //  Protocol(1, 2).
 
   /** Max reader protocol version the connector engine can read */
-  private val connectorReaderVersion = 1
+  private lazy val connectorReaderVersion = 1
 
   /** Max writer protocol version the connector engine can write to */
-  private val connectorWriterVersion = 2
+  private lazy val connectorWriterVersion = 2
 
   ///////////////////////////////////////////////////////////////////////////
   // Public Java API Methods

--- a/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
@@ -493,7 +493,7 @@ private[internal] class OptimisticTransactionImpl(
     }
 
     Protocol.checkMetadataProtocolProperties(metadata, protocol)
-    Protocol.checkMetadataProtocolCompatibility(metadata, protocol)
+    Protocol.checkMetadataFeatureProtocolCompatibility(metadata, protocol)
   }
 
   /**

--- a/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
@@ -326,7 +326,8 @@ private class InitialSnapshotImpl(
     SnapshotImpl.State(Nil, Nil, Nil, 0L, 0L, 0L, 0L)
   }
 
-  override lazy val protocolScala: Protocol = Protocol()
+  // TODO: select the default initial protocol version
+  override lazy val protocolScala: Protocol = Protocol(1, 2)
 
   override lazy val metadataScala: Metadata = Metadata()
 

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
@@ -84,7 +84,7 @@ private[internal] object Protocol {
   }
 
   /** Check that the protocol is compatible with any features enabled in the table metadata */
-  def checkMetadataProtocolCompatibility(metadata: Metadata, protocol: Protocol): Unit = {
+  def checkMetadataFeatureProtocolCompatibility(metadata: Metadata, protocol: Protocol): Unit = {
     // look at Protocol.requiredMinimumProtocol in Delta
 
     // Column invariants

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
@@ -64,8 +64,8 @@ private[internal] sealed trait Action {
  * fields that they do not understand.
  */
 private[internal] case class Protocol(
-    minReaderVersion: Int = Action.readerVersion,
-    minWriterVersion: Int = Action.writerVersion) extends Action {
+    minReaderVersion: Int,
+    minWriterVersion: Int) extends Action {
   override def wrap: SingleAction = SingleAction(protocol = this)
 
   @JsonIgnore

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
@@ -33,6 +33,8 @@ import io.delta.standalone.internal.util.{DataTypeParser, JsonUtils}
 
 private[internal] object Action {
   /** The maximum version of the protocol that this version of Delta Standalone understands. */
+  // Note: features between version (1,2) and (2,5) are in development. We bump to (2,5) now
+  // since the features are not being implemented linearly. This does not affect any public APIs.
   val readerVersion = 2
   val writerVersion = 5
   val protocolVersion: Protocol = Protocol(readerVersion, writerVersion)

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
@@ -24,14 +24,17 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.{JsonSerializer, SerializerProvider}
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
 
+import io.delta.standalone.Constraint
 import io.delta.standalone.types.StructType
 
+import io.delta.standalone.internal.DeltaConfigs
+import io.delta.standalone.internal.exception.DeltaErrors
 import io.delta.standalone.internal.util.{DataTypeParser, JsonUtils}
 
 private[internal] object Action {
   /** The maximum version of the protocol that this version of Delta Standalone understands. */
-  val readerVersion = 1
-  val writerVersion = 2
+  val readerVersion = 2
+  val writerVersion = 5
   val protocolVersion: Protocol = Protocol(readerVersion, writerVersion)
 
   def fromJson(json: String): Action = {
@@ -78,6 +81,36 @@ private[internal] object Protocol {
       s"protocol version ($MIN_READER_VERSION_PROP) as part of table properties")
     assert(!metadata.configuration.contains(MIN_WRITER_VERSION_PROP), s"Should not have the " +
       s"protocol version ($MIN_WRITER_VERSION_PROP) as part of table properties")
+  }
+
+  /** Check that the protocol is compatible with any features enabled in the table metadata */
+  def checkMetadataProtocolCompatibility(metadata: Metadata, protocol: Protocol): Unit = {
+    // look at Protocol.requiredMinimumProtocol in Delta
+
+    // Column invariants
+    // check for invariants in the schema
+
+    // Append-only
+    if (DeltaConfigs.IS_APPEND_ONLY.fromMetadata(metadata) && protocol.minWriterVersion < 2) {
+      // todo: when we add the feature enums we can use their string here (and all below)
+      throw DeltaErrors.insufficientWriterVersion(protocol, 2, "appendOnly")
+    }
+
+    // Check constraints
+    if (metadata.configuration.keys.exists(_.startsWith(Constraint.CHECK_CONSTRAINT_KEY_PREFIX))
+      && protocol.minWriterVersion < 3) {
+      throw DeltaErrors.insufficientWriterVersion(protocol, 3, "checkConstraint")
+    }
+
+    // Generated columns
+
+    // CDF
+    // check config
+
+    // Column mapping
+    // check column mapping mode
+
+    // todo: Should we check for any unsupported features? i.e. identity columns
   }
 }
 

--- a/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
@@ -31,6 +31,8 @@ import io.delta.standalone.internal.util.JsonUtils
 /** A holder object for Delta errors. */
 private[internal] object DeltaErrors {
 
+  // TODO: improve this error message to accommodate for standalone vs. connector protocol
+  //  incompatibilities
   /**
    * Thrown when the protocol version of a table is greater than the one supported by this client
    */
@@ -347,6 +349,23 @@ private[internal] object DeltaErrors {
   def nonPartitionColumnAbsentException(): Throwable = {
     new DeltaStandaloneException("Data written into Delta needs to contain at least one " +
       "non-partitioned column")
+  }
+
+  def checkConstraintAlreadyExists(name: String, expression: String): Throwable = {
+    new IllegalArgumentException(
+      s"Constraint '$name' already exists. Please remove the old constraint first.\n" +
+        s"Old constraint: $expression")
+  }
+
+  def checkConstraintDoesNotExist(name: String): Throwable = {
+    new IllegalArgumentException(s"Cannot drop nonexistent constraint '$name'.")
+  }
+
+  def insufficientWriterVersion(existingProtocol: Protocol, minWriterVersion: Int,
+      featureString: String): Throwable = {
+    new DeltaStandaloneException(
+      s"Feature $featureString requires at least writer version $minWriterVersion but current " +
+        s"table protocol is ${existingProtocol.simpleString}")
   }
 
   ///////////////////////////////////////////////////////////////////////////

--- a/standalone/src/test/scala/io/delta/standalone/internal/ConversionUtilsSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ConversionUtilsSuite.scala
@@ -53,7 +53,7 @@ class ConversionUtilsSuite extends FunSuite {
 
   private val setTransaction = SetTransaction("appId", 1L, Some(2000L))
 
-  private val protocol = Protocol()
+  private val protocol = Protocol(1, 2)
 
   private val actions =
     Seq(addFile, cdcFile, removeFile, metadata, commitInfo, setTransaction, protocol)

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright (2020-present) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.standalone.internal
+
+import scala.collection.JavaConverters._
+
+import org.apache.hadoop.conf.Configuration
+import org.scalatest.FunSuite
+
+import io.delta.standalone.{Constraint, Operation}
+import io.delta.standalone.actions.Metadata
+import io.delta.standalone.types.{IntegerType, StructField, StructType}
+
+import io.delta.standalone.internal.util.TestUtils._
+
+class DeltaConstraintsSuite extends FunSuite {
+
+  // todo: should we add a test-suite trait storing helpers like this?
+  private def testException[T <: Throwable](f: => Any, messageContains: String)
+    (implicit manifest: Manifest[T]) = {
+    val e = intercept[T]{
+      f;
+    }.getMessage
+    assert(e.contains(messageContains))
+  }
+
+  def testGetConstraints(configuration: Map[String, String],
+      expectedConstraints: Seq[Constraint]): Unit = {
+    val metadata = Metadata.builder().configuration(configuration.asJava).build()
+    assert(metadata.getConstraints.asScala == expectedConstraints)
+  }
+
+  test("getConstraints") {
+    // no constraints
+    assert(Metadata.builder().build().getConstraints.isEmpty)
+
+    // retrieve one check constraints
+    testGetConstraints(
+      Map("delta.constraints.constraint1" -> "expression1"),
+      Seq(new Constraint("constraint1", "expression1"))
+    )
+
+    // retrieve two check constraints
+    testGetConstraints(
+      Map(
+        "delta.constraints.constraint1" -> "expression1",
+        "delta.constraints.constraint2" -> "expression2"
+      ),
+      Seq(new Constraint("constraint1", "expression1"),
+        new Constraint("constraint2", "expression2"))
+    )
+
+    // check constraint key format
+    testGetConstraints(
+      Map(
+        // should be retrieved, preserves expression case
+        "delta.constraints.constraints" -> "EXPRESSION3",
+        // should not be retrieved
+        "constraint1" -> "expression1",
+        "delta.constraint.constraint2" -> "expression2",
+        "constraints.constraint3" -> "expression3",
+        "DELTA.CONSTRAINTS.constraint4" -> "expression4"
+      ),
+      Seq(new Constraint("constraints", "EXPRESSION3"))
+    )
+  }
+
+  test("addCheckConstraint") {
+    // add a constraint
+    var metadata = Metadata.builder().build().addCheckConstraint("name", "expression")
+    assert(metadata.getConfiguration.get("delta.constraints.name").contains("expression"))
+
+    // add an already existing constraint
+    testException[IllegalArgumentException](
+      metadata.addCheckConstraint("name", "expression2"),
+      "Constraint 'name' already exists. Please remove the old constraint first.\n" +
+        "Old constraint: expression"
+    )
+
+    // not-case sensitive
+    testException[IllegalArgumentException](
+      metadata.addCheckConstraint("NAME", "expression2"),
+      "Constraint 'NAME' already exists. Please remove the old constraint first.\n" +
+        "Old constraint: expression"
+    )
+
+    // stores constraint lower case
+    metadata = Metadata.builder().build().addCheckConstraint("NAME", "expression")
+    assert(metadata.getConfiguration.get("delta.constraints.name").contains("expression"))
+  }
+
+  test("removeCheckConstraint") {
+    // remove a constraint
+    val configuration = Map("delta.constraints.name" -> "expression").asJava
+    var metadata = Metadata.builder().configuration(configuration).build()
+      .removeCheckConstraint("name")
+    assert(!metadata.getConfiguration.containsKey("delta.constraints.name"))
+
+    // remove a non-existent constraint
+    val e = intercept[IllegalArgumentException](
+      metadata.removeCheckConstraint("name")
+    ).getMessage
+    assert(e.contains("Cannot drop nonexistent constraint 'name'"))
+
+    // not-case sensitive
+    metadata = Metadata.builder().configuration(configuration).build()
+      .removeCheckConstraint("NAME")
+    assert(!metadata.getConfiguration.containsKey("delta.constraints.name"))
+  }
+
+  test("addCheckConstraint/removeCheckConstraint + getConstraints") {
+    // add one constraint
+    var metadata = Metadata.builder().build().addCheckConstraint("name", "expression")
+    assert(metadata.getConstraints.asScala == Seq(new Constraint("name", "expression")))
+
+    // remove the constraint
+    metadata = metadata.removeCheckConstraint("name")
+    assert(Metadata.builder().build().getConstraints.isEmpty)
+  }
+
+  test("check constraints + protocol version checks") {
+    val schema = new StructType(Array(new StructField("col1", new IntegerType(), true)))
+
+    // fail correctly when too low a protocol version
+    withTempDir { dir =>
+      val log = DeltaLogImpl.forTable(new Configuration(), dir.getCanonicalPath, true)
+      val txn = log.startTransactionWithInitialProtocolVersion(1, 2)
+      val metadata = Metadata.builder().schema(schema).build()
+        .addCheckConstraint("test", "col1 < 0")
+      testException[RuntimeException](
+        txn.commit(
+          Iterable(metadata).asJava,
+          new Operation(Operation.Name.MANUAL_UPDATE),
+          "test-engine-info"
+        ),
+        "Feature checkConstraint requires at least writer version 3 but current " +
+          "table protocol is (1,2)"
+      )
+    }
+
+    // can commit and retrieve check constraint with sufficient protocol version
+    withTempDir { dir =>
+      val log = DeltaLogImpl.forTable(new Configuration(), dir.getCanonicalPath, true)
+      val txn = log.startTransactionWithInitialProtocolVersion(1, 3)
+      val metadata = Metadata.builder().schema(schema).build()
+        .addCheckConstraint("test", "col1 < 0")
+      txn.commit(
+        Iterable(metadata).asJava,
+        new Operation(Operation.Name.MANUAL_UPDATE),
+        "test-engine-info"
+      )
+      assert(log.startTransaction().metadata().getConstraints.asScala ==
+        Seq(new Constraint("test", "col1 < 0")))
+    }
+  }
+}

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
@@ -138,10 +138,10 @@ class DeltaConstraintsSuite extends FunSuite {
     assert(Metadata.builder().build().getConstraints.isEmpty)
   }
 
-  test("check constraints + protocol version checks") {
+  test("check constraints: metadata-protocol compatibility checks") {
     val schema = new StructType(Array(new StructField("col1", new IntegerType(), true)))
 
-    // fail correctly when too low a protocol version
+    // cannot add a check constraint to a table with too low a protocol version
     withTempDir { dir =>
       val log = getDeltaLogWithStandaloneAsConnector(new Configuration(), dir.getCanonicalPath)
       val txn = log.startTransactionWithInitialProtocolVersion(1, 2)
@@ -158,7 +158,7 @@ class DeltaConstraintsSuite extends FunSuite {
       )
     }
 
-    // can commit and retrieve check constraint with sufficient protocol version
+    // can commit and retrieve check constraint for table with sufficient protocol version
     withTempDir { dir =>
       val log = getDeltaLogWithStandaloneAsConnector(new Configuration(), dir.getCanonicalPath)
       val txn = log.startTransactionWithInitialProtocolVersion(1, 3)
@@ -175,15 +175,15 @@ class DeltaConstraintsSuite extends FunSuite {
   }
 
   test("example testing connector protocol checks") {
-    // reads fail when connector doesn't support protocol
+    // reads fail when connector doesn't support the table protocol
     withTempDir { dir =>
 
       // create delta log as a connector that supports readerVersion = 1 (in the future,
       // a list of features that doesn't include all the features in the table's protocol)
-      // this will be the public DeltaLog.forTable(...) API and will use supported feature lists
+      // also this will be the public DeltaLog.forTable(...) API and use supported feature lists
       val connectorLog = DeltaLogImpl.forTable(new Configuration(), dir.getCanonicalPath, 1, 2)
 
-      // separately commit to table with Protocol(2, 5)
+      // separately commit to the table Protocol(2, 5)
       val schema = new StructType(Array(new StructField("col1", new IntegerType(), true)))
       val log = getDeltaLogWithStandaloneAsConnector(new Configuration(), dir.getCanonicalPath)
       val txn = log.startTransactionWithInitialProtocolVersion(2, 5)

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
@@ -31,9 +31,9 @@ class DeltaConstraintsSuite extends FunSuite {
 
   // todo: should we add a test-suite trait storing helpers like this?
   private def testException[T <: Throwable](f: => Any, messageContains: String)
-    (implicit manifest: Manifest[T]) = {
+      (implicit manifest: Manifest[T]) = {
     val e = intercept[T]{
-      f;
+      f
     }.getMessage
     assert(e.contains(messageContains))
   }
@@ -98,7 +98,7 @@ class DeltaConstraintsSuite extends FunSuite {
         "Old constraint: expression"
     )
 
-    // stores constraint lower case
+    // stores constraint lower case in metadata.configuration
     metadata = Metadata.builder().build().addCheckConstraint("NAME", "expression")
     assert(metadata.getConfiguration.get("delta.constraints.name").contains("expression"))
   }
@@ -123,7 +123,7 @@ class DeltaConstraintsSuite extends FunSuite {
   }
 
   test("addCheckConstraint/removeCheckConstraint + getConstraints") {
-    // add one constraint
+    // add a constraint
     var metadata = Metadata.builder().build().addCheckConstraint("name", "expression")
     assert(metadata.getConstraints.asScala == Seq(new Constraint("name", "expression")))
 

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -336,7 +336,7 @@ abstract class DeltaLogSuiteBase extends FunSuite {
     }
 
     assert(e.getMessage === new DeltaErrors.InvalidProtocolVersionException(Action.protocolVersion,
-      Protocol(99)).getMessage)
+      Protocol(99, 2)).getMessage)
   }
 
   test("get commit info") {

--- a/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionLegacySuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionLegacySuite.scala
@@ -262,7 +262,7 @@ class OptimisticTransactionLegacySuite extends FunSuite {
   test("can't change protocol to invalid version") {
     withTempDir { dir =>
       val log = DeltaLog.forTable(new Configuration(), dir.getCanonicalPath)
-      log.startTransaction().commit(metadata :: Protocol() :: Nil, manualUpdate, engineInfo)
+      log.startTransaction().commit(metadata :: Protocol(1, 2) :: Nil, manualUpdate, engineInfo)
 
       Seq(Protocol(1, 3), Protocol(1, 1), Protocol(2, 2)).foreach { protocol =>
         val e = intercept[AssertionError] {

--- a/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/OptimisticTransactionSuite.scala
@@ -316,4 +316,10 @@ class OptimisticTransactionSuite extends OptimisticTransactionSuiteBase {
       assert(committedAddFile.getPath === "file:/absolute/path/to/file/test.parquet")
     }
   }
+
+  ///////////////////////////////////////////////////////////////////////////
+  // prepareCommit() protocol checks
+  ///////////////////////////////////////////////////////////////////////////
+
+  // TODO: test appendOnly protocol check
 }


### PR DESCRIPTION
## Overview

Adds internal APIs for testing purposes to allow creating tables of higher-protocol versions, and allow reading/writing to them. All public APIs should be unaffected and will still only support Protocol(1, 2).

Also adds support for CHECK constraints.

## Internal higher-protocol APIs (out-of-date)

### Reading/writing to higher-protocol tables
We introduce the separate concepts of standalone's supported protocol version vs. the connector's supported protocol version. For testing, we have flag `ignoreConnectorProtocolChecks` which ignores the second check and only checks for standalone's protocol compatibility. This can only be set to true from `DeltaLogImpl.forTable`.

### Creating higher-protocol tables
We also introduce `log.startTransactionWithInitialProtocolVersion` which enables creating a new table with a higher protocol version than (1,2). This is a private API that will only be used for testing. Once we introduce public APIs this operation can be updated to be:
```
val txn = log.startTransaction()
txn.upgradeProtocolVersion(1, 3)
```
#### Reasoning

Other possibilities to allow this include:
1. Adding a private API to `OptimisticTransactionImpl` instead, but this would require any tests using it to cast `txn.asInstanceOf[OptimisticTransactionImpl]`. We also would still only want to support version 0 so this would not be the same API that we plan to later make public.
2. Commit the Protocol file action directly. Since we plan to block this later on this makes the later migration more painful.

## CHECK constraints

We introduce a java class `Constraint` that will represent check constraints and column invariants. APIs for retrieving constraints and adding/removing check constraints are added to `Metadata`. We also add a test suite `DeltaConstraintsSuite`
