### PR TITLE
[FlinkSQL_PR_2] - SQL Support for Delta Source connector.

### DIFF
--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaDynamicTableFactory.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaDynamicTableFactory.java
@@ -18,17 +18,14 @@
 package io.delta.flink.internal.table;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -41,19 +38,18 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.hadoop.conf.Configuration;
 
 /**
- * Creates a {@link DynamicTableSink} instance representing DeltaLake table.
+ * Creates a {@link DynamicTableSink} and {@link DynamicTableSource} instance representing DeltaLake
+ * table.
  *
  * <p>
  * This implementation automatically resolves all necessary object for creating instance of {@link
- * io.delta.flink.sink.DeltaSink} except Delta table's path that needs to be provided explicitly.
+ * io.delta.flink.sink.DeltaSink} and {@link io.delta.flink.source.DeltaSource} except Delta table's
+ * path that needs to be provided explicitly.
  */
 public class DeltaDynamicTableFactory implements DynamicTableSinkFactory,
     DynamicTableSourceFactory {
 
     public static final String IDENTIFIER = "delta";
-
-    public final org.apache.flink.configuration.Configuration emptyClusterConfig =
-        new org.apache.flink.configuration.Configuration();
 
     @Override
     public String factoryIdentifier() {
@@ -67,10 +63,12 @@ public class DeltaDynamicTableFactory implements DynamicTableSinkFactory,
             FactoryUtil.createTableFactoryHelper(this, context);
         helper.validate();
 
+
         ReadableConfig tableOptions = helper.getOptions();
         ResolvedSchema tableSchema = context.getCatalogTable().getResolvedSchema();
 
-        Configuration conf = resolveHadoopConf(tableOptions);
+        Configuration conf =
+            HadoopUtils.getHadoopConfiguration(GlobalConfiguration.loadConfiguration());
 
         RowType rowType = (RowType) tableSchema.toSinkRowDataType().getLogicalType();
 
@@ -94,25 +92,22 @@ public class DeltaDynamicTableFactory implements DynamicTableSinkFactory,
         helper.validate();
 
         ReadableConfig tableOptions = helper.getOptions();
-        ResolvedSchema tableSchema = context.getCatalogTable().getResolvedSchema();
-
-        Configuration hadoopConf = resolveHadoopConf(tableOptions);
-
-        RowType rowType = (RowType) tableSchema.toSourceRowDataType().getLogicalType();
+        Configuration hadoopConf =
+            HadoopUtils.getHadoopConfiguration(GlobalConfiguration.loadConfiguration());
+        List<String> columns = context.getCatalogTable().getResolvedSchema().getColumnNames();
 
         return new DeltaDynamicTableSource(
             hadoopConf,
             tableOptions,
-            rowType
+            columns
         );
     }
 
     @Override
     public Set<ConfigOption<?>> forwardOptions() {
-        return Stream.of(
-            DeltaTableConnectorOptions.TABLE_PATH,
-            DeltaTableConnectorOptions.HADOOP_CONF_DIR
-        ).collect(Collectors.toSet());
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(DeltaTableConnectorOptions.TABLE_PATH);
+        return options;
     }
 
     @Override
@@ -125,57 +120,12 @@ public class DeltaDynamicTableFactory implements DynamicTableSinkFactory,
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
         final Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(DeltaTableConnectorOptions.HADOOP_CONF_DIR);
         options.add(DeltaTableConnectorOptions.MERGE_SCHEMA);
 
         // TODO With Delta Catalog, this option will be injected only through query hints.
         //  The DDL validation will be done in Delta Catalog during "createTable" operation.
         options.add(DeltaFlinkJobSpecificOptions.MODE);
         return options;
-    }
-
-    /**
-     * Tries to resolve Hadoop conf from conf dir provided as table option or from environment
-     * variable HADOOP_HOME and HADOOP_CONF_DIR.
-     * <p>
-     * The configuration will be resolved in below order, where every next element will override
-     * configuration loaded from previous one.
-     * <ul>
-     *     <li>HADOOP_HOME environment variable</li>
-     *     <li>HADOOP_CONF_DIR environment variable</li>
-     *     <li>"hadoop-conf-dir" table property</li>
-     * </ul>
-     *
-     * @param tableOptions Flink Table's options resolved for given table
-     * @return {@link Configuration} object
-     */
-    private Configuration resolveHadoopConf(ReadableConfig tableOptions) {
-
-        Configuration userHadoopConf = null;
-        Optional<String> hadoopConfDirOptional =
-            tableOptions.getOptional(DeltaTableConnectorOptions.HADOOP_CONF_DIR);
-
-        if (hadoopConfDirOptional.isPresent()) {
-            userHadoopConf = loadHadoopConfFromFolder(hadoopConfDirOptional.get());
-            if (userHadoopConf == null) {
-                throw new RuntimeException(
-                    "Failed to resolve Hadoop userHadoopConf file from given path",
-                    new FileNotFoundException(
-                        "Couldn't resolve Hadoop userHadoopConf at given path: " +
-                            hadoopConfDirOptional.get()));
-            }
-        }
-
-        // We are using helper method HadoopUtils.getHadoopConfiguration to resolve
-        // cluster's Hadoop configuration. This method looks for Hadoop config in env variables and
-        // Flink cluster configuration. For this moment DynamicTableSinkFactory does not have
-        // access to Flink's configuration that is why we are passing "dummy" config as an argument.
-        Configuration hadoopConfiguration = HadoopUtils.getHadoopConfiguration(emptyClusterConfig);
-        if (userHadoopConf != null) {
-            hadoopConfiguration.addResource(userHadoopConf);
-        }
-
-        return hadoopConfiguration;
     }
 
     /**

--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaDynamicTableFactory.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaDynamicTableFactory.java
@@ -70,7 +70,7 @@ public class DeltaDynamicTableFactory implements DynamicTableSinkFactory,
         Configuration conf =
             HadoopUtils.getHadoopConfiguration(GlobalConfiguration.loadConfiguration());
 
-        RowType rowType = (RowType) tableSchema.toSinkRowDataType().getLogicalType();
+        RowType rowType = (RowType) tableSchema.toPhysicalRowDataType().getLogicalType();
 
         Boolean shouldTryUpdateSchema = tableOptions
             .getOptional(DeltaTableConnectorOptions.MERGE_SCHEMA)
@@ -94,7 +94,13 @@ public class DeltaDynamicTableFactory implements DynamicTableSinkFactory,
         ReadableConfig tableOptions = helper.getOptions();
         Configuration hadoopConf =
             HadoopUtils.getHadoopConfiguration(GlobalConfiguration.loadConfiguration());
-        List<String> columns = context.getCatalogTable().getResolvedSchema().getColumnNames();
+
+        List<String> columns = ((RowType) context
+            .getCatalogTable()
+            .getResolvedSchema()
+            .toPhysicalRowDataType()
+            .getLogicalType()
+        ).getFieldNames();
 
         return new DeltaDynamicTableSource(
             hadoopConf,

--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaDynamicTableSource.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaDynamicTableSource.java
@@ -1,7 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.delta.flink.internal.table;
 
 import java.util.List;
 
+import io.delta.flink.internal.table.DeltaFlinkJobSpecificOptions.TableMode;
 import io.delta.flink.source.DeltaSource;
 import io.delta.flink.source.internal.builder.DeltaSourceBuilderBase;
 import org.apache.flink.configuration.ReadableConfig;
@@ -10,36 +28,36 @@ import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.SourceProvider;
-import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
-import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
-import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.expressions.ResolvedExpression;
-import org.apache.flink.table.types.logical.RowType;
 import org.apache.hadoop.conf.Configuration;
 
-public class DeltaDynamicTableSource implements
-        ScanTableSource,
-        SupportsProjectionPushDown,
-        SupportsFilterPushDown,
-        SupportsLimitPushDown {
+/**
+ * Implementation of {@link ScanTableSource} interface for Table/SQL support for Delta Source
+ * connector.
+ */
+public class DeltaDynamicTableSource implements ScanTableSource {
 
     private final Configuration hadoopConf;
 
     private final ReadableConfig tableOptions;
 
-    private final RowType rowType;
+    private final List<String> columns;
 
-    private long limit;
-
+    /**
+     * Constructor for creating Source of Flink dynamic table to Delta table.
+     *
+     * @param hadoopConf   Hadoop's configuration.
+     * @param tableOptions Table options returned by Catalog and resolved query plan.
+     * @param columns      Table's columns to extract from Delta table.
+     */
     public DeltaDynamicTableSource(
             Configuration hadoopConf,
             ReadableConfig tableOptions,
-            RowType rowType) {
+            List<String> columns) {
 
         this.hadoopConf = hadoopConf;
         this.tableOptions = tableOptions;
-        this.rowType = rowType;
+        this.columns = columns;
     }
 
     @Override
@@ -50,27 +68,34 @@ public class DeltaDynamicTableSource implements
     @Override
     public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
 
-        String mode = tableOptions.get(DeltaFlinkJobSpecificOptions.MODE);
+        TableMode mode = tableOptions.get(DeltaFlinkJobSpecificOptions.MODE);
         String tablePath = tableOptions.get(DeltaTableConnectorOptions.TABLE_PATH);
 
         DeltaSourceBuilderBase<RowData, ?> sourceBuilder;
 
-        if (DeltaFlinkJobSpecificOptions.MODE.defaultValue().equalsIgnoreCase(mode)) {
-            sourceBuilder = DeltaSource.forBoundedRowData(new Path(tablePath), hadoopConf);
-        } else {
-            // TODO FLINK_SQL_PR2 write IT test for this.
-            sourceBuilder = DeltaSource.forContinuousRowData(new Path(tablePath), hadoopConf);
+        switch (mode) {
+            case BATCH:
+                sourceBuilder = DeltaSource.forBoundedRowData(new Path(tablePath), hadoopConf);
+                break;
+            case STREAMING:
+                sourceBuilder = DeltaSource.forContinuousRowData(new Path(tablePath), hadoopConf);
+                break;
+            default:
+                throw new RuntimeException(
+                    String.format(
+                        "Unrecognized table mode %s used for Delta table %s",
+                        mode, tablePath
+                    ));
         }
 
-        sourceBuilder
-            .columnNames(rowType.getFieldNames());
+        sourceBuilder.columnNames(columns);
 
         return SourceProvider.of(sourceBuilder.build());
     }
 
     @Override
     public DynamicTableSource copy() {
-        return new DeltaDynamicTableSource(this.hadoopConf, this.tableOptions, this.rowType);
+        return new DeltaDynamicTableSource(this.hadoopConf, this.tableOptions, this.columns);
     }
 
     @Override
@@ -78,22 +103,4 @@ public class DeltaDynamicTableSource implements
         return "DeltaSource";
     }
 
-    @Override
-    public Result applyFilters(List<ResolvedExpression> filters) {
-        // TODO FLINK_SQL_PR2 Support filters
-        return null;
-    }
-
-    @Override
-    public void applyLimit(long limit) {
-        // TODO FLINK_SQL_PR2 use this
-        this.limit = limit;
-
-    }
-
-    @Override
-    public boolean supportsNestedProjection() {
-        /// TODO FLINK_SQL_PR2  support nested projection
-        return false;
-    }
 }

--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaDynamicTableSource.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaDynamicTableSource.java
@@ -1,0 +1,99 @@
+package io.delta.flink.internal.table;
+
+import java.util.List;
+
+import io.delta.flink.source.DeltaSource;
+import io.delta.flink.source.internal.builder.DeltaSourceBuilderBase;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.hadoop.conf.Configuration;
+
+public class DeltaDynamicTableSource implements
+        ScanTableSource,
+        SupportsProjectionPushDown,
+        SupportsFilterPushDown,
+        SupportsLimitPushDown {
+
+    private final Configuration hadoopConf;
+
+    private final ReadableConfig tableOptions;
+
+    private final RowType rowType;
+
+    private long limit;
+
+    public DeltaDynamicTableSource(
+            Configuration hadoopConf,
+            ReadableConfig tableOptions,
+            RowType rowType) {
+
+        this.hadoopConf = hadoopConf;
+        this.tableOptions = tableOptions;
+        this.rowType = rowType;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return ChangelogMode.insertOnly();
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+
+        String mode = tableOptions.get(DeltaFlinkJobSpecificOptions.MODE);
+        String tablePath = tableOptions.get(DeltaTableConnectorOptions.TABLE_PATH);
+
+        DeltaSourceBuilderBase<RowData, ?> sourceBuilder;
+
+        if (DeltaFlinkJobSpecificOptions.MODE.defaultValue().equalsIgnoreCase(mode)) {
+            sourceBuilder = DeltaSource.forBoundedRowData(new Path(tablePath), hadoopConf);
+        } else {
+            // TODO FLINK_SQL_PR2 write IT test for this.
+            sourceBuilder = DeltaSource.forContinuousRowData(new Path(tablePath), hadoopConf);
+        }
+
+        sourceBuilder
+            .columnNames(rowType.getFieldNames());
+
+        return SourceProvider.of(sourceBuilder.build());
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        return new DeltaDynamicTableSource(this.hadoopConf, this.tableOptions, this.rowType);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "DeltaSource";
+    }
+
+    @Override
+    public Result applyFilters(List<ResolvedExpression> filters) {
+        // TODO FLINK_SQL_PR2 Support filters
+        return null;
+    }
+
+    @Override
+    public void applyLimit(long limit) {
+        // TODO FLINK_SQL_PR2 use this
+        this.limit = limit;
+
+    }
+
+    @Override
+    public boolean supportsNestedProjection() {
+        /// TODO FLINK_SQL_PR2  support nested projection
+        return false;
+    }
+}

--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaFlinkJobSpecificOptions.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaFlinkJobSpecificOptions.java
@@ -1,0 +1,13 @@
+package io.delta.flink.internal.table;
+
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+public class DeltaFlinkJobSpecificOptions {
+
+    public static final ConfigOption<String> MODE =
+        ConfigOptions.key("mode")
+            .stringType()
+            .defaultValue("batch");
+}

--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaFlinkJobSpecificOptions.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaFlinkJobSpecificOptions.java
@@ -24,13 +24,18 @@ import org.apache.hadoop.conf.Configuration;
 
 /**
  * This class contains Flink job specific options for {@link io.delta.flink.source.DeltaSource} and
- *  {@link io.delta.flink.sink.DeltaSink}. For Table API, this options can be set only using Flink,
- *  dynamic table options from DML/DQL query level, for example:
- *  <pre>{@code
+ * {@link io.delta.flink.sink.DeltaSink} that are relevant for Table API. For Table API, this
+ * options can be set only using Flink, dynamic table options from DML/DQL query level, for
+ * example:
+ * <pre>{@code
  *    SELECT * FROM my_delta_source_table /*+ OPTIONS(‘mode' = 'streaming')
  *  }</pre>
- *  Flink job specific options are not stored in metastore nor in Delta Log. Their scope is
- *  single Flink Job (DML/DQL query) only.
+ * Flink job specific options are not stored in metastore nor in Delta Log. Their scope is single
+ * Flink Job (DML/DQL query) only.
+ *
+ * <p>In practice this class will contain options from
+ * {@link io.delta.flink.source.internal.DeltaSourceOptions} and
+ * {@link io.delta.flink.sink.internal.DeltaSinkOptions} + extra ones like MODE.
  */
 public class DeltaFlinkJobSpecificOptions {
 

--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaFlinkJobSpecificOptions.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaFlinkJobSpecificOptions.java
@@ -1,13 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.delta.flink.internal.table;
-
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.core.fs.Path;
+import org.apache.hadoop.conf.Configuration;
 
+/**
+ * This class contains Flink job specific options for {@link io.delta.flink.source.DeltaSource} and
+ *  {@link io.delta.flink.sink.DeltaSink}. For Table API, this options can be set only using Flink,
+ *  dynamic table options from DML/DQL query level, for example:
+ *  <pre>{@code
+ *    SELECT * FROM my_delta_source_table /*+ OPTIONS(‘mode' = 'streaming')
+ *  }</pre>
+ *  Flink job specific options are not stored in metastore nor in Delta Log. Their scope is
+ *  single Flink Job (DML/DQL query) only.
+ */
 public class DeltaFlinkJobSpecificOptions {
 
-    public static final ConfigOption<String> MODE =
+    /**
+     * Option to specify if SELECT query should be bounded (read only Delta Snapshot) or should
+     * continuously monitor Delta table for new changes.
+     */
+    public static final ConfigOption<TableMode> MODE =
         ConfigOptions.key("mode")
-            .stringType()
-            .defaultValue("batch");
+            .enumType(TableMode.class)
+            .defaultValue(TableMode.BATCH);
+
+
+    /**
+     * Expected values for {@link DeltaFlinkJobSpecificOptions#MODE} job specific option. Based on
+     * this value, proper Delta source builder instance (DeltaSource.forBoundedRowData or
+     * DeltaSource.forContinuousRowData) will be created. Flink will automatically convert string
+     * value from dynamic table option from DML/DQL query and convert to TableMode value. The value
+     * is case-insensitive.
+     */
+    public enum TableMode {
+
+        /**
+         * Used to created Bounded Delta Source -
+         * {@link io.delta.flink.source.DeltaSource#forBoundedRowData(Path, Configuration)}
+         */
+        BATCH("batch"),
+
+        /**
+         * Used to created continuous Delta Source -
+         * {@link io.delta.flink.source.DeltaSource#forContinuousRowData(Path, Configuration)}
+         */
+        STREAMING("streaming");
+
+        private final String name;
+
+        TableMode(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
 }

--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaTableConnectorOptions.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaTableConnectorOptions.java
@@ -35,20 +35,6 @@ public class DeltaTableConnectorOptions {
             .noDefaultValue();
 
     /**
-     * Path to folder with Hadoop Conf containing files such as:
-     * <ul>
-     *     <li>core-site.xml</li>
-     *     <li>hdfs-site.xml</li>
-     *     <li>yarn-site.xml</li>
-     *     <li>mapred-site.xml</li>
-     * </ul>
-     */
-    public static final ConfigOption<String> HADOOP_CONF_DIR =
-        ConfigOptions.key("hadoop-conf-dir")
-            .stringType()
-            .noDefaultValue();
-
-    /**
      * Indicator whether we should try to update table's schema with stream's schema in case
      * those will not match. The update is not guaranteed as there will be still some checks
      * performed whether the updates to the schema are compatible.

--- a/flink/src/main/java/io/delta/flink/internal/table/HadoopUtils.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/HadoopUtils.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.delta.flink.internal.table;
 
 import java.io.File;

--- a/flink/src/test/java/io/delta/flink/sink/utils/CheckpointCountingSource.java
+++ b/flink/src/test/java/io/delta/flink/sink/utils/CheckpointCountingSource.java
@@ -1,44 +1,67 @@
 package io.delta.flink.sink.utils;
 
+import java.io.Serializable;
 import java.util.Collections;
 
 import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.RowType.RowField;
 import org.apache.flink.types.Row;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import static io.delta.flink.sink.utils.DeltaSinkTestUtils.TEST_ROW_TYPE;
 
 /**
- * Each of the source operators outputs records in given number of checkpoints.
- * Number of records per checkpoint is constant between checkpoints, and defined by user.
- * When all records are emitted, the source waits for two more checkpoints until it
- * finishes.
+ * Each of the source operators outputs records in given number of checkpoints. Number of records
+ * per checkpoint is constant between checkpoints, and defined by user. When all records are
+ * emitted, the source waits for two more checkpoints until it finishes.
  * <p>
- * All credits for this implementation goes to <b>Grzegorz Kolakowski<b>
- * who implemented the original version of this class for end2end tests.
- * This class was copied from his Pull Request here.
+ * All credits for this implementation goes to <b>Grzegorz Kolakowski<b> who implemented the
+ * original version of this class for end2end tests. This class was copied from his Pull Request
+ * here.
  */
 public class CheckpointCountingSource extends RichParallelSourceFunction<RowData>
-    implements CheckpointListener, CheckpointedFunction {
+    implements CheckpointListener, CheckpointedFunction, ResultTypeQueryable<RowData> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CheckpointCountingSource.class);
 
     private final int numberOfCheckpoints;
+
     private final int recordsPerCheckpoint;
+
+    private final RowProducer rowProducer;
+
     private ListState<Integer> nextValueState;
+
     private int nextValue;
+
     private volatile boolean isCanceled;
+
     private volatile boolean waitingForCheckpoint;
 
     public CheckpointCountingSource(int recordsPerCheckpoint, int numberOfCheckpoints) {
+        this(recordsPerCheckpoint, numberOfCheckpoints, new DefaultRowProducer());
+    }
+
+    public CheckpointCountingSource(
+            int recordsPerCheckpoint,
+            int numberOfCheckpoints,
+            RowProducer rowProducer) {
+
         this.numberOfCheckpoints = numberOfCheckpoints;
         this.recordsPerCheckpoint = recordsPerCheckpoint;
+        this.rowProducer = rowProducer;
     }
 
     @Override
@@ -60,7 +83,8 @@ public class CheckpointCountingSource extends RichParallelSourceFunction<RowData
 
         sendRecordsUntil(numberOfCheckpoints, ctx);
         idleUntilNextCheckpoint(ctx);
-        LOGGER.info("Source task done; subtask={}.", getRuntimeContext().getIndexOfThisSubtask());
+        LOGGER.info("Source task done; subtask={}.",
+            getRuntimeContext().getIndexOfThisSubtask());
     }
 
     private void sendRecordsUntil(int targetCheckpoints, SourceContext<RowData> ctx)
@@ -79,22 +103,13 @@ public class CheckpointCountingSource extends RichParallelSourceFunction<RowData
     }
 
     private void emitRecordsBatch(int batchSize, SourceContext<RowData> ctx) {
-        for (int i = 0; i < batchSize; ++i) {
-            RowData row = DeltaSinkTestUtils.TEST_ROW_TYPE_CONVERTER.toInternal(
-                Row.of(
-                    String.valueOf(nextValue),
-                    String.valueOf((nextValue + nextValue)),
-                    nextValue
-                )
-            );
-            ctx.collect(row);
-            nextValue++;
-        }
+        nextValue = rowProducer.emitRecordsBatch(nextValue, ctx, batchSize);
         LOGGER.info("Emitted {} records (total {}); subtask={}.", batchSize, nextValue,
             getRuntimeContext().getIndexOfThisSubtask());
     }
 
-    private void idleUntilNextCheckpoint(SourceContext<RowData> ctx) throws InterruptedException {
+    private void idleUntilNextCheckpoint(SourceContext<RowData> ctx) throws
+        InterruptedException {
         // Idle until the next checkpoint completes to avoid any premature job termination and
         // race conditions.
         LOGGER.info("Waiting for an additional checkpoint to complete; subtask={}.",
@@ -133,4 +148,44 @@ public class CheckpointCountingSource extends RichParallelSourceFunction<RowData
     public void cancel() {
         isCanceled = true;
     }
+
+    @Override
+    public TypeInformation<RowData> getProducedType() {
+        return rowProducer.getProducedType();
+    }
+
+    public interface RowProducer extends Serializable {
+
+        int emitRecordsBatch(int nextValue, SourceContext<RowData> ctx, int batchSize);
+
+        TypeInformation<RowData> getProducedType();
+    }
+
+    private static class DefaultRowProducer implements RowProducer {
+
+        @Override
+        public int emitRecordsBatch(int nextValue, SourceContext<RowData> ctx, int batchSize) {
+            for (int i = 0; i < batchSize; ++i) {
+                RowData row = DeltaSinkTestUtils.TEST_ROW_TYPE_CONVERTER.toInternal(
+                    Row.of(
+                        String.valueOf(nextValue),
+                        String.valueOf((nextValue + nextValue)),
+                        nextValue
+                    )
+                );
+                ctx.collect(row);
+                nextValue++;
+            }
+            return nextValue;
+        }
+
+        @Override
+        public TypeInformation<RowData> getProducedType() {
+            LogicalType[] fieldTypes = TEST_ROW_TYPE.getFields().stream()
+                .map(RowField::getType).toArray(LogicalType[]::new);
+            String[] fieldNames = TEST_ROW_TYPE.getFieldNames().toArray(new String[0]);
+            return InternalTypeInfo.of(RowType.of(fieldTypes, fieldNames));
+        }
+    }
+
 }

--- a/flink/src/test/java/io/delta/flink/sink/utils/DeltaSinkTestUtils.java
+++ b/flink/src/test/java/io/delta/flink/sink/utils/DeltaSinkTestUtils.java
@@ -82,6 +82,10 @@ public class DeltaSinkTestUtils {
         new RowType.RowField("col2", new VarCharType(VarCharType.MAX_LENGTH))
     ));
 
+    /**
+     * {@link org.apache.flink.table.data.util.DataFormatConverters.DataFormatConverter} for
+     * {@link #TEST_ROW_TYPE}
+     */
     @SuppressWarnings("unchecked")
     public static final DataFormatConverters.DataFormatConverter<RowData, Row>
         TEST_ROW_TYPE_CONVERTER = DataFormatConverters.getConverterForDataType(

--- a/flink/src/test/java/io/delta/flink/source/DeltaSourceContinuousExecutionITCaseTest.java
+++ b/flink/src/test/java/io/delta/flink/source/DeltaSourceContinuousExecutionITCaseTest.java
@@ -106,7 +106,7 @@ public class DeltaSourceContinuousExecutionITCaseTest extends DeltaSourceITBase 
 
         // Each row has a unique column across all Delta table data. We are converting List or
         // read rows to set of values for that unique column.
-        // If there were eny duplicates or missing values we will catch them here by comparing
+        // If there were any duplicates or missing values we will catch them here by comparing
         // size of that Set to expected number of rows.
         Set<String> uniqueValues =
             resultData.stream().flatMap(Collection::stream).map(row -> row.getString(1).toString())
@@ -139,7 +139,7 @@ public class DeltaSourceContinuousExecutionITCaseTest extends DeltaSourceITBase 
 
         // Each row has a unique column across all Delta table data. We are converting List or
         // read rows to set of values for that unique column.
-        // If there were eny duplicates or missing values we will catch them here by comparing
+        // If there were any duplicates or missing values we will catch them here by comparing
         // size of that Set to expected number of rows.
         Set<Long> uniqueValues =
             resultData.stream().flatMap(Collection::stream).map(row -> row.getLong(0))
@@ -533,9 +533,9 @@ public class DeltaSourceContinuousExecutionITCaseTest extends DeltaSourceITBase 
     }
 
     private void shouldReadDeltaTableFromSnapshotAndUpdates(
-        DeltaSource<RowData> deltaSource,
-        FailoverType failoverType)
-        throws Exception {
+            DeltaSource<RowData> deltaSource,
+            FailoverType failoverType)
+            throws Exception {
 
         int numberOfTableUpdateBulks = 5;
         int rowsPerTableUpdate = 5;
@@ -559,7 +559,7 @@ public class DeltaSourceContinuousExecutionITCaseTest extends DeltaSourceITBase 
 
         // Each row has a unique column across all Delta table data. We are converting List or
         // read rows to set of values for that unique column.
-        // If there were eny duplicates or missing values we will catch them here by comparing
+        // If there were any duplicates or missing values we will catch them here by comparing
         // size of that Set to expected number of rows.
         Set<String> uniqueValues =
             resultData.stream().flatMap(Collection::stream)

--- a/flink/src/test/java/io/delta/flink/table/DeltaEndToEndTableITCase.java
+++ b/flink/src/test/java/io/delta/flink/table/DeltaEndToEndTableITCase.java
@@ -1,0 +1,115 @@
+package io.delta.flink.table;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import io.delta.flink.utils.DeltaTestUtils;
+import io.delta.flink.utils.ExecutionITCaseTestConstants;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.rules.TemporaryFolder;
+import static io.delta.flink.utils.DeltaTestUtils.buildCluster;
+import static io.delta.flink.utils.DeltaTestUtils.getTestStreamEnv;
+import static io.delta.flink.utils.DeltaTestUtils.verifyDeltaTable;
+import static io.delta.flink.utils.ExecutionITCaseTestConstants.LARGE_TABLE_ALL_COLUMN_NAMES;
+import static io.delta.flink.utils.ExecutionITCaseTestConstants.LARGE_TABLE_ALL_COLUMN_TYPES;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+
+public class DeltaEndToEndTableITCase {
+
+    private static final int PARALLELISM = 2;
+
+    private static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    private final MiniClusterWithClientResource miniClusterResource = buildCluster(PARALLELISM);
+
+    /**
+     * Schema for this table has only
+     * {@link ExecutionITCaseTestConstants#LARGE_TABLE_ALL_COLUMN_NAMES} of type
+     * {@link ExecutionITCaseTestConstants#LARGE_TABLE_ALL_COLUMN_TYPES} columns.
+     * Column types are long, long, String
+     */
+    private String nonPartitionedLargeTablePath;
+
+    private String sinkTablePath;
+
+    @BeforeAll
+    public static void beforeAll() throws IOException {
+        TEMPORARY_FOLDER.create();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        TEMPORARY_FOLDER.delete();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        try {
+            miniClusterResource.before();
+            nonPartitionedLargeTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+            sinkTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+            DeltaTestUtils.initTestForNonPartitionedLargeTable(nonPartitionedLargeTablePath);
+        } catch (Exception e) {
+            throw new RuntimeException("Weren't able to setup the test dependencies", e);
+        }
+
+        assertThat(sinkTablePath, not(equalTo(nonPartitionedLargeTablePath)));
+    }
+
+    @AfterEach
+    public void afterEach() {
+        miniClusterResource.after();
+    }
+
+    @Test
+    public void testEndToEndTableJob() throws Exception {
+
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(
+            getTestStreamEnv(false) // streamingMode = false
+        );
+
+        String sourceTable =
+            String.format("CREATE TABLE sourceTable ("
+                    + "col1 BIGINT,"
+                    + "col2 BIGINT,"
+                    + "col3 VARCHAR"
+                    + ") "
+                    + "WITH ("
+                    + " 'connector' = 'delta',"
+                    + " 'table-path' = '%s'"
+                    + ")",
+                nonPartitionedLargeTablePath);
+
+        String sinkTable =
+            String.format("CREATE TABLE sinkTable ("
+                    + "col1 BIGINT,"
+                    + "col2 BIGINT,"
+                    + "col3 VARCHAR"
+                    + ") "
+                    + "WITH ("
+                    + " 'connector' = 'delta',"
+                    + " 'table-path' = '%s'"
+                    + ")",
+                sinkTablePath);
+
+        String selectToInsertSql = "INSERT INTO sinkTable SELECT * FROM sourceTable;";
+
+        tableEnv.executeSql(sourceTable);
+        tableEnv.executeSql(sinkTable);
+
+        tableEnv.executeSql(selectToInsertSql).await(10, TimeUnit.SECONDS);
+
+        RowType rowType = RowType.of(LARGE_TABLE_ALL_COLUMN_TYPES, LARGE_TABLE_ALL_COLUMN_NAMES);
+        verifyDeltaTable(sinkTablePath, rowType, 1100);
+    }
+
+}

--- a/flink/src/test/java/io/delta/flink/table/DeltaSinkTableITCase.java
+++ b/flink/src/test/java/io/delta/flink/table/DeltaSinkTableITCase.java
@@ -18,32 +18,37 @@
 
 package io.delta.flink.table;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 
+import io.delta.flink.sink.utils.CheckpointCountingSource;
+import io.delta.flink.sink.utils.CheckpointCountingSource.RowProducer;
 import io.delta.flink.sink.utils.DeltaSinkTestUtils;
 import io.delta.flink.utils.DeltaTestUtils;
 import io.delta.flink.utils.TestParquetReader;
-import io.github.artsok.ParameterizedRepeatedIfExceptionsTest;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.RowType.RowField;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.types.Row;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -143,8 +148,7 @@ public class DeltaSinkTableITCase {
         );
     }
 
-    @ParameterizedRepeatedIfExceptionsTest(
-        suspend = 2000L, repeats = 3,
+    @ParameterizedTest(
         name = "isPartitioned = {0}, " +
             "includeOptionalOptions = {1}, " +
             "useStaticPartition = {2}, " +
@@ -156,6 +160,7 @@ public class DeltaSinkTableITCase {
             boolean useStaticPartition,
             boolean useBoundedMode) throws Exception {
 
+        int expectedNumberOfRows = 20;
         String deltaTablePath = setupTestFolders(includeOptionalOptions);
 
         // Column `col1` would be a partition column if isPartitioned or useStaticPartition
@@ -170,24 +175,28 @@ public class DeltaSinkTableITCase {
                 includeOptionalOptions,
                 useStaticPartition,
                 useBoundedMode,
-                insertSql
+                insertSql,
+                expectedNumberOfRows
             );
 
         Snapshot snapshot = deltaLog.update();
 
         // Validate that every inserted column has non value.
+        int recordCount = 0;
         try (CloseableIterator<RowRecord> open = snapshot.open()) {
             while (open.hasNext()) {
+                recordCount++;
                 RowRecord record = open.next();
                 assertThat(record.getString("col1"), notNullValue());
                 assertThat(record.getString("col2"), notNullValue());
                 assertThat(record.getInt("col3"), notNullValue());
             }
         }
+
+        //
+        assertThat(recordCount, equalTo(expectedNumberOfRows));
     }
 
-    /*    @ParameterizedRepeatedIfExceptionsTest(
-        suspend = 2000L, repeats = 3,*/
     @ParameterizedTest(
         name = "isPartitioned = {0}, " +
             "includeOptionalOptions = {1}, " +
@@ -199,6 +208,8 @@ public class DeltaSinkTableITCase {
             boolean includeOptionalOptions,
             boolean useStaticPartition,
             boolean useBoundedMode) throws Exception {
+
+        int expectedNumberOfRows = 20;
 
         // Column `col1` would be a partition column if isPartitioned or useStaticPartition
         // set to true.
@@ -212,12 +223,15 @@ public class DeltaSinkTableITCase {
                 includeOptionalOptions,
                 useStaticPartition,
                 useBoundedMode,
-                insertSql
+                insertSql,
+                expectedNumberOfRows
             );
 
         // Validate that every inserted column has null or not null value depends on the settings
+        int recordCount = 0;
         try (CloseableIterator<RowRecord> open = deltaLog.update().open()) {
             while (open.hasNext()) {
+                recordCount++;
                 RowRecord record = open.next();
                 assertThat(record.getString("col1"), notNullValue());
                 assertThat(
@@ -230,10 +244,10 @@ public class DeltaSinkTableITCase {
                 );
             }
         }
+        assertThat(recordCount, equalTo(expectedNumberOfRows));
     }
 
-    @ParameterizedRepeatedIfExceptionsTest(
-        suspend = 2000L, repeats = 3,
+    @ParameterizedTest(
         name = "isPartitioned = {0}, " +
             "includeOptionalOptions = {1}, " +
             "useStaticPartition = {2}, " +
@@ -244,6 +258,8 @@ public class DeltaSinkTableITCase {
             boolean includeOptionalOptions,
             boolean useStaticPartition,
             boolean useBoundedMode) throws Exception {
+
+        int expectedNumberOfRows = 20;
 
         // Column `col1` would be a partition column if isPartitioned or useStaticPartition
         // set to true.
@@ -260,12 +276,15 @@ public class DeltaSinkTableITCase {
                 includeOptionalOptions,
                 useStaticPartition,
                 useBoundedMode,
-                insertSql
+                insertSql,
+                expectedNumberOfRows
             );
 
         // Validate that every inserted column has null or not null value depends on the settings
+        int recordCount = 0;
         try (CloseableIterator<RowRecord> open = deltaLog.update().open()) {
             while (open.hasNext()) {
+                recordCount++;
                 RowRecord record = open.next();
                 assertThat(record.getString("col1"), notNullValue());
                 assertThat(
@@ -278,6 +297,7 @@ public class DeltaSinkTableITCase {
                 );
             }
         }
+        assertThat(recordCount, equalTo(expectedNumberOfRows));
     }
 
     private String buildInsertAllFieldsSql(boolean useStaticPartition) {
@@ -343,19 +363,21 @@ public class DeltaSinkTableITCase {
             boolean includeOptionalOptions,
             boolean useStaticPartition,
             boolean useBoundedMode,
-            String insertSql) throws Exception {
+            String insertSql,
+            int expectedNumberOfRows) throws Exception {
 
         // GIVEN
         DeltaLog deltaLog = DeltaLog.forTable(DeltaTestUtils.getHadoopConf(), deltaTablePath);
         List<AddFile> initialDeltaFiles = deltaLog.snapshot().getAllFiles();
 
         // WHEN
-        setupAndRunFLinkJob(
-            isPartitioned,
-            includeOptionalOptions,
-            useBoundedMode,
+        runFlinkJob(
             deltaTablePath,
-            insertSql);
+            useBoundedMode,
+            includeOptionalOptions,
+            isPartitioned,
+            insertSql,
+            expectedNumberOfRows);
 
         DeltaTestUtils.waitUntilDeltaLogExists(deltaLog, deltaLog.snapshot().getVersion() + 1);
 
@@ -365,7 +387,8 @@ public class DeltaSinkTableITCase {
             includeOptionalOptions,
             useStaticPartition,
             deltaLog,
-            initialDeltaFiles
+            initialDeltaFiles,
+            expectedNumberOfRows
         );
 
         return deltaLog;
@@ -377,7 +400,8 @@ public class DeltaSinkTableITCase {
             boolean includeOptionalOptions,
             boolean useStaticPartition,
             DeltaLog deltaLog,
-            List<AddFile> initialDeltaFiles) throws IOException {
+            List<AddFile> initialDeltaFiles,
+            int expectedRecordCount) throws IOException {
 
         int tableRecordsCount =
             TestParquetReader.readAndValidateAllTableRecords(
@@ -390,15 +414,18 @@ public class DeltaSinkTableITCase {
         Snapshot snapshot = deltaLog.update();
         List<AddFile> files = snapshot.getAllFiles();
         assertThat(files.size() > initialDeltaFiles.size(), equalTo(true));
-        assertThat(tableRecordsCount > 0, equalTo(true));
+        assertThat(tableRecordsCount, equalTo(expectedRecordCount));
 
         if (isPartitioned) {
             assertThat(
                 deltaLog.snapshot().getMetadata().getPartitionColumns(),
-                CoreMatchers.is(Arrays.asList("col1", "col3")));
+                CoreMatchers.is(Arrays.asList("col1", "col3"))
+            );
         } else {
-            assertThat(deltaLog.snapshot().getMetadata().getPartitionColumns().isEmpty(),
-                equalTo(true));
+            assertThat(
+                deltaLog.snapshot().getMetadata().getPartitionColumns().isEmpty(),
+                equalTo(true)
+            );
         }
 
         List<String> expectedTableCols = includeOptionalOptions ?
@@ -414,38 +441,12 @@ public class DeltaSinkTableITCase {
         }
     }
 
-    private void setupAndRunFLinkJob(
-                boolean isPartitioned,
-                boolean includeOptionalOptions,
-                boolean useBoundedMode,
-                String deltaTablePath,
-                String insertSql) {
-
-        if (useBoundedMode) {
-            runFlinkJob(
-                deltaTablePath,
-                useBoundedMode,
-                includeOptionalOptions,
-                isPartitioned,
-                insertSql);
-        } else {
-            runFlinkJobInBackground(
-                deltaTablePath,
-                useBoundedMode,
-                includeOptionalOptions,
-                isPartitioned,
-                insertSql
-            );
-        }
-    }
-
     public String setupTestFolders(boolean includeOptionalOptions) {
         try {
             String deltaTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
             // one of the optional options is whether the sink should try to update the table's
             // schema, so we are initializing an existing table to test this behaviour
             if (includeOptionalOptions) {
-                DeltaTestUtils.initTestForTableApiTable(deltaTablePath);
                 testRowType = DeltaSinkTestUtils.addNewColumnToSchema(TEST_ROW_TYPE);
             } else {
                 testRowType = TEST_ROW_TYPE;
@@ -457,35 +458,6 @@ public class DeltaSinkTableITCase {
     }
 
     /**
-     * Runs Flink job in a daemon thread.
-     * <p>
-     * This workaround is needed because if we try to first run the Flink job and then query the
-     * table with Delta Standalone Reader (DSR) then we are hitting "closes classloader exception"
-     * which in short means that finished Flink job closes the classloader for the classes that DSR
-     * tries to reuse.
-     */
-    private void runFlinkJobInBackground(
-            String deltaTablePath,
-            boolean useBoundedMode,
-            boolean includeOptionalOptions,
-            boolean isPartitioned,
-            String insertSql) {
-
-        CompletableFuture.runAsync(
-            () -> runFlinkJob(
-                deltaTablePath,
-                useBoundedMode,
-                includeOptionalOptions,
-                isPartitioned,
-                insertSql),
-            testWorkers
-        ).exceptionally(throwable -> {
-            LOG.error("Error while running Flink job in background.", throwable);
-            return null;
-        });
-    }
-
-    /**
      * Run Flink Job and block current thread until job finishes.
      */
     private void runFlinkJob(
@@ -493,30 +465,46 @@ public class DeltaSinkTableITCase {
             boolean useBoundedMode,
             boolean includeOptionalOptions,
             boolean isPartitioned,
-            String insertSql) {
+            String insertSql,
+            int expectedNumberOfRows) {
 
-        TableEnvironment tableEnv;
+        StreamExecutionEnvironment streamEnv = getTestStreamEnv(!useBoundedMode);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(streamEnv);
+
         if (useBoundedMode) {
-            EnvironmentSettings settings = EnvironmentSettings
-                .newInstance()
-                .inBatchMode()
-                .build();
-            tableEnv = TableEnvironment.create(settings);
+            // will use datagen for Source Table
+            String sourceSql = buildSourceTableSql(expectedNumberOfRows, includeOptionalOptions);
+            tableEnv.executeSql(sourceSql);
         } else {
-            tableEnv = StreamTableEnvironment.create(getTestStreamEnv());
+            // Since Delta Sink's Global Committer lags 1 commit behind rest of the pipeline,
+            // in Streaming mode we cannot use datagen since it will end just after emitting last
+            // record, and we will need extra Flink commit to commit this last records in Delta
+            // Log. Because of that we are using CheckpointCountingSource which will wait extra
+            // one commit after emitting entire data set. CheckpointCountingSource can't be used
+            // in bounded mode though.
+            CheckpointCountingSource source;
+            int recordsPerCheckpoint = 5;
+            int numberOfCheckpoints =
+                (int) Math.ceil(expectedNumberOfRows / (double) recordsPerCheckpoint);
+            if (includeOptionalOptions) {
+                source =
+                    new CheckpointCountingSource(
+                        recordsPerCheckpoint,
+                        numberOfCheckpoints,
+                        new ExtraColumnRowProducer());
+            } else {
+                source =
+                    new CheckpointCountingSource(
+                        recordsPerCheckpoint,
+                        numberOfCheckpoints,
+                        new RowTypeColumnarRowProducer());
+            }
+
+            DataStreamSource<RowData> streamSource = streamEnv.addSource(source).setParallelism(1);
+            tableEnv.createTemporaryView(TEST_SOURCE_TABLE_NAME, streamSource);
         }
 
-        String sourceSql = buildSourceTableSql(
-            10,
-            includeOptionalOptions,
-            useBoundedMode);
-        tableEnv.executeSql(sourceSql);
-
-        String sinkSql = buildSinkTableSql(
-            deltaTablePath,
-            includeOptionalOptions,
-            isPartitioned);
-
+        String sinkSql = buildSinkTableSql(deltaTablePath, includeOptionalOptions, isPartitioned);
         tableEnv.executeSql(sinkSql);
 
         try {
@@ -528,21 +516,23 @@ public class DeltaSinkTableITCase {
         }
     }
 
-    private StreamExecutionEnvironment getTestStreamEnv() {
+    private StreamExecutionEnvironment getTestStreamEnv(boolean streamingMode) {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
-        env.enableCheckpointing(1000, CheckpointingMode.EXACTLY_ONCE);
+
+        if (streamingMode) {
+            env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+            env.enableCheckpointing(1000, CheckpointingMode.EXACTLY_ONCE);
+        } else {
+            env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        }
+
         return env;
     }
 
-    private String buildSourceTableSql(
-            int rows,
-            boolean includeOptionalOptions,
-            boolean useBoundedMode) {
+    private String buildSourceTableSql(int rows, boolean includeOptionalOptions) {
 
         String additionalCol = includeOptionalOptions ? ", col4 INT " : "";
-        String rowLimit = useBoundedMode ? "'number-of-rows' = '1'," : "";
         return String.format(
             "CREATE TABLE %s ("
                 + " col1 VARCHAR,"
@@ -551,10 +541,11 @@ public class DeltaSinkTableITCase {
                 + additionalCol
                 + ") WITH ("
                 + " 'connector' = 'datagen',"
-                + rowLimit
-                + " 'rows-per-second' = '20'"
+                + "'number-of-rows' = '%s',"
+                + " 'rows-per-second' = '5'"
                 + ")",
-            DeltaSinkTableITCase.TEST_SOURCE_TABLE_NAME, rows);
+            DeltaSinkTableITCase.TEST_SOURCE_TABLE_NAME,
+            rows);
     }
 
     private String buildSinkTableSql(
@@ -562,13 +553,7 @@ public class DeltaSinkTableITCase {
             boolean includeOptionalOptions,
             boolean isPartitioned) {
 
-        String resourcesDirectory = new File("src/test/resources/hadoop-conf").getAbsolutePath();
-        String optionalTableOptions = (includeOptionalOptions ?
-            String.format(
-                " 'hadoop-conf-dir' = '%s', 'mergeSchema' = 'true', ",
-                resourcesDirectory)
-            : ""
-        );
+        String optionalTableOptions = (includeOptionalOptions ? "'mergeSchema' = 'true', " : "");
 
         String partitionedClause = isPartitioned ? "PARTITIONED BY (col1, col3) " : "";
         String additionalCol = includeOptionalOptions ? ", col4 INT " : "";
@@ -587,5 +572,81 @@ public class DeltaSinkTableITCase {
                 + " 'table-path' = '%s'"
                 + ")",
             DeltaSinkTableITCase.TEST_SINK_TABLE_NAME, tablePath);
+    }
+
+    private static class RowTypeColumnarRowProducer implements RowProducer {
+
+        @SuppressWarnings("unchecked")
+        private static final DataFormatConverters.DataFormatConverter<RowData, Row>
+            ROW_TYPE_CONVERTER = DataFormatConverters.getConverterForDataType(
+            TypeConversions.fromLogicalToDataType(TEST_ROW_TYPE)
+        );
+
+        @Override
+        public int emitRecordsBatch(int nextValue, SourceContext<RowData> ctx, int batchSize) {
+            for (int i = 0; i < batchSize; ++i) {
+                RowData row = ROW_TYPE_CONVERTER.toInternal(
+                    Row.of(
+                        String.valueOf(nextValue),
+                        String.valueOf((nextValue + nextValue)),
+                        nextValue
+                    )
+                );
+                ctx.collect(row);
+                nextValue++;
+            }
+
+            return nextValue;
+        }
+
+        @Override
+        public TypeInformation<RowData> getProducedType() {
+            LogicalType[] fieldTypes = TEST_ROW_TYPE.getFields().stream()
+                .map(RowField::getType).toArray(LogicalType[]::new);
+            String[] fieldNames = TEST_ROW_TYPE.getFieldNames().toArray(new String[0]);
+            return InternalTypeInfo.of(RowType.of(fieldTypes, fieldNames));
+        }
+    }
+
+    private static class ExtraColumnRowProducer implements RowProducer {
+
+        private static final RowType EXTRA_COLUMN_ROW_TYPE = new RowType(Arrays.asList(
+            new RowType.RowField("col1", new VarCharType(VarCharType.MAX_LENGTH)),
+            new RowType.RowField("col2", new VarCharType(VarCharType.MAX_LENGTH)),
+            new RowType.RowField("col3", new IntType()),
+            new RowType.RowField("col4", new IntType())
+        ));
+
+        @SuppressWarnings("unchecked")
+        private static final DataFormatConverters.DataFormatConverter<RowData, Row>
+            EXTRA_COLUMN_ROW_TYPE_CONVERTER = DataFormatConverters.getConverterForDataType(
+            TypeConversions.fromLogicalToDataType(EXTRA_COLUMN_ROW_TYPE)
+        );
+
+
+        @Override
+        public int emitRecordsBatch(int nextValue, SourceContext<RowData> ctx, int batchSize) {
+            for (int i = 0; i < batchSize; ++i) {
+                RowData row = EXTRA_COLUMN_ROW_TYPE_CONVERTER.toInternal(
+                    Row.of(
+                        String.valueOf(nextValue),
+                        String.valueOf((nextValue + nextValue)),
+                        nextValue,
+                        nextValue
+                    )
+                );
+                ctx.collect(row);
+                nextValue++;
+            }
+            return nextValue;
+        }
+
+        @Override
+        public TypeInformation<RowData> getProducedType() {
+            LogicalType[] fieldTypes = EXTRA_COLUMN_ROW_TYPE.getFields().stream()
+                .map(RowField::getType).toArray(LogicalType[]::new);
+            String[] fieldNames = EXTRA_COLUMN_ROW_TYPE.getFieldNames().toArray(new String[0]);
+            return InternalTypeInfo.of(RowType.of(fieldTypes, fieldNames));
+        }
     }
 }

--- a/flink/src/test/java/io/delta/flink/table/DeltaSourceTableITCase.java
+++ b/flink/src/test/java/io/delta/flink/table/DeltaSourceTableITCase.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.flink.table;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import io.delta.flink.utils.DeltaTestUtils;
+import io.delta.flink.utils.ExecutionITCaseTestConstants;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.StringUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import static io.delta.flink.utils.DeltaTestUtils.buildCluster;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class DeltaSourceTableITCase {
+
+    private static final int PARALLELISM = 2;
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeltaSourceTableITCase.class);
+
+    private static final String TEST_SOURCE_TABLE_NAME = "sourceTable";
+
+    private static final String TEST_SINK_TABLE_NAME = "sinkTable";
+
+    private static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    /**
+     * Schema for this table has only {@link ExecutionITCaseTestConstants#DATA_COLUMN_NAMES}
+     * of type {@link ExecutionITCaseTestConstants#DATA_COLUMN_TYPES} columns.
+     */
+    private String nonPartitionedTablePath;
+
+    /**
+     * Schema for this table contains data columns
+     * {@link ExecutionITCaseTestConstants#DATA_COLUMN_NAMES} and col1, col2
+     * partition columns. Types of data columns are
+     * {@link ExecutionITCaseTestConstants#DATA_COLUMN_TYPES}
+     */
+    private String partitionedTablePath;
+
+    /**
+     * Schema for this table has only
+     * {@link ExecutionITCaseTestConstants#LARGE_TABLE_ALL_COLUMN_NAMES} of type
+     * {@link ExecutionITCaseTestConstants#LARGE_TABLE_ALL_COLUMN_TYPES} columns.
+     * Column types are long, long, String
+     */
+    private String nonPartitionedLargeTablePath;
+
+    public static final RowType TEST_ROW_TYPE = new RowType(Arrays.asList(
+        new RowType.RowField("col1", new VarCharType(VarCharType.MAX_LENGTH)),
+        new RowType.RowField("col2", new VarCharType(VarCharType.MAX_LENGTH)),
+        new RowType.RowField("col3", new IntType())
+    ));
+
+    private static ExecutorService testWorkers;
+
+    private final MiniClusterWithClientResource miniClusterResource = buildCluster(PARALLELISM);
+
+    protected RowType testRowType;
+
+    @BeforeAll
+    public static void beforeAll() throws IOException {
+        testWorkers = Executors.newCachedThreadPool(r -> {
+            final Thread thread = new Thread(r);
+            thread.setUncaughtExceptionHandler((t, e) -> {
+                t.interrupt();
+                throw new RuntimeException(e);
+            });
+            return thread;
+        });
+        TEMPORARY_FOLDER.create();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        testWorkers.shutdownNow();
+        TEMPORARY_FOLDER.delete();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        try {
+            miniClusterResource.before();
+
+            nonPartitionedTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+            nonPartitionedLargeTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+            partitionedTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+
+            DeltaTestUtils.initTestForPartitionedTable(partitionedTablePath);
+            DeltaTestUtils.initTestForNonPartitionedTable(nonPartitionedTablePath);
+            DeltaTestUtils.initTestForNonPartitionedLargeTable(
+                nonPartitionedLargeTablePath);
+        } catch (Exception e) {
+            throw new RuntimeException("Weren't able to setup the test dependencies", e);
+        }
+    }
+
+    @AfterEach
+    public void afterEach() {
+        miniClusterResource.after();
+    }
+
+    // TODO FLINK_SQL_PR2 Write test for streaming
+    // TODO FLINK_SQL_PR2 Write test for static partition
+    // TODO FLINK_SQL_PR2 with partitions from Delta Table
+    @ParameterizedTest
+    @ValueSource(strings = {"", "batch"})
+    public void testBatchTableJob(String jobMode) throws Exception {
+
+        String sinkTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(
+            getTestStreamEnv(("streaming".equalsIgnoreCase(jobMode)))
+        );
+
+        tableEnv.executeSql(
+            buildSourceTableSql(
+                nonPartitionedTablePath,
+                false,
+                false)
+        );
+
+        tableEnv.executeSql(buildSinkTableSql(sinkTablePath));
+
+        String connectorModeHint = StringUtils.isNullOrWhitespaceOnly(jobMode) ?
+            "" : String.format("/*+ OPTIONS('mode' = '%s') */", jobMode);
+
+        String insertSql = String.format(
+            "INSERT INTO sinkTable SELECT * FROM sourceTable %s",
+            connectorModeHint);
+        tableEnv.executeSql(insertSql).await(30, TimeUnit.SECONDS);
+
+        // TODO FLINK_SQL_PR2 check column values.
+        List<Integer> data = DeltaTestUtils.readParquetTable(sinkTablePath + "/");
+        System.out.println(data);
+        assertThat(data.size(), equalTo(2));
+
+    }
+
+    private String buildSinkTableSql(String tablePath) {
+        return String.format(
+            "CREATE TABLE sinkTable ("
+                + " name VARCHAR,"
+                + " surname VARCHAR,"
+                + " age INT"
+                + ") WITH ("
+                + " 'connector' = 'filesystem',"
+                + " 'path' = '%s',"
+                + " 'auto-compaction' = 'false',"
+                + " 'format' = 'parquet',"
+                + " 'sink.parallelism' = '3'"
+                + ")",
+            tablePath);
+    }
+
+    private String buildSourceTableSql(
+        String tablePath,
+        boolean includeHadoopConfDir,
+        boolean isPartitioned) {
+
+        String resourcesDirectory = new File("src/test/resources/hadoop-conf").getAbsolutePath();
+        String hadoopConfDirPath = (includeHadoopConfDir ?
+            String.format(
+                " 'hadoop-conf-dir' = '%s',",
+                resourcesDirectory)
+            : ""
+        );
+
+        String partitionedClause = isPartitioned ? "PARTITIONED BY (col1, col3) " : "";
+
+        return String.format(
+            "CREATE TABLE %s ("
+                + " name VARCHAR,"
+                + " surname VARCHAR,"
+                + " age INT"
+                + ") "
+                + partitionedClause
+                + "WITH ("
+                + " 'connector' = 'delta',"
+                + hadoopConfDirPath
+                + " 'table-path' = '%s'"
+                + ")",
+            DeltaSourceTableITCase.TEST_SOURCE_TABLE_NAME,
+            tablePath
+        );
+    }
+
+    private StreamExecutionEnvironment getTestStreamEnv(boolean streamingMode) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+
+        if (streamingMode) {
+            env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+            env.enableCheckpointing(1000, CheckpointingMode.EXACTLY_ONCE);
+        } else {
+            env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        }
+
+        return env;
+    }
+
+}

--- a/flink/src/test/java/io/delta/flink/table/DeltaSourceTableITCase.java
+++ b/flink/src/test/java/io/delta/flink/table/DeltaSourceTableITCase.java
@@ -85,7 +85,7 @@ public class DeltaSourceTableITCase {
     // TODO would have been nice to make a TableInfo class that contained the path (maybe a
     //  generator so it is always random), column names, column types, so all this information
     //  was coupled together. This class could be used for all IT tests where we use predefined
-    //  Tables.
+    //  Tables - https://github.com/delta-io/connectors/issues/499
     /**
      * Schema for this table has only
      * {@link ExecutionITCaseTestConstants#LARGE_TABLE_ALL_COLUMN_NAMES} of type

--- a/flink/src/test/java/io/delta/flink/table/DeltaSourceTableITCase.java
+++ b/flink/src/test/java/io/delta/flink/table/DeltaSourceTableITCase.java
@@ -18,65 +18,70 @@
 
 package io.delta.flink.table;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.delta.flink.utils.DeltaTestUtils;
 import io.delta.flink.utils.ExecutionITCaseTestConstants;
-import org.apache.flink.api.common.RuntimeExecutionMode;
-import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.streaming.api.CheckpointingMode;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import io.delta.flink.utils.FailoverType;
+import io.delta.flink.utils.RecordCounterToFail.FailCheck;
+import io.delta.flink.utils.TableUpdateDescriptor;
+import io.delta.flink.utils.TestDescriptor;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.types.Row;
 import org.apache.flink.util.StringUtils;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import static io.delta.flink.utils.DeltaTestUtils.buildCluster;
+import static io.delta.flink.utils.DeltaTestUtils.getTestStreamEnv;
+import static io.delta.flink.utils.ExecutionITCaseTestConstants.AGE_COLUMN_VALUES;
+import static io.delta.flink.utils.ExecutionITCaseTestConstants.DATA_COLUMN_NAMES;
+import static io.delta.flink.utils.ExecutionITCaseTestConstants.DATA_COLUMN_TYPES;
+import static io.delta.flink.utils.ExecutionITCaseTestConstants.NAME_COLUMN_VALUES;
+import static io.delta.flink.utils.ExecutionITCaseTestConstants.SMALL_TABLE_COUNT;
+import static io.delta.flink.utils.ExecutionITCaseTestConstants.SURNAME_COLUMN_VALUES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DeltaSourceTableITCase {
 
     private static final int PARALLELISM = 2;
 
-    private static final Logger LOG = LoggerFactory.getLogger(DeltaSourceTableITCase.class);
-
     private static final String TEST_SOURCE_TABLE_NAME = "sourceTable";
 
-    private static final String TEST_SINK_TABLE_NAME = "sinkTable";
+    private static final String SMALL_TABLE_SCHEMA = "name VARCHAR, surname VARCHAR, age INT";
+
+    private static final String LARGE_TABLE_SCHEMA = "col1 BIGINT, col2 BIGINT, col3 VARCHAR";
 
     private static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
+    private final MiniClusterWithClientResource miniClusterResource = buildCluster(PARALLELISM);
+
     /**
-     * Schema for this table has only {@link ExecutionITCaseTestConstants#DATA_COLUMN_NAMES}
-     * of type {@link ExecutionITCaseTestConstants#DATA_COLUMN_TYPES} columns.
+     * Schema for this table has only {@link ExecutionITCaseTestConstants#DATA_COLUMN_NAMES} of type
+     * {@link ExecutionITCaseTestConstants#DATA_COLUMN_TYPES} columns.
      */
     private String nonPartitionedTablePath;
 
-    /**
-     * Schema for this table contains data columns
-     * {@link ExecutionITCaseTestConstants#DATA_COLUMN_NAMES} and col1, col2
-     * partition columns. Types of data columns are
-     * {@link ExecutionITCaseTestConstants#DATA_COLUMN_TYPES}
-     */
-    private String partitionedTablePath;
-
+    // TODO would have been nice to make a TableInfo class that contained the path (maybe a
+    //  generator so it is always random), column names, column types, so all this information
+    //  was coupled together. This class could be used for all IT tests where we use predefined
+    //  Tables.
     /**
      * Schema for this table has only
      * {@link ExecutionITCaseTestConstants#LARGE_TABLE_ALL_COLUMN_NAMES} of type
@@ -85,50 +90,35 @@ public class DeltaSourceTableITCase {
      */
     private String nonPartitionedLargeTablePath;
 
-    public static final RowType TEST_ROW_TYPE = new RowType(Arrays.asList(
-        new RowType.RowField("col1", new VarCharType(VarCharType.MAX_LENGTH)),
-        new RowType.RowField("col2", new VarCharType(VarCharType.MAX_LENGTH)),
-        new RowType.RowField("col3", new IntType())
-    ));
-
-    private static ExecutorService testWorkers;
-
-    private final MiniClusterWithClientResource miniClusterResource = buildCluster(PARALLELISM);
-
-    protected RowType testRowType;
-
     @BeforeAll
     public static void beforeAll() throws IOException {
-        testWorkers = Executors.newCachedThreadPool(r -> {
-            final Thread thread = new Thread(r);
-            thread.setUncaughtExceptionHandler((t, e) -> {
-                t.interrupt();
-                throw new RuntimeException(e);
-            });
-            return thread;
-        });
         TEMPORARY_FOLDER.create();
     }
 
     @AfterAll
     public static void afterAll() {
-        testWorkers.shutdownNow();
         TEMPORARY_FOLDER.delete();
+    }
+
+    public static void assertNoMoreColumns(List<Row> resultData, int extraColumnIndex) {
+        resultData.forEach(rowData ->
+            assertThrows(
+                ArrayIndexOutOfBoundsException.class,
+                () -> rowData.getField(extraColumnIndex),
+                "Found row with extra column."
+            )
+        );
     }
 
     @BeforeEach
     public void setUp() {
         try {
             miniClusterResource.before();
-
             nonPartitionedTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
             nonPartitionedLargeTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
-            partitionedTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
 
-            DeltaTestUtils.initTestForPartitionedTable(partitionedTablePath);
             DeltaTestUtils.initTestForNonPartitionedTable(nonPartitionedTablePath);
-            DeltaTestUtils.initTestForNonPartitionedLargeTable(
-                nonPartitionedLargeTablePath);
+            DeltaTestUtils.initTestForNonPartitionedLargeTable(nonPartitionedLargeTablePath);
         } catch (Exception e) {
             throw new RuntimeException("Weren't able to setup the test dependencies", e);
         }
@@ -139,103 +129,189 @@ public class DeltaSourceTableITCase {
         miniClusterResource.after();
     }
 
-    // TODO FLINK_SQL_PR2 Write test for streaming
-    // TODO FLINK_SQL_PR2 Write test for static partition
-    // TODO FLINK_SQL_PR2 with partitions from Delta Table
     @ParameterizedTest
-    @ValueSource(strings = {"", "batch"})
+    @ValueSource(strings = {"", "batch", "BATCH", "baTCH"})
     public void testBatchTableJob(String jobMode) throws Exception {
 
-        String sinkTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
-
         StreamTableEnvironment tableEnv = StreamTableEnvironment.create(
-            getTestStreamEnv(("streaming".equalsIgnoreCase(jobMode)))
+            getTestStreamEnv(false) // streamingMode = false
         );
 
+        // CREATE Source TABLE
         tableEnv.executeSql(
-            buildSourceTableSql(
-                nonPartitionedTablePath,
-                false,
-                false)
+            buildSourceTableSql(nonPartitionedTablePath, SMALL_TABLE_SCHEMA)
         );
-
-        tableEnv.executeSql(buildSinkTableSql(sinkTablePath));
 
         String connectorModeHint = StringUtils.isNullOrWhitespaceOnly(jobMode) ?
             "" : String.format("/*+ OPTIONS('mode' = '%s') */", jobMode);
 
-        String insertSql = String.format(
-            "INSERT INTO sinkTable SELECT * FROM sourceTable %s",
-            connectorModeHint);
-        tableEnv.executeSql(insertSql).await(30, TimeUnit.SECONDS);
+        String selectSql = String.format("SELECT * FROM sourceTable %s", connectorModeHint);
 
-        // TODO FLINK_SQL_PR2 check column values.
-        List<Integer> data = DeltaTestUtils.readParquetTable(sinkTablePath + "/");
-        System.out.println(data);
-        assertThat(data.size(), equalTo(2));
+        Table resultTable = tableEnv.sqlQuery(selectSql);
 
+        DataStream<Row> rowDataStream = tableEnv.toDataStream(resultTable);
+
+        List<Row> resultData = DeltaTestUtils.testBoundedStream(rowDataStream, miniClusterResource);
+
+        List<String> readNames =
+            resultData.stream()
+                .map(row -> row.getFieldAs(0).toString()).collect(Collectors.toList());
+
+        Set<String> readSurnames =
+            resultData.stream()
+                .map(row -> row.getFieldAs(1).toString())
+                .collect(Collectors.toSet());
+
+        Set<Integer> readAge =
+            resultData.stream().map(row -> (int) row.getFieldAs(2)).collect(Collectors.toSet());
+
+        // THEN
+        assertThat("Source read different number of rows that Delta Table have.",
+            resultData.size(),
+            equalTo(SMALL_TABLE_COUNT));
+
+        // check for column values
+        assertThat("Source produced different values for [name] column",
+            readNames,
+            equalTo(NAME_COLUMN_VALUES));
+
+        assertThat("Source produced different values for [surname] column",
+            readSurnames,
+            equalTo(SURNAME_COLUMN_VALUES));
+
+        assertThat("Source produced different values for [age] column", readAge,
+            equalTo(AGE_COLUMN_VALUES));
+
+        // Checking that we don't have more columns.
+        assertNoMoreColumns(resultData, 3);
     }
 
-    private String buildSinkTableSql(String tablePath) {
-        return String.format(
-            "CREATE TABLE sinkTable ("
-                + " name VARCHAR,"
-                + " surname VARCHAR,"
-                + " age INT"
-                + ") WITH ("
-                + " 'connector' = 'filesystem',"
-                + " 'path' = '%s',"
-                + " 'auto-compaction' = 'false',"
-                + " 'format' = 'parquet',"
-                + " 'sink.parallelism' = '3'"
-                + ")",
-            tablePath);
-    }
+    @ParameterizedTest
+    @ValueSource(strings = {"streaming", "STREAMING", "streamING"})
+    public void testStreamingTableJob(String jobMode) throws Exception {
 
-    private String buildSourceTableSql(
-        String tablePath,
-        boolean includeHadoopConfDir,
-        boolean isPartitioned) {
+        int numberOfTableUpdateBulks = 5;
+        int rowsPerTableUpdate = 5;
+        int initialTableSize = 2;
 
-        String resourcesDirectory = new File("src/test/resources/hadoop-conf").getAbsolutePath();
-        String hadoopConfDirPath = (includeHadoopConfDir ?
-            String.format(
-                " 'hadoop-conf-dir' = '%s',",
-                resourcesDirectory)
-            : ""
+        TestDescriptor testDescriptor = DeltaTestUtils.prepareTableUpdates(
+            nonPartitionedTablePath,
+            RowType.of(DATA_COLUMN_TYPES, DATA_COLUMN_NAMES),
+            initialTableSize,
+            new TableUpdateDescriptor(numberOfTableUpdateBulks, rowsPerTableUpdate)
         );
 
-        String partitionedClause = isPartitioned ? "PARTITIONED BY (col1, col3) " : "";
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(
+            getTestStreamEnv(true) // streamingMode = true
+        );
+
+        // CREATE Source TABLE
+        tableEnv.executeSql(
+            buildSourceTableSql(nonPartitionedTablePath, SMALL_TABLE_SCHEMA)
+        );
+
+        String connectorModeHint = StringUtils.isNullOrWhitespaceOnly(jobMode) ?
+            "" : String.format("/*+ OPTIONS('mode' = '%s') */", jobMode);
+
+        String selectSql = String.format("SELECT * FROM sourceTable %s", connectorModeHint);
+
+        Table resultTable = tableEnv.sqlQuery(selectSql);
+
+        DataStream<Row> rowDataStream = tableEnv.toDataStream(resultTable);
+
+        List<List<Row>> resultData = DeltaTestUtils.testContinuousStream(
+            FailoverType.NONE,
+            testDescriptor,
+            (FailCheck) readRows -> true,
+            rowDataStream,
+            miniClusterResource
+        );
+
+        int totalNumberOfRows = resultData.stream().mapToInt(List::size).sum();
+
+        // Each row has a unique column across all Delta table data. We are converting List or
+        // read rows to set of values for that unique column.
+        // If there were any duplicates or missing values we will catch them here by comparing
+        // size of that Set to expected number of rows.
+        Set<String> uniqueValues =
+            resultData.stream().flatMap(Collection::stream)
+                .map(row -> row.getFieldAs(1).toString())
+                .collect(Collectors.toSet());
+
+        // THEN
+        assertThat("Source read different number of rows that Delta Table have.",
+            totalNumberOfRows,
+            CoreMatchers.equalTo(initialTableSize + numberOfTableUpdateBulks * rowsPerTableUpdate)
+        );
+
+        assertThat("Source Produced Different Rows that were in Delta Table",
+            uniqueValues.size(),
+            CoreMatchers.equalTo(initialTableSize + numberOfTableUpdateBulks * rowsPerTableUpdate)
+        );
+    }
+
+    @Test
+    public void testSelectWithWhereFilter() throws Exception {
+
+        // GIVEN
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(
+            getTestStreamEnv(false) // streamingMode = false
+        );
+
+        // CREATE Source TABLE
+        tableEnv.executeSql(
+            buildSourceTableSql(nonPartitionedLargeTablePath, LARGE_TABLE_SCHEMA)
+        );
+
+        // WHEN
+        String selectSql = "SELECT * FROM sourceTable WHERE col1 > 500";
+
+        Table resultTable = tableEnv.sqlQuery(selectSql);
+
+        DataStream<Row> rowDataStream = tableEnv.toDataStream(resultTable);
+
+        List<Row> resultData = DeltaTestUtils.testBoundedStream(rowDataStream, miniClusterResource);
+
+        // THEN
+        List<Long> readCol1Values =
+            resultData.stream()
+                .map(row -> (long) row.getFieldAs(0))
+                .sorted()
+                .collect(Collectors.toList());
+
+        // THEN
+        // The table that we read has 1100 records, where col1 with sequence value from 0 to 1099.
+        // the WHERE query filters all records with col1 <= 500, so we expect 599 records
+        // produced by SELECT query.
+        assertThat("SELECT with WHERE read different number of rows that expected.",
+            resultData.size(),
+            equalTo(599)
+        );
+
+        assertThat("SELECT with WHERE read different unique values for column col1.",
+            readCol1Values.size(),
+            equalTo(599)
+        );
+
+        assertThat(readCol1Values.get(0), equalTo(501L));
+        assertThat(readCol1Values.get(readCol1Values.size() - 1), equalTo(1099L));
+
+        // Checking that we don't have more columns.
+        assertNoMoreColumns(resultData, 3);
+    }
+
+    private String buildSourceTableSql(String tablePath, String schemaString) {
 
         return String.format(
             "CREATE TABLE %s ("
-                + " name VARCHAR,"
-                + " surname VARCHAR,"
-                + " age INT"
+                + schemaString
                 + ") "
-                + partitionedClause
                 + "WITH ("
                 + " 'connector' = 'delta',"
-                + hadoopConfDirPath
                 + " 'table-path' = '%s'"
                 + ")",
             DeltaSourceTableITCase.TEST_SOURCE_TABLE_NAME,
             tablePath
         );
     }
-
-    private StreamExecutionEnvironment getTestStreamEnv(boolean streamingMode) {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
-
-        if (streamingMode) {
-            env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
-            env.enableCheckpointing(1000, CheckpointingMode.EXACTLY_ONCE);
-        } else {
-            env.setRuntimeMode(RuntimeExecutionMode.BATCH);
-        }
-
-        return env;
-    }
-
 }


### PR DESCRIPTION
Adding base Table/SQL support for Delta-Flink Source connector. The Table architecture for Flink connectors is showed on below diagram:

![image](https://user-images.githubusercontent.com/7932805/187198747-02943535-72a8-4cc7-ac1b-fb87a06592de.png)

This PR provides Delta specific implementation for:
- DynamicTableSourceFactory
- ScanTableSource
- ScanRuntimeProvider