### PR TITLE
[ColumnMapping] Add support for setting column mapping mode through txn

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -19,6 +19,7 @@ package io.delta.standalone.actions;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,9 +28,11 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import io.delta.standalone.Constraint;
+import io.delta.standalone.exceptions.ColumnMappingUnsupportedException;
 import io.delta.standalone.types.StructType;
 
 import io.delta.standalone.internal.ConstraintImpl;
+import io.delta.standalone.internal.DeltaConfigs;
 import io.delta.standalone.internal.exception.DeltaErrors;
 
 /**
@@ -187,6 +190,25 @@ public final class Metadata implements Action {
         Map<String, String> newConfiguration = new HashMap(configuration);
         newConfiguration.remove(fullKey);
         return copyBuilder().configuration(newConfiguration).build();
+    }
+
+    /**
+     * Returns a copy of this {@link Metadata} instance with the given column mapping mode.
+     * Any validation of the given column mapping mode happens when this new metadata is
+     * applied on the table.
+     *
+     * @param mode Column mapping mode. One of the ("none", "id", "none")
+     * @return A copy of this metadata object with the given column mapping mode.
+     * @throws ColumnMappingUnsupportedException if the given mode is not supported.
+     */
+    public Metadata withColumnMappingMode(String mode) throws ColumnMappingUnsupportedException {
+        Map<String, String> newConfiguration = new HashMap(configuration);
+        mode = mode.toLowerCase(Locale.ROOT);
+        if ("name".equals(mode) || "id".equals(mode) || "none".equals(mode)) {
+            newConfiguration.put(DeltaConfigs.COLUMN_MAPPING_MODE().key(), mode);
+            return copyBuilder().configuration(newConfiguration).build();
+        }
+        throw DeltaErrors.unsupportedColumnMappingMode(mode);
     }
 
     @Override

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaColumnMapping.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaColumnMapping.scala
@@ -29,7 +29,6 @@ import io.delta.standalone.internal.logging.Logging
 import io.delta.standalone.internal.util.{CaseInsensitiveMap, SchemaMergingUtils, SchemaUtils}
 
 trait DeltaColumnMappingBase extends Logging {
-
   // Minimum writer and reader version required for column mapping support
   val MIN_WRITER_VERSION = 5
   val MIN_READER_VERSION = 2
@@ -370,7 +369,7 @@ object DeltaColumnMapping extends DeltaColumnMappingBase
  * A trait for Delta column mapping modes.
  */
 sealed trait DeltaColumnMappingMode {
-  def name: String
+  val name: String
 }
 
 /**

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
@@ -125,6 +125,9 @@ private[internal] object Protocol {
     // check config
 
     // Column mapping
+    // The check is actually done as part of `OptimisticTransactionImpl.updateMetadata`
+    // when updating the metadata for column mapping mode. Added the check here for
+    // completeness of all protocol checks in this method.
     metadata.columnMappingMode match {
       case NameMapping | IdMapping =>
         if (protocol.minWriterVersion < DeltaColumnMapping.MIN_WRITER_VERSION ||

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize
 
 import io.delta.standalone.types.StructType
 
-import io.delta.standalone.internal.{ConstraintImpl, DeltaColumnMappingMode, DeltaConfigs}
+import io.delta.standalone.internal.{ConstraintImpl, DeltaColumnMapping, DeltaColumnMappingMode, DeltaConfigs, IdMapping, NameMapping}
 import io.delta.standalone.internal.exception.DeltaErrors
 import io.delta.standalone.internal.util.{DataTypeParser, JsonUtils}
 
@@ -125,7 +125,14 @@ private[internal] object Protocol {
     // check config
 
     // Column mapping
-    // check column mapping mode
+    metadata.columnMappingMode match {
+      case NameMapping | IdMapping =>
+        if (protocol.minWriterVersion < DeltaColumnMapping.MIN_WRITER_VERSION ||
+          protocol.minReaderVersion < DeltaColumnMapping.MIN_READER_VERSION) {
+          throw DeltaErrors.changeColumnMappingModeOnOldProtocol(protocol)
+        }
+      case _ =>
+    }
 
     // todo: Should we check for any unsupported features? i.e. identity columns
   }

--- a/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/exception/DeltaErrors.scala
@@ -320,7 +320,7 @@ private[internal] object DeltaErrors {
       s"The Delta table configuration $prop cannot be specified by the user")
   }
 
-  def unsupportedColumnMappingMode(mode: String): Throwable =
+  def unsupportedColumnMappingMode(mode: String): ColumnMappingUnsupportedException =
     new ColumnMappingUnsupportedException(s"The column mapping mode `$mode` is " +
       s"not supported for this Delta version. Please upgrade if you want to use this mode.")
 

--- a/standalone/src/test/scala/io/delta/standalone/internal/util/TestUtils.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/util/TestUtils.scala
@@ -26,6 +26,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.Matchers.intercept
 
+import io.delta.standalone.DeltaLog
 import io.delta.standalone.actions.{Action => ActionJ, AddFile => AddFileJ}
 
 import io.delta.standalone.internal.DeltaLogImpl
@@ -62,7 +63,7 @@ object TestUtils {
    * Get a DeltaLog instance with the connector's supported protocol set to Standalone's supported
    * protocol.
    */
-  def getDeltaLogWithMaxFeatureSupport(conf: Configuration, path: String) : DeltaLogImpl = {
+  def getDeltaLogWithMaxFeatureSupport(conf: Configuration, path: String) : DeltaLog = {
     DeltaLogImpl.forTable(conf, path,
       Action.maxSupportedReaderVersion, Action.maxSupportedWriterVersion)
   }


### PR DESCRIPTION
(This is fifth PR for column mapping support in Standalone. End-2-end prototype is at #453)

It integrates the APIs added as part of (#461, #460) in `OptimisticTransaction.updateMetadata` API. Using `OptimisticTransaction.updateMetadata`, clients can update the column mapping mode in a Delta table.