### PR TITLE
Update sbt-assembly to fix Scala shading

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@
 
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.0")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 


### PR DESCRIPTION
- This PR upgrades `sbt-assembly` from `0.14.9` to `2.1.0`.
- The intention of this PR is to fix bugs in the underlying shading library that `sbt-assembly` uses - Jar Jar Links.
- The version used by `0.14.9` does not properly shade Scala libraries. Shaded Scala libraries will work properly at _runtime_ - however, if a shaded jar is used at compile time - any use of a shaded library will fail the compile with an error like the following (this example was run in the Scala Repl)

```
import shadedelta.com.github.mjakubowski84.parquet4s.ValueImplicits
ValueImplicits
```

```
<console>:14: error: Symbol 'term com.github.mjakubowski84.parquet4s' is missing from the classpath.
This symbol is required by ' <none>'.
Make sure that term parquet4s is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
A full rebuild may help if 'ValueImplicits.class' was compiled against an incompatible version of com.github.mjakubowski84.
```

Upgrading sbt-assembly fixes this error and allows the shaded class to be used in subsequent compilations