### PR TITLE
[ColumnMapping] Column mapping metadata verification and physical schema

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/exceptions/ColumnMappingException.java
+++ b/standalone/src/main/java/io/delta/standalone/exceptions/ColumnMappingException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (2020-present) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.standalone.exceptions;
+
+/** Errors thrown around column mapping. */
+public class ColumnMappingException extends Exception {
+    public ColumnMappingException(String msg) {
+        super(msg);
+    }
+}

--- a/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
+++ b/standalone/src/main/java/io/delta/standalone/types/FieldMetadata.java
@@ -189,6 +189,11 @@ public final class FieldMetadata {
             return this;
         }
 
+        public Builder remove(String key) {
+            metadata.remove(key);
+            return this;
+        }
+
         /**
          * @return a new {@link FieldMetadata} with the mappings added to the builder
          */

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaColumnMapping.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaColumnMapping.scala
@@ -125,7 +125,10 @@ trait DeltaColumnMappingBase extends Logging {
     }
   }
 
-  /** Check the ids and physical names assigned to the columns are unique. */
+  /**
+   * Verify the ids and physical names assigned to the columns are unique and are valid.
+   * If not throw errors.
+   */
   def checkColumnIdAndPhysicalNameAssignments(
       schema: StructType,
       mode: DeltaColumnMappingMode): Unit = {

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaColumnMapping.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaColumnMapping.scala
@@ -18,6 +18,8 @@ package io.delta.standalone.internal
 
 import java.util.{Locale, UUID}
 
+import scala.collection.mutable
+
 import io.delta.standalone.types.{FieldMetadata, StructField, StructType}
 
 import io.delta.standalone.internal.actions.{Metadata, Protocol}
@@ -47,6 +49,25 @@ trait DeltaColumnMappingBase extends Logging {
   val COLUMN_MAPPING_PHYSICAL_NAME_KEY = COLUMN_MAPPING_METADATA_PREFIX + "physicalName"
 
   private val supportedModes: Set[DeltaColumnMappingMode] = Set(NoMapping, NameMapping)
+
+  /**
+   * This list of internal columns (and only this list) is allowed to have missing
+   * column mapping metadata such as field id and physical name because
+   * they might not be present in user's table schema.
+   *
+   * These fields, if materialized to parquet, will always be matched by their display name in the
+   * downstream parquet reader even under column mapping modes.
+   *
+   * For future developers who want to utilize additional internal columns without generating
+   * column mapping metadata, please add them here.
+   *
+   * This list is case-insensitive.
+   */
+  protected val DELTA_INTERNAL_COLUMNS: Set[String] = Seq(
+    "__is_cdc",
+    "_change_type",
+    "_commit_version",
+    "_commit_timestamp").map(_.toLowerCase(Locale.ROOT)).toSet
 
   /**
    * Update the metadata based on valid column mapping transition. If the column mapping
@@ -101,6 +122,96 @@ trait DeltaColumnMappingBase extends Logging {
         newMetadata
       case mode =>
         throw unsupportedColumnMappingMode(mode.name)
+    }
+  }
+
+  /** Check the ids and physical names assigned to the columns are unique. */
+  def checkColumnIdAndPhysicalNameAssignments(
+      schema: StructType,
+      mode: DeltaColumnMappingMode): Unit = {
+    // physical name/column id -> full field path
+    val columnIds = mutable.Set[Int]()
+    val physicalNames = mutable.Set[String]()
+
+    // use id mapping to keep all column mapping metadata
+    // this method checks for missing physical name & column id already
+    val physicalSchema = createPhysicalSchema(schema, schema, IdMapping, checkSupportedMode = false)
+
+    SchemaMergingUtils.transformColumns(physicalSchema) ((parentPhysicalPath, field, _) => {
+      // field.name is now physical name
+      // We also need to apply backticks to column paths with dots in them to prevent a possible
+      // false alarm in which a column `a.b` is duplicated with `a`.`b`
+      val curFullPhysicalPath = SchemaUtils.prettyFieldName(parentPhysicalPath :+ field.getName)
+      val columnId = getColumnId(field)
+      if (columnIds.contains(columnId)) {
+        throw DeltaErrors.duplicatedColumnId(mode, columnId, schema)
+      }
+      columnIds.add(columnId)
+
+      // We should check duplication by full physical name path, because nested fields
+      // such as `a.b.c` shouldn't conflict with `x.y.c` due to same column name.
+      if (physicalNames.contains(curFullPhysicalPath)) {
+        throw DeltaErrors.duplicatedPhysicalName(mode, curFullPhysicalPath, schema)
+      }
+      physicalNames.add(curFullPhysicalPath)
+
+      field
+    })
+  }
+
+  /**
+   * Create a physical schema for the given schema using the Delta table schema as a reference.
+   * Physical schema is used when reading data from or writing data into parquet files.
+   *
+   * @param schema the given logical schema (potentially without any metadata)
+   * @param referenceSchema the schema from the delta log, which has all the metadata
+   * @param columnMappingMode column mapping mode of the delta table, which determines which
+   *                          metadata to fill in
+   * @param checkSupportedMode whether we should check of the column mapping mode is supported
+   */
+  def createPhysicalSchema(
+      schema: StructType,
+      referenceSchema: StructType,
+      columnMappingMode: DeltaColumnMappingMode,
+      checkSupportedMode: Boolean = true): StructType = {
+    if (columnMappingMode == NoMapping) {
+      return schema
+    }
+
+    // createPhysicalSchema is the narrow-waist for both read/write code path
+    // so we could check for mode support here
+    if (checkSupportedMode && !supportedModes.contains(columnMappingMode)) {
+      throw DeltaErrors.unsupportedColumnMappingMode(columnMappingMode.name)
+    }
+
+    SchemaMergingUtils.transformColumns(schema) { (path, field, _) =>
+      val fullName = path :+ field.getName
+      val inSchema = SchemaUtils
+        .findNestedFieldIgnoreCase(referenceSchema, fullName)
+      inSchema.map { refField =>
+        val physicalMetadata = getColumnMappingMetadata(refField, columnMappingMode)
+        field.withNewName(getPhysicalName(refField))
+          .withNewMetadata(physicalMetadata)
+      }.getOrElse {
+        if (isInternalField(field)) {
+          field
+        } else {
+          throw DeltaErrors.columnNotFound(fullName, referenceSchema)
+        }
+      }
+    }
+  }
+
+  def dropColumnMappingMetadata(schema: StructType): StructType = {
+    SchemaMergingUtils.transformColumns(schema) { (_, field, _) =>
+      field.withNewMetadata(
+        FieldMetadata.builder()
+          .withMetadata(field.getMetadata)
+          .remove(COLUMN_MAPPING_METADATA_ID_KEY)
+          .remove(COLUMN_MAPPING_PHYSICAL_NAME_KEY)
+          .remove(PARQUET_FIELD_ID_METADATA_KEY)
+          .build()
+        )
     }
   }
 
@@ -160,6 +271,57 @@ trait DeltaColumnMappingBase extends Logging {
   }
 
   /**
+   * Gets the required column metadata for each column based on the column mapping mode.
+   */
+  private def getColumnMappingMetadata(
+      field: StructField, mode: DeltaColumnMappingMode): FieldMetadata = {
+    mode match {
+      case NoMapping =>
+        // drop all column mapping related fields
+        FieldMetadata.builder()
+            .withMetadata(field.getMetadata)
+            .remove(COLUMN_MAPPING_METADATA_ID_KEY)
+            .remove(PARQUET_FIELD_ID_METADATA_KEY)
+            .remove(COLUMN_MAPPING_PHYSICAL_NAME_KEY)
+            .build()
+
+      case IdMapping =>
+        if (!hasColumnId(field)) {
+          throw DeltaErrors.missingColumnId(IdMapping, field.getName)
+        }
+        if (!hasPhysicalName(field)) {
+          throw DeltaErrors.missingPhysicalName(IdMapping, field.getName)
+        }
+        FieldMetadata.builder()
+            .withMetadata(field.getMetadata)
+            .putLong(PARQUET_FIELD_ID_METADATA_KEY, getColumnId(field))
+            .build()
+
+      case NameMapping =>
+        if (!hasPhysicalName(field)) {
+          throw DeltaErrors.missingPhysicalName(NameMapping, field.getName)
+        }
+        FieldMetadata.builder()
+            .withMetadata(field.getMetadata)
+            .remove(COLUMN_MAPPING_METADATA_ID_KEY)
+            .remove(PARQUET_FIELD_ID_METADATA_KEY)
+            .build()
+
+      case mode =>
+        throw DeltaErrors.unsupportedColumnMappingMode(mode.name)
+    }
+  }
+
+  /** Get the physical name of the column. If no physical name defined, return the logical name */
+  def getPhysicalName(field: StructField): String = {
+    if (field.getMetadata.contains(COLUMN_MAPPING_PHYSICAL_NAME_KEY)) {
+      field.getMetadata.get(COLUMN_MAPPING_PHYSICAL_NAME_KEY).toString
+    } else {
+      field.getName
+    }
+  }
+
+  /**
    * The only allowed mode change is from NoMapping to NameMapping. Other changes
    * would require re-writing Parquet files and are not supported right now.
    */
@@ -192,6 +354,9 @@ trait DeltaColumnMappingBase extends Logging {
 
   private def hasPhysicalName(field: StructField): Boolean =
     field.getMetadata().contains(COLUMN_MAPPING_PHYSICAL_NAME_KEY)
+
+  def isInternalField(field: StructField): Boolean = DELTA_INTERNAL_COLUMNS
+      .contains(field.getName.toLowerCase(Locale.ROOT))
 
   private def generatePhysicalName: String = "col-" + UUID.randomUUID()
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaColumnMappingSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaColumnMappingSuite.scala
@@ -250,9 +250,9 @@ class DeltaColumnMappingSuite extends FunSuite {
       assert(field.getMetadata.contains(COLUMN_MAPPING_METADATA_ID_KEY))
       assert(field.getMetadata.contains(PARQUET_FIELD_ID_METADATA_KEY))
 
-      // Make sure the parquet filed id is same as the column mapping id
+      // Make sure the parquet field id is same as the column mapping id
       assert(
-        field.getMetadata.get(PARQUET_FIELD_ID_METADATA_KEY) ===
+        field.getMetadata.get(COLUMN_MAPPING_METADATA_ID_KEY) ===
         field.getMetadata.get(PARQUET_FIELD_ID_METADATA_KEY))
 
       field

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaColumnMappingSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaColumnMappingSuite.scala
@@ -19,13 +19,14 @@ import scala.collection.mutable
 
 import org.scalatest.FunSuite
 
-import io.delta.standalone.exceptions.ColumnMappingUnsupportedException
+import io.delta.standalone.exceptions.{ColumnMappingException, ColumnMappingUnsupportedException}
 import io.delta.standalone.types.{ArrayType, DataType, FieldMetadata, FloatType, IntegerType, LongType, MapType, StringType, StructField, StructType}
 import io.delta.standalone.types.FieldMetadata.builder
 
 import io.delta.standalone.internal.DeltaColumnMapping._
 import io.delta.standalone.internal.actions.{Metadata, Protocol}
 import io.delta.standalone.internal.util.{SchemaMergingUtils, SchemaUtils}
+import io.delta.standalone.internal.util.SchemaMergingUtils.transformColumns
 
 
 class DeltaColumnMappingSuite extends FunSuite {
@@ -167,6 +168,141 @@ class DeltaColumnMappingSuite extends FunSuite {
     assert(updatedMetadata.schema.get("b").getMetadata.getEntries.size() == 3)
   }
 
+  test("verify column mapping metadata") {
+    val updatedMetadata = verifyAndUpdateMetadataChange(
+      oldProtocol = protocol(1, 2),
+      oldMetadata = metadata(complexSchema, Map.empty),
+      newMetadata = metadata(complexSchema,
+                             withProtocol(withMode(Map.empty, "name"), readerV = 2, writerV = 5)),
+      isCreatingNewTable = false)
+
+    checkColumnIdAndPhysicalNameAssignments(updatedMetadata.schema, NameMapping)
+  }
+
+  test("verify column mapping metadata - invalid metadata") {
+    {
+      // Update one of the field to has duplicate id
+      val schemaDuplicateId =
+        transformColumns(schemaWithCMMetadata)((_, field, _) => {
+          if (field.getName.equals("si")) {
+            field.withNewMetadata(
+              FieldMetadata.builder().withMetadata(field.getMetadata)
+                .putLong(COLUMN_MAPPING_METADATA_ID_KEY, 3L).build())
+          } else {
+            field
+          }
+        })
+
+      Seq(IdMapping, NameMapping).foreach(mode => {
+        val ex = intercept[ColumnMappingException] {
+          checkColumnIdAndPhysicalNameAssignments(schemaDuplicateId, mode)
+        }
+        assert(ex.getMessage contains
+          s"Found duplicated column id `3` in column mapping mode `${mode.name}`")
+      })
+    }
+
+    {
+      // Update one of the fields to have a duplicate physical name
+      val schemaDuplicateName =
+        transformColumns(schemaWithCMMetadata)((_, field, _) => {
+          if (field.getName.equals("si")) {
+            field.withNewMetadata(
+              FieldMetadata.builder().withMetadata(field.getMetadata)
+                .putString(COLUMN_MAPPING_PHYSICAL_NAME_KEY, "sf").build())
+          } else {
+            field
+          }
+        })
+
+      Seq(IdMapping, NameMapping).foreach(mode => {
+        val ex = intercept[ColumnMappingException] {
+          checkColumnIdAndPhysicalNameAssignments(schemaDuplicateName, mode)
+        }
+        assert(ex.getMessage contains
+          s"Found duplicated physical name `s.sf` in column mapping mode `${mode.name}`")
+      })
+    }
+  }
+
+  test("create physical schema") {
+    // Reference schema is the schema without any metadata
+    val referenceSchema = schemaWithCMMetadata
+    val logicalSchema = dropColumnMappingMetadata(schemaWithCMMetadata)
+
+    val physicalSchemaName = createPhysicalSchema(
+      logicalSchema, referenceSchema, NameMapping, checkSupportedMode = false)
+
+    // Make sure every field has physical name and no id. Only the physical name is
+    // used to read from or write into parquet files
+    transformColumns(physicalSchemaName)((_, field, _) => {
+      assert(field.getMetadata.contains(COLUMN_MAPPING_PHYSICAL_NAME_KEY))
+      assert(!field.getMetadata.contains(COLUMN_MAPPING_METADATA_ID_KEY))
+      field
+    })
+
+    val physicalSchemaId = createPhysicalSchema(
+      logicalSchema, referenceSchema, IdMapping, checkSupportedMode = false)
+
+    // Make sure every field has the parquet field id. This id is used to read from
+    // or write data into the parquet files.
+    transformColumns(physicalSchemaId)((path, field, _) => {
+      assert(field.getMetadata.contains(COLUMN_MAPPING_METADATA_ID_KEY))
+      assert(field.getMetadata.contains(PARQUET_FIELD_ID_METADATA_KEY))
+
+      // Make sure the parquet filed id is same as the column mapping id
+      assert(
+        field.getMetadata.get(PARQUET_FIELD_ID_METADATA_KEY) ===
+        field.getMetadata.get(PARQUET_FIELD_ID_METADATA_KEY))
+
+      field
+    })
+  }
+
+  test("create physical schema - negative cases") {
+    val referenceSchema = schemaWithCMMetadata
+    val logicalSchema = dropColumnMappingMetadata(schemaWithCMMetadata)
+
+    {
+      // Remove the id for one of the columns
+      val schemaMissingId = SchemaMergingUtils.transformColumns(referenceSchema)((_, field, _) => {
+        if (field.getName.equals("si")) {
+          field.withNewMetadata(
+            FieldMetadata.builder().withMetadata(field.getMetadata)
+                .remove(COLUMN_MAPPING_METADATA_ID_KEY).build())
+        } else {
+          field
+        }
+      })
+
+      val ex = intercept[ColumnMappingException] {
+        createPhysicalSchema(logicalSchema, schemaMissingId, IdMapping, checkSupportedMode = false)
+      }
+      assert(ex.getMessage contains
+        s"Missing column ID in column mapping mode `id` in the field: si")
+    }
+    {
+      // Remove the physical name for one of the columns
+      val schemaMissingId = SchemaMergingUtils.transformColumns(referenceSchema)((_, field, _) => {
+        if (field.getName.equals("si")) {
+          field.withNewMetadata(
+            FieldMetadata.builder().withMetadata(field.getMetadata)
+                .remove(COLUMN_MAPPING_PHYSICAL_NAME_KEY).build())
+        } else {
+          field
+        }
+      })
+
+      Seq(IdMapping, NameMapping).foreach(mode => {
+        val ex = intercept[ColumnMappingException] {
+          createPhysicalSchema(logicalSchema, schemaMissingId, mode, checkSupportedMode = false)
+        }
+        assert(ex.getMessage contains
+          s"Missing physical name in column mapping mode `${mode.name}` in the field: si")
+      })
+    }
+  }
+
   private def struct(fields: StructField *): StructType = new StructType(fields.toArray)
 
   private def map(keyType: DataType, valueType: DataType): MapType =
@@ -200,17 +336,12 @@ class DeltaColumnMappingSuite extends FunSuite {
     newConf.toMap
   }
 
-  private def assertColumnMappingMetadata(
-      actualMetadata: FieldMetadata, expId: Long, expPhyName: String): Unit = {
-    assert(actualMetadata.get(COLUMN_MAPPING_METADATA_ID_KEY) == expId)
-    val actualPhyName = actualMetadata.get(COLUMN_MAPPING_PHYSICAL_NAME_KEY).toString
-    // For new tables the physical column name is a UUID. For existing tables, we
-    // try to keep the physical column name same as the one in the schema
-    if (expPhyName == "UUID") {
-      assertUUIDColumnName(actualPhyName)
-    } else {
-      assert(actualMetadata.get(COLUMN_MAPPING_PHYSICAL_NAME_KEY) == expPhyName)
-    }
+  private def withCMMetdata(field: StructField, id: Int, phyName: String): StructField = {
+    field.withNewMetadata(
+      FieldMetadata.builder().withMetadata(field.getMetadata)
+        .putLong(COLUMN_MAPPING_METADATA_ID_KEY, id)
+        .putString(COLUMN_MAPPING_PHYSICAL_NAME_KEY, phyName)
+        .build())
   }
 
   private def assertUUIDColumnName(physicalName: String): Unit =
@@ -221,7 +352,7 @@ class DeltaColumnMappingSuite extends FunSuite {
       schema: StructType): (Map[Seq[String], Long], Map[Seq[String], String]) = {
     val actIds = mutable.Map[Seq[String], Long]()
     val actPhyNames = mutable.Map[Seq[String], String]()
-    SchemaMergingUtils.transformColumns(schema)((path, field, _) => {
+    transformColumns(schema)((path, field, _) => {
       val colPath = path :+ field.getName
       actIds.put(colPath, field.getMetadata.get(COLUMN_MAPPING_METADATA_ID_KEY).asInstanceOf[Long])
       actPhyNames.put(colPath, field.getMetadata.get(COLUMN_MAPPING_PHYSICAL_NAME_KEY).toString)
@@ -285,4 +416,16 @@ class DeltaColumnMappingSuite extends FunSuite {
     Seq("s", "ss") -> "ss",
     Seq("s", "ss", "ssstr") -> "ssstr"
   )
+
+  private val schemaWithCMMetadata = struct(
+    withCMMetdata(field("a", new IntegerType), id = 1, phyName = "a"),
+    withCMMetdata(field("b", new StringType), id = 2, phyName = "b"),
+    withCMMetdata(
+      field("s",
+            struct(
+              withCMMetdata(field("si", new IntegerType), id = 4, phyName = "si"),
+              withCMMetdata(field("sf", new FloatType), id = 5, phyName = "sf"))),
+      id = 3,
+      phyName = "s")
+    )
 }


### PR DESCRIPTION
(This is fourth PR for column mapping support in Standalone. End-2-end prototype is at #453)

This PR adds:
 * `checkColumnIdAndPhysicalNameAssignments`: It verifies given a schema, each field has the required column mapping metadata given column mapping mode and the column mapping metadata is unique to each field.
 * `createPhysicalSchema`: Given a schema with column mapping metadata, returns a schema that can be used to read data from or write data into the Parquet files depending upon the column mapping mode
   * NAME mode: returned physical contains only the physical name in the field metadata. This physical name is used to reference a field in the Parquet file
   * ID mode: returned physical schema contains `parquet.field.id` which is matched with field id in column metadata in Parquet file.