### PR TITLE
Column Invariants

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/Constraint.java
+++ b/standalone/src/main/java/io/delta/standalone/Constraint.java
@@ -24,8 +24,9 @@ import io.delta.standalone.types.StructField;
  * Constraints can come in one of two ways:
  * - A CHECK constraint which is stored in {@link Metadata#getConfiguration()}. CHECK constraints
  *   are stored as the key-value pair ("delta.constraints.{constraintName}", "{expression}")
- * - A column invariant which is stored in {@link StructField#getMetadata()}
- *   TODO: provide more details here
+ * - A column invariant which is stored in {@link StructField#getMetadata()}. See
+ *   <a href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md#column-invariants">Column Invariants</a>
+ *   for more information.
  */
 public interface Constraint {
 

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -31,6 +31,8 @@ import io.delta.standalone.types.StructType;
 
 import io.delta.standalone.internal.ConstraintImpl;
 import io.delta.standalone.internal.exception.DeltaErrors;
+import io.delta.standalone.internal.util.InvariantUtils;
+
 
 /**
  * Updates the metadata of the table. The first version of a table must contain

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -31,7 +31,6 @@ import io.delta.standalone.types.StructType;
 
 import io.delta.standalone.internal.ConstraintImpl;
 import io.delta.standalone.internal.exception.DeltaErrors;
-import io.delta.standalone.internal.util.InvariantUtils;
 
 /**
  * Updates the metadata of the table. The first version of a table must contain

--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -33,7 +33,6 @@ import io.delta.standalone.internal.ConstraintImpl;
 import io.delta.standalone.internal.exception.DeltaErrors;
 import io.delta.standalone.internal.util.InvariantUtils;
 
-
 /**
  * Updates the metadata of the table. The first version of a table must contain
  * a {@link Metadata} action. Subsequent {@link Metadata} actions completely

--- a/standalone/src/main/scala/io/delta/standalone/internal/ConstraintImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/ConstraintImpl.scala
@@ -21,7 +21,6 @@ import java.util.Locale
 import scala.collection.JavaConverters._
 
 import io.delta.standalone.Constraint
-
 import io.delta.standalone.actions.Metadata
 
 import io.delta.standalone.internal.util.InvariantUtils

--- a/standalone/src/main/scala/io/delta/standalone/internal/ConstraintImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/ConstraintImpl.scala
@@ -21,7 +21,10 @@ import java.util.Locale
 import scala.collection.JavaConverters._
 
 import io.delta.standalone.Constraint
+
 import io.delta.standalone.actions.Metadata
+
+import io.delta.standalone.internal.util.InvariantUtils
 
 /**
  * Scala implementation of Java interface [[Constraint]].
@@ -44,10 +47,8 @@ private[standalone] object ConstraintImpl {
    * [[StructField#getMetadata( )]].
    */
   def getConstraints(metadata: Metadata): java.util.List[Constraint] = {
-    // todo: get column invariants
-
-    // get check constraints
-    getCheckConstraints(metadata.getConfiguration.asScala.toMap).asJava
+    (InvariantUtils.getFromSchema(metadata.getSchema)
+      ++ getCheckConstraints(metadata.getConfiguration.asScala.toMap)).asJava
   }
 
   ///////////////////////////////////////////////////////////////////////////

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
@@ -28,7 +28,7 @@ import io.delta.standalone.types.StructType
 
 import io.delta.standalone.internal.{ConstraintImpl, DeltaColumnMappingMode, DeltaConfigs}
 import io.delta.standalone.internal.exception.DeltaErrors
-import io.delta.standalone.internal.util.{DataTypeParser, JsonUtils}
+import io.delta.standalone.internal.util.{DataTypeParser, InvariantUtils, JsonUtils}
 
 private[internal] object Action {
   /** The maximum version of the protocol that this version of Delta Standalone understands. */
@@ -100,7 +100,9 @@ private[internal] object Protocol {
     // look at Protocol.requiredMinimumProtocol in Delta
 
     // Column invariants
-    // check for invariants in the schema
+    if (InvariantUtils.getFromSchema(metadata.schema).size > 0 && protocol.minWriterVersion < 2) {
+      throw DeltaErrors.insufficientWriterVersion(protocol, 2, "columnInvariants")
+    }
 
     // Append-only
     val appendOnlyMinProtocol = Protocol(0, 2)

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
@@ -89,7 +89,12 @@ private[internal] object Protocol {
       s"protocol version ($MIN_WRITER_VERSION_PROP) as part of table properties")
   }
 
-  /** Check that the protocol is compatible with any features enabled in the table metadata */
+  /**
+   * Checks that the table protocol is sufficient for any features enabled in the table metadata.
+   * For writer features, we check for sufficient writer version. For reader features, we check
+   * for sufficient reader version. And for reader and writer features, we check for sufficient
+   * reader and writer version.
+   */
   def checkMetadataFeatureProtocolCompatibility(metadata: Metadata, protocol: Protocol): Unit = {
 
     def insufficientProtocol(requiredProtocol: Protocol): Boolean = {

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
@@ -105,8 +105,11 @@ private[internal] object Protocol {
     // look at Protocol.requiredMinimumProtocol in Delta
 
     // Column invariants
-    if (InvariantUtils.getFromSchema(metadata.schema).size > 0 && protocol.minWriterVersion < 2) {
-      throw DeltaErrors.insufficientWriterVersion(protocol, 2, "columnInvariants")
+    val columnInvariantsMinProtocol = Protocol(0, 2)
+    if (InvariantUtils.getFromSchema(metadata.schema).size > 0 &&
+      insufficientProtocol(columnInvariantsMinProtocol)) {
+      throw DeltaErrors.insufficientTableProtocolVersion(protocol,
+        columnInvariantsMinProtocol, "columnInvariants")
     }
 
     // Append-only

--- a/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
@@ -400,6 +400,7 @@ private[internal] object DeltaErrors {
     new IllegalArgumentException(s"Cannot drop nonexistent constraint '$name'.")
   }
 
+<<<<<<< HEAD
   def changeColumnMappingModeNotSupported(oldMode: String, newMode: String): Throwable = {
     new ColumnMappingUnsupportedException(
       s"Changing column mapping mode from $oldMode to $newMode is not supported.")
@@ -421,6 +422,11 @@ private[internal] object DeltaErrors {
       s"old schema: ${oldSchema.getTreeString}\n" +
       s"new schema: ${newSchema.getTreeString}\n" +
       "Schema changes are not allowed during the change of column mapping mode.")
+=======
+  def unrecognizedInvariant(): Throwable = {
+    // todo: investigate when we see this
+    new UnsupportedOperationException("Unrecognized invariant.")
+>>>>>>> 99e648e2 (save)
   }
 
   def missingColumnId(mode: DeltaColumnMappingMode, field: String): Throwable = {

--- a/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
@@ -400,7 +400,7 @@ private[internal] object DeltaErrors {
     new IllegalArgumentException(s"Cannot drop nonexistent constraint '$name'.")
   }
 
-<<<<<<< HEAD
+
   def changeColumnMappingModeNotSupported(oldMode: String, newMode: String): Throwable = {
     new ColumnMappingUnsupportedException(
       s"Changing column mapping mode from $oldMode to $newMode is not supported.")
@@ -419,14 +419,13 @@ private[internal] object DeltaErrors {
       oldSchema: StructType, newSchema: StructType): Throwable = {
     new ColumnMappingUnsupportedException(
       "Schema change is detected: \n" +
-      s"old schema: ${oldSchema.getTreeString}\n" +
-      s"new schema: ${newSchema.getTreeString}\n" +
-      "Schema changes are not allowed during the change of column mapping mode.")
-=======
-  def unrecognizedInvariant(): Throwable = {
-    // todo: investigate when we see this
-    new UnsupportedOperationException("Unrecognized invariant.")
->>>>>>> 99e648e2 (save)
+        s"old schema: ${oldSchema.getTreeString}\n" +
+        s"new schema: ${newSchema.getTreeString}\n" +
+        "Schema changes are not allowed during the change of column mapping mode.")
+  }
+
+  def misformattedInvariant(expr: String): Throwable = {
+    new IllegalStateException(s"Misformatted invariant: $expr")
   }
 
   def missingColumnId(mode: DeltaColumnMappingMode, field: String): Throwable = {

--- a/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
@@ -400,7 +400,6 @@ private[internal] object DeltaErrors {
     new IllegalArgumentException(s"Cannot drop nonexistent constraint '$name'.")
   }
 
-
   def changeColumnMappingModeNotSupported(oldMode: String, newMode: String): Throwable = {
     new ColumnMappingUnsupportedException(
       s"Changing column mapping mode from $oldMode to $newMode is not supported.")
@@ -419,9 +418,9 @@ private[internal] object DeltaErrors {
       oldSchema: StructType, newSchema: StructType): Throwable = {
     new ColumnMappingUnsupportedException(
       "Schema change is detected: \n" +
-        s"old schema: ${oldSchema.getTreeString}\n" +
-        s"new schema: ${newSchema.getTreeString}\n" +
-        "Schema changes are not allowed during the change of column mapping mode.")
+      s"old schema: ${oldSchema.getTreeString}\n" +
+      s"new schema: ${newSchema.getTreeString}\n" +
+      "Schema changes are not allowed during the change of column mapping mode.")
   }
 
   def misformattedInvariant(expr: String): Throwable = {

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/InvariantUtils.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/InvariantUtils.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (2020-present) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.standalone.internal.util
+
+import scala.collection.JavaConverters._
+
+import io.delta.standalone.Constraint
+import io.delta.standalone.types.StructType
+
+import io.delta.standalone.internal.exception.DeltaErrors
+
+/**
+ * Invariant utils for retrieving column invariants from the schema.
+ */
+private[internal] object InvariantUtils {
+  sealed trait Rule {
+    val name: String
+  }
+
+  sealed trait RulePersistedInMetadata {
+    def wrap: PersistedRule
+    def json: String = JsonUtils.toJson(wrap)
+  }
+
+  /** Rules that are persisted in the metadata field of a schema. */
+  case class PersistedRule(expression: PersistedExpression = null) {
+    def unwrap: RulePersistedInMetadata = {
+      if (expression != null) {
+        expression
+      } else {
+        null
+      }
+    }
+  }
+
+  /** Persisted companion of the ArbitraryExpression rule. */
+  case class PersistedExpression(expression: String) extends RulePersistedInMetadata {
+    override def wrap: PersistedRule = PersistedRule(expression = this)
+  }
+
+  /** Extract column invariants from the given schema */
+  def getFromSchema(schema: StructType): Seq[Constraint] = {
+    val columns = SchemaUtils.filterRecursively(schema, checkComplexTypes = false) { field =>
+      field.getMetadata.contains(INVARIANTS_FIELD)
+    }
+    columns.map {
+      case (_, field) =>
+        val rule = field.getMetadata.get(INVARIANTS_FIELD).asInstanceOf[String]
+        val invariant = Option(JsonUtils.mapper.readValue[PersistedRule](rule).unwrap) match {
+          case Some(PersistedExpression(exprString)) =>
+            exprString
+          case _ =>
+             // todo: clarify when we might hit this?
+             throw DeltaErrors.unrecognizedInvariant()
+        }
+        new Constraint(s"EXPRESSION($invariant)", invariant)
+    }
+  }
+
+  val INVARIANTS_FIELD = "delta.invariants"
+}

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/SchemaUtils.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/SchemaUtils.scala
@@ -91,6 +91,7 @@ private[standalone] object SchemaUtils {
    *   - Drops any column that is present in the current schema
    *   - Converts nullable=true to nullable=false for any column
    *   - Changes any datatype
+   *   - Adds a new column invariant or changes an existing column invariant for any column
    */
   def isWriteCompatible(existingSchema: StructType, newSchema: StructType): Boolean = {
 
@@ -134,7 +135,11 @@ private[standalone] object SchemaUtils {
             // if existing value is nullable, so should be the new value
             && (!existingField.isNullable || newField.isNullable)
             // and the type of the field must be compatible, too
-            && isDatatypeWriteCompatible(existingField.getDataType, newField.getDataType))
+            && isDatatypeWriteCompatible(existingField.getDataType, newField.getDataType)
+            // and no column invariant is added or altered
+            &&
+            Option(newField.getMetadata.get(InvariantUtils.INVARIANTS_FIELD)).forall(
+              _ == existingField.getMetadata.get(InvariantUtils.INVARIANTS_FIELD)))
         }
       }
     }

--- a/standalone/src/main/scala/io/delta/standalone/internal/util/SchemaUtils.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/util/SchemaUtils.scala
@@ -137,8 +137,7 @@ private[standalone] object SchemaUtils {
             // and the type of the field must be compatible, too
             && isDatatypeWriteCompatible(existingField.getDataType, newField.getDataType)
             // and no column invariant is added or altered
-            &&
-            Option(newField.getMetadata.get(InvariantUtils.INVARIANTS_FIELD)).forall(
+            && Option(newField.getMetadata.get(InvariantUtils.INVARIANTS_FIELD)).forall(
               _ == existingField.getMetadata.get(InvariantUtils.INVARIANTS_FIELD)))
         }
       }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
@@ -258,10 +258,10 @@ class DeltaConstraintsSuite extends FunSuite {
           "nested",
           new StructType().add(nestedStructField),
           true,
-          fieldMetadataWithInvariant("nested is null")
+          fieldMetadataWithInvariant("nested is not null")
         )),
       expectedConstraints = Seq(ConstraintImpl("EXPRESSION(nested.col1 < 3)", "nested.col1 < 3"),
-        ConstraintImpl("EXPRESSION(nested is null)", "nested is null"))
+        ConstraintImpl("EXPRESSION(nested is not null)", "nested is not null"))
     )
 
     // ignore constraints from Array<StructType> column

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
@@ -231,7 +231,7 @@ class DeltaConstraintsSuite extends FunSuite {
   // column invariants
   ///////////////////////////////////////////////////////////////////////////
 
-  def fieldMetadataWithInvariant(expr: String): FieldMetadata = {
+  private def fieldMetadataWithInvariant(expr: String): FieldMetadata = {
     FieldMetadata.builder()
       .putString(
         InvariantUtils.INVARIANTS_FIELD,

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
@@ -20,8 +20,8 @@ import scala.collection.JavaConverters._
 
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.FunSuite
-import io.delta.standalone.{Constraint, Operation}
 
+import io.delta.standalone.{Constraint, Operation}
 import io.delta.standalone.actions.Metadata
 import io.delta.standalone.types.{ArrayType, FieldMetadata, IntegerType, MapType, StringType, StructField, StructType}
 
@@ -258,7 +258,8 @@ class DeltaConstraintsSuite extends FunSuite {
     )
 
     // two top-level columns with column invariant
-    val structField2 = new StructField("col2", new IntegerType(), true, fieldMetadataWithInvariant("col2 < 3"))
+    val structField2 = new StructField("col2", new IntegerType(), true,
+      fieldMetadataWithInvariant("col2 < 3"))
     testGetConstraints(
       schema = new StructType(Array(structField1, structField2)),
       expectedConstraints = Seq(new Constraint("EXPRESSION(col1 < 3)", "col1 < 3"),

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
@@ -113,10 +113,6 @@ class DeltaConstraintsSuite extends FunSuite {
     )
   }
 
-  ///////////////////////////////////////////////////////////////////////////
-  // CHECK constraints
-  ///////////////////////////////////////////////////////////////////////////
-
   test("addCheckConstraint") {
     // add a constraint
     var metadata = Metadata.builder().build().withCheckConstraint("name", "expression")

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaConstraintsSuite.scala
@@ -39,50 +39,28 @@ class DeltaConstraintsSuite extends FunSuite {
     assert(expectedConstraints.toSet == metadata.getConstraints.asScala.toSet)
   }
 
-<<<<<<< HEAD
-  test("getConstraints") {
-=======
-  private def getCheckConstraintKey(name: String): String = {
-    Constraint.CHECK_CONSTRAINT_KEY_PREFIX + name
-  }
-
   ///////////////////////////////////////////////////////////////////////////
   // CHECK constraints
   ///////////////////////////////////////////////////////////////////////////
 
   test("getConstraints with check constraints") {
->>>>>>> b9581ea1 (updateds)
     // no constraints
     assert(Metadata.builder().build().getConstraints.isEmpty)
 
     // retrieve one check constraints
     testGetConstraints(
-<<<<<<< HEAD
-      Map(ConstraintImpl.getCheckConstraintKey("constraint1") -> "expression1"),
-      Seq(ConstraintImpl("constraint1", "expression1"))
-=======
-      configuration = Map(getCheckConstraintKey("constraint1") -> "expression1"),
-      expectedConstraints = Seq(new Constraint("constraint1", "expression1"))
->>>>>>> b9581ea1 (updateds)
+      configuration = Map(ConstraintImpl.getCheckConstraintKey("constraint1") -> "expression1"),
+      expectedConstraints = Seq(ConstraintImpl("constraint1", "expression1"))
     )
 
     // retrieve two check constraints
     testGetConstraints(
-<<<<<<< HEAD
-      Map(
+      configuration = Map(
         ConstraintImpl.getCheckConstraintKey("constraint1") -> "expression1",
         ConstraintImpl.getCheckConstraintKey("constraint2") -> "expression2"
       ),
-      Seq(ConstraintImpl("constraint1", "expression1"),
+      expectedConstraints = Seq(ConstraintImpl("constraint1", "expression1"),
         ConstraintImpl("constraint2", "expression2"))
-=======
-      configuration = Map(
-        getCheckConstraintKey("constraint1") -> "expression1",
-        getCheckConstraintKey("constraint2") -> "expression2"
-      ),
-      expectedConstraints = Seq(new Constraint("constraint1", "expression1"),
-        new Constraint("constraint2", "expression2"))
->>>>>>> b9581ea1 (updateds)
     )
 
     // check constraint key format
@@ -101,15 +79,9 @@ class DeltaConstraintsSuite extends FunSuite {
         "DELTA.CONSTRAINTS.constraint4" -> "expression4",
         "deltaxconstraintsxname" -> "expression5"
       ),
-<<<<<<< HEAD
-      Seq(ConstraintImpl("constraints", "EXPRESSION"),
+      expectedConstraints = Seq(ConstraintImpl("constraints", "EXPRESSION"),
         ConstraintImpl("delta.constraints", "expression0"),
         ConstraintImpl(ConstraintImpl.CHECK_CONSTRAINT_KEY_PREFIX, "expression1"))
-=======
-      expectedConstraints = Seq(new Constraint("constraints", "EXPRESSION"),
-        new Constraint("delta.constraints", "expression0"),
-        new Constraint(Constraint.CHECK_CONSTRAINT_KEY_PREFIX, "expression1"))
->>>>>>> b9581ea1 (updateds)
     )
   }
 
@@ -254,7 +226,7 @@ class DeltaConstraintsSuite extends FunSuite {
       fieldMetadataWithInvariant("col1 < 3"))
     testGetConstraints(
       schema = new StructType().add(structField1),
-      expectedConstraints = Seq(new Constraint("EXPRESSION(col1 < 3)", "col1 < 3"))
+      expectedConstraints = Seq(ConstraintImpl("EXPRESSION(col1 < 3)", "col1 < 3"))
     )
 
     // two top-level columns with column invariant
@@ -262,8 +234,8 @@ class DeltaConstraintsSuite extends FunSuite {
       fieldMetadataWithInvariant("col2 < 3"))
     testGetConstraints(
       schema = new StructType(Array(structField1, structField2)),
-      expectedConstraints = Seq(new Constraint("EXPRESSION(col1 < 3)", "col1 < 3"),
-        new Constraint("EXPRESSION(col2 < 3)", "col2 < 3"))
+      expectedConstraints = Seq(ConstraintImpl("EXPRESSION(col1 < 3)", "col1 < 3"),
+        ConstraintImpl("EXPRESSION(col2 < 3)", "col2 < 3"))
     )
 
     // nested column with a column invariant
@@ -275,7 +247,7 @@ class DeltaConstraintsSuite extends FunSuite {
           "nested",
           new StructType().add(nestedStructField)
         )),
-      expectedConstraints = Seq(new Constraint("EXPRESSION(nested.col1 < 3)", "nested.col1 < 3"))
+      expectedConstraints = Seq(ConstraintImpl("EXPRESSION(nested.col1 < 3)", "nested.col1 < 3"))
     )
 
     // nested column + top-level column with column invariant
@@ -287,8 +259,8 @@ class DeltaConstraintsSuite extends FunSuite {
           true,
           fieldMetadataWithInvariant("nested is null")
         )),
-      expectedConstraints = Seq(new Constraint("EXPRESSION(nested.col1 < 3)", "nested.col1 < 3"),
-        new Constraint("EXPRESSION(nested is null)", "nested is null"))
+      expectedConstraints = Seq(ConstraintImpl("EXPRESSION(nested.col1 < 3)", "nested.col1 < 3"),
+        ConstraintImpl("EXPRESSION(nested is null)", "nested is null"))
     )
 
     // ignore constraints from Array<StructType> column
@@ -368,7 +340,7 @@ class DeltaConstraintsSuite extends FunSuite {
         "test-engine-info"
       )
       assert(log.startTransaction().metadata().getConstraints.asScala ==
-        Seq(new Constraint("EXPRESSION(col1 > 3)", "col1 > 3")))
+        Seq(ConstraintImpl("EXPRESSION(col1 > 3)", "col1 > 3")))
     }
   }
 }


### PR DESCRIPTION
Changes in this PR:
- Adds column invariants to `Metadata::getConstraints()`
   - Adds InvariantUtils and adds to SchemaUtils which is 95% copied from Invariants - [here](https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/constraints/Invariants.scala) and SchemaUtils - [here](https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala#L55)
- Adds tests to `DeltaConstraintsSuite`

*Since column invariants are deprecated we don't provide a public API to set them.