### PR TITLE
[Minor refactor] Rename variables in `Action`

### DIFF
--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -210,7 +210,7 @@ private[internal] class DeltaLogImpl private(
    * allowed to read the table that is using the given `protocol`.
    */
   def assertProtocolRead(protocol: Protocol): Unit = {
-    if (protocol != null && Action.readerVersion < protocol.minReaderVersion) {
+    if (protocol != null && Action.maxSupportedReaderVersion < protocol.minReaderVersion) {
       throw new DeltaErrors.InvalidProtocolVersionException(Action.protocolVersion, protocol)
     }
   }
@@ -220,7 +220,7 @@ private[internal] class DeltaLogImpl private(
    * allowed to write to the table that is using the given `protocol`.
    */
   def assertProtocolWrite(protocol: Protocol): Unit = {
-    if (protocol != null && Action.writerVersion < protocol.minWriterVersion) {
+    if (protocol != null && Action.maxSupportedWriterVersion < protocol.minWriterVersion) {
       throw new DeltaErrors.InvalidProtocolVersionException(Action.protocolVersion, protocol)
     }
   }

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
@@ -30,9 +30,9 @@ import io.delta.standalone.internal.util.{DataTypeParser, JsonUtils}
 
 private[internal] object Action {
   /** The maximum version of the protocol that this version of Delta Standalone understands. */
-  val readerVersion = 1
-  val writerVersion = 2
-  val protocolVersion: Protocol = Protocol(readerVersion, writerVersion)
+  val maxSupportedReaderVersion = 1
+  val maxSupportedWriterVersion = 2
+  val protocolVersion: Protocol = Protocol(maxSupportedReaderVersion, maxSupportedWriterVersion)
 
   def fromJson(json: String): Action = {
     JsonUtils.mapper.readValue[SingleAction](json).unwrap
@@ -61,8 +61,8 @@ private[internal] sealed trait Action {
  * fields that they do not understand.
  */
 private[internal] case class Protocol(
-    minReaderVersion: Int = Action.readerVersion,
-    minWriterVersion: Int = Action.writerVersion) extends Action {
+    minReaderVersion: Int = Action.maxSupportedReaderVersion,
+    minWriterVersion: Int = Action.maxSupportedWriterVersion) extends Action {
   override def wrap: SingleAction = SingleAction(protocol = this)
 
   @JsonIgnore


### PR DESCRIPTION
Rename `readerVersion` and `writerVersion` to `maxSupportedReaderVersion` and `maxSupportedWriterVersion` to be more clear (https://github.com/delta-io/connectors/pull/451/files#r1001126007)