### PR TITLE
[ColumnMapping] Expose the physical schema through `StructType` and `StructField`

### DIFF
--- a/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
+++ b/standalone/src/main/java/io/delta/standalone/actions/Metadata.java
@@ -27,6 +27,9 @@ import javax.annotation.Nullable;
 
 import io.delta.standalone.types.StructType;
 
+import io.delta.standalone.internal.DeltaColumnMapping;
+import io.delta.standalone.internal.DeltaColumnMappingMode;
+
 /**
  * Updates the metadata of the table. The first version of a table must contain
  * a {@link Metadata} action. Subsequent {@link Metadata} actions completely
@@ -131,6 +134,17 @@ public final class Metadata implements Action {
     @Nullable
     public StructType getSchema() {
         return schema;
+    }
+
+    /**
+     * @return the physical schema used to read or write data in table data files such as Parquet.
+     */
+    public StructType getPhysicalSchema() {
+        return DeltaColumnMapping.createPhysicalSchema(
+                schema,
+                schema,
+                DeltaColumnMappingMode.apply(getConfiguration().get("delta.columnMapping.mode")),
+                false /* checkSupportedMode */);
     }
 
     @Override

--- a/standalone/src/main/java/io/delta/standalone/types/StructField.java
+++ b/standalone/src/main/java/io/delta/standalone/types/StructField.java
@@ -39,6 +39,9 @@
 package io.delta.standalone.types;
 
 import java.util.Objects;
+import java.util.Optional;
+
+import io.delta.standalone.internal.DeltaColumnMapping;
 
 /**
  * A field inside a {@link StructType}.
@@ -107,6 +110,26 @@ public final class StructField {
      */
     public FieldMetadata getMetadata() {
         return metadata;
+    }
+
+    /**
+     * @return if exists, the physical column name used to refer the column
+     *         in underlying table data files
+     */
+    public Optional<String> getPhysicalName() {
+        return Optional.ofNullable(
+                        metadata.get(DeltaColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY()))
+                .map(Object::toString);
+    }
+
+    /**
+     * @return if exists, the physical column id used to refer the column
+     *         in underlying table data files.
+     */
+    public Optional<String> getPhysicalId() {
+        return Optional.ofNullable(
+                        metadata.get(DeltaColumnMapping.COLUMN_MAPPING_METADATA_ID_KEY()))
+                .map(Object::toString);
     }
 
     /**

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaColumnMapping.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaColumnMapping.scala
@@ -48,7 +48,7 @@ trait DeltaColumnMappingBase extends Logging {
   // This could be different from the column name in schema.
   val COLUMN_MAPPING_PHYSICAL_NAME_KEY = COLUMN_MAPPING_METADATA_PREFIX + "physicalName"
 
-  private val supportedModes: Set[DeltaColumnMappingMode] = Set(NoMapping, NameMapping)
+  private val supportedModes: Set[DeltaColumnMappingMode] = Set(NoMapping, NameMapping, IdMapping)
 
   /**
    * This list of internal columns (and only this list) is allowed to have missing
@@ -325,13 +325,14 @@ trait DeltaColumnMappingBase extends Logging {
   }
 
   /**
-   * The only allowed mode change is from NoMapping to NameMapping. Other changes
+   * The only allowed mode change is from NoMapping to NameMapping or IdMapping. Other changes
    * would require re-writing Parquet files and are not supported right now.
    */
   private def allowMappingModeChange(
       oldMode: DeltaColumnMappingMode, newMode: DeltaColumnMappingMode): Boolean = {
     if (oldMode == newMode) true
-    else oldMode == NoMapping && newMode == NameMapping
+    else (oldMode == NoMapping && newMode == NameMapping) ||
+      (oldMode == NoMapping && newMode == IdMapping)
   }
 
   private def satisfyColumnMappingProtocol(protocol: Protocol): Boolean =

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize
 
 import io.delta.standalone.types.StructType
 
-import io.delta.standalone.internal.{DeltaColumnMappingMode, DeltaConfigs}
+import io.delta.standalone.internal.{DeltaColumnMapping, DeltaColumnMappingMode, DeltaConfigs, IdMapping, NameMapping}
 import io.delta.standalone.internal.exception.DeltaErrors
 import io.delta.standalone.internal.util.{DataTypeParser, JsonUtils}
 
@@ -106,7 +106,14 @@ private[internal] object Protocol {
     // check config
 
     // Column mapping
-    // check column mapping mode
+    metadata.columnMappingMode match {
+      case NameMapping | IdMapping =>
+        if (protocol.minWriterVersion < DeltaColumnMapping.MIN_WRITER_VERSION ||
+          protocol.minReaderVersion < DeltaColumnMapping.MIN_READER_VERSION) {
+          throw DeltaErrors.changeColumnMappingModeOnOldProtocol(protocol)
+        }
+      case _ =>
+    }
 
     // todo: Should we check for any unsupported features? i.e. identity columns
   }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaColumnMappingSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaColumnMappingSuite.scala
@@ -309,7 +309,7 @@ class DeltaColumnMappingSuite extends FunSuite {
 
   test("Upgrade to column mapping mode 'name' on the table") {
     withTempDir { dir =>
-      var log = DeltaLog.forTable(new Configuration(), dir.getCanonicalPath)
+      var log = getDeltaLogWithMaxFeatureSupport(new Configuration(), dir.getCanonicalPath)
       var txn = log.startTransaction()
       val addFile = AddFile("/absolute/path/to/file/test.parquet", Map(), 0, 0, true)
 
@@ -320,7 +320,7 @@ class DeltaColumnMappingSuite extends FunSuite {
       txn.updateMetadata(metadataJ(simpleSchema, withMode(Map.empty, "name")))
       txn.commit( addFile :: Nil, OP, "test")
 
-      log = DeltaLog.forTable(new Configuration(), dir.getCanonicalPath)
+      log = getDeltaLogWithMaxFeatureSupport(new Configuration(), dir.getCanonicalPath)
       txn = log.startTransaction()
 
       val oldMetadata = txn.metadata()
@@ -334,14 +334,14 @@ class DeltaColumnMappingSuite extends FunSuite {
       txn.updateMetadata(newMetadata)
       txn.commit(Seq.empty, OP, "test")
 
-      log = DeltaLog.forTable(new Configuration(), dir.getCanonicalPath)
+      log = getDeltaLogWithMaxFeatureSupport(new Configuration(), dir.getCanonicalPath)
       txn = log.startTransaction()
 
       val updatedSchema = txn.metadata().getSchema();
 
       val (actIds, actPhyNames) = extractIdsAndPhyNames(updatedSchema)
       assert(actIds === simpleSchemaExpIds)
-      assert(actPhyNames === simpleSchemaExpPhyNames)
+      actPhyNames.values.foreach(assertUUIDColumnName(_))
     }
   }
 

--- a/standalone/src/test/scala/io/delta/standalone/internal/util/TestUtils.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/util/TestUtils.scala
@@ -26,6 +26,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.Matchers.intercept
 
+import io.delta.standalone.DeltaLog
 import io.delta.standalone.actions.{Action => ActionJ, AddFile => AddFileJ}
 
 import io.delta.standalone.internal.DeltaLogImpl
@@ -62,7 +63,7 @@ object TestUtils {
    * Get a DeltaLog instance with the connector's supported protocol set to Standalone's supported
    * protocol.
    */
-  def getDeltaLogWithMaxFeatureSupport(conf: Configuration, path: String) : DeltaLogImpl = {
+  def getDeltaLogWithMaxFeatureSupport(conf: Configuration, path: String) : DeltaLog = {
     DeltaLogImpl.forTable(conf, path,
       Action.maxSupportedReaderVersion, Action.maxSupportedWriterVersion)
   }


### PR DESCRIPTION
(This is seventh PR for column mapping support in Standalone. End-2-end prototype is at #453)

(This PR is stacked on top of #464 and #465, look only at the last commit for this PR specific changes).

Expose the physical schema details such as physical name and field id through `StructType` and `StructField`.

Tests are pending.