### PR TITLE
[ColumnMapping] Add utility methods to `SchemaUtils`

### DIFF
--- a/standalone/src/test/scala/io/delta/standalone/internal/SchemaUtilsSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/SchemaUtilsSuite.scala
@@ -400,7 +400,7 @@ class SchemaUtilsSuite extends FunSuite {
   ////////////////////////////
   // findNestedFieldIgnoreCase
   ////////////////////////////
-  test("complex schema access") {
+  test("search nested columns in schema") {
     val st = new StringType()
     val it = new IntegerType()
     def m(a: DataType, b: DataType): MapType = new MapType(a, b, true)
@@ -481,5 +481,20 @@ class SchemaUtilsSuite extends FunSuite {
       val f = find(path)
       assert(f.isEmpty, s"$key should be empty")
     }
+  }
+
+  ////////////////////////////
+  // prettyFieldName
+  ////////////////////////////
+  test("pretty column name") {
+    val tests = Map(
+      Seq("a") -> "a",
+      Seq("a", "b") -> "a.b",
+      Seq("a", "b", "c") -> "a.b.c",
+      Seq("a.b", "c.d", "e") -> "`a.b`.`c.d`.e",
+      Seq("a.b") -> "`a.b`"
+    )
+
+    tests.foreach(test => assert(prettyFieldName(test._1) === test._2));
   }
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/SchemaUtilsSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/SchemaUtilsSuite.scala
@@ -396,4 +396,90 @@ class SchemaUtilsSuite extends FunSuite {
       .add("map", new MapType(
         new IntegerType(),
         new ArrayType(new StringType(), containsNull), true))) // valueContainsNull
+
+  ////////////////////////////
+  // findNestedFieldIgnoreCase
+  ////////////////////////////
+  test("complex schema access") {
+    val st = new StringType()
+    val it = new IntegerType()
+    def m(a: DataType, b: DataType): MapType = new MapType(a, b, true)
+    def a(el: DataType): ArrayType = new ArrayType(el, true)
+    def struct(el: DataType): StructType = new StructType().add("f1", el)
+
+    val schema = new StructType()
+      .add("a", it)
+      .add("b", struct(st))
+      .add("c", struct(struct(struct(st))))
+      .add("d", a(it))
+      .add("e", a(a(it)))
+      .add("f", a(a(struct(st))))
+      .add("g", m(m(st, it), m(st, it)))
+      .add("h", m(a(st), a(it)))
+      .add("i", m(a(struct(st)), a(struct(st))))
+      .add("j", m(m(struct(st), struct(it)), m(struct(st), struct(it))))
+      .add("k", m(struct(a(a(struct(a(struct(st)))))),
+                m(m(struct(st), struct(it)), m(struct(st), struct(it)))))
+
+    def find(names: Seq[String]): Option[StructField] =
+      findNestedFieldIgnoreCase(schema, names)
+
+    val checks = Map(
+      "a" -> it,
+      "b" -> struct(st),
+      "b.f1" -> st,
+      "c.f1.f1.f1" -> st,
+      "d.element" -> it,
+      "e.element.element" -> it,
+      "f.element.element.f1" -> st,
+      "g.key.key" -> st,
+      "g.key.value" -> it,
+      "g.value.key" -> st,
+      "g.value.value" -> it,
+      "h.key.element" -> st,
+      "h.value.element" -> it,
+      "i.key.element.f1" -> st,
+      "i.value.element.f1" -> st,
+      "j.key.key.f1" -> st,
+      "j.key.value.f1" -> it,
+      "j.value.key.f1" -> st,
+      "j.value.value.f1" -> it,
+      "k.key.f1.element.element.f1.element.f1" -> st,
+      "k.value.key.key.f1" -> st,
+      "k.value.key.value.f1" -> it,
+      "k.value.value.key.f1" -> st,
+      "k.value.value.value.f1" -> it
+    )
+
+    checks.foreach { pair =>
+      val (key, t) = pair
+      val path = key.split('.')
+      val f = find(path)
+      assert(f.isDefined, s"cannot find $key")
+      assert(f.get.getName == path.last && f.get.getDataType == t)
+    }
+
+    val negativeChecks = Seq(
+      "x",
+      "b.f2",
+      "c.f1.f2",
+      "c.f1.f1.f2",
+      "d.f1",
+      "d.element.f1",
+      "e.element.element.f1",
+      "f.element.key.f1",
+      "g.key.element",
+      "g.key.keyy",
+      "g.key.valuee",
+      "h.key.element.f1",
+      "k.key.f1.element.element.f2.element.f1",
+      "k.value.value.f1"
+    )
+
+    negativeChecks.foreach { key =>
+      val path = key.split('.')
+      val f = find(path)
+      assert(f.isEmpty, s"$key should be empty")
+    }
+  }
 }


### PR DESCRIPTION
(This is first PR for column mapping support in Standalone. End-2-end prototype is at #453)

Add/Update following utility methods in `SchemaUtils`
* Make the `prettyFieldName` a public method. This will be used in column mapping metadata population (see PR #453 for end-2-end implementation).
* Add method to search for a (nested) field in a given struct.