### PR TITLE
Respect writeStatsAsJson and writeStatsAsStruct during checkpoint

### DIFF
--- a/oss-compatibility-tests/src/test/scala/io/delta/standalone/internal/compatibility/tests/OSSCompatibilitySuite.scala
+++ b/oss-compatibility-tests/src/test/scala/io/delta/standalone/internal/compatibility/tests/OSSCompatibilitySuite.scala
@@ -25,12 +25,12 @@ import scala.collection.JavaConverters._
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.delta.{DeltaLog => OSSDeltaLog}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{DataType, StructType}
 
 import io.delta.standalone.{DeltaLog => StandaloneDeltaLog}
 
 import io.delta.standalone.internal.{DeltaLogImpl => InternalStandaloneDeltaLog}
-import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.types.{DataType, StructType}
 import io.delta.standalone.internal.util.{ComparisonUtil, FileNames}
 
 class OSSCompatibilitySuite extends OssCompatibilitySuiteBase with ComparisonUtil {

--- a/standalone/src/main/scala/io/delta/standalone/internal/DeltaConfig.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/DeltaConfig.scala
@@ -271,4 +271,27 @@ private[internal] object DeltaConfigs extends Logging {
     "",
     minimumProtocolVersion = Some(DeltaColumnMapping.MIN_PROTOCOL_VERSION),
     userConfigurable = false)
+
+  /**
+   * When enabled, we will write file statistics in the checkpoint in JSON format as the "stats"
+   * column.
+   */
+  val CHECKPOINT_WRITE_STATS_AS_JSON = buildConfig[Boolean](
+    "checkpoint.writeStatsAsJson",
+    "true",
+    _.toBoolean,
+    _ => true,
+    "needs to be a boolean.")
+
+  /**
+   * When enabled, we will write file statistics in the checkpoint in the struct format in the
+   * "stats_parsed" column. We will also write partition values as a struct as
+   * "partitionValues_parsed".
+   */
+  val CHECKPOINT_WRITE_STATS_AS_STRUCT = buildConfig[Option[Boolean]](
+    "checkpoint.writeStatsAsStruct",
+    null,
+    v => Option(v).map(_.toBoolean),
+    _ => true,
+    "needs to be a boolean.")
 }

--- a/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
@@ -33,7 +33,7 @@ import io.delta.standalone.actions.{AddFile => AddFileJ, Metadata => MetadataJ, 
 import io.delta.standalone.data.{CloseableIterator, RowRecord => RowParquetRecordJ}
 import io.delta.standalone.expressions.Expression
 
-import io.delta.standalone.internal.actions.{AddFile, InMemoryLogReplay, MemoryOptimizedLogReplay, Metadata, Parquet4sSingleActionWrapper, Protocol, RemoveFile, SetTransaction, SingleAction}
+import io.delta.standalone.internal.actions.{AddFile, InMemoryLogReplay, MemoryOptimizedLogReplay, Metadata, Parquet4sSingleActionWrapper, ParsedPartitionValuesCodec, Protocol, RemoveFile, SetTransaction, SingleAction}
 import io.delta.standalone.internal.data.CloseableParquetDataIterator
 import io.delta.standalone.internal.exception.DeltaErrors
 import io.delta.standalone.internal.logging.Logging
@@ -57,6 +57,7 @@ private[internal] class SnapshotImpl(
     val timestamp: Long) extends Snapshot with Logging {
 
   import SnapshotImpl._
+  import ParsedPartitionValuesCodec._
 
   private val memoryOptimizedLogReplay =
     new MemoryOptimizedLogReplay(files, deltaLog.store, hadoopConf, deltaLog.timezone)

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/MemoryOptimizedLogReplay.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/MemoryOptimizedLogReplay.scala
@@ -34,6 +34,7 @@ private[internal] class MemoryOptimizedLogReplay(
     logStore: LogStore,
     val hadoopConf: Configuration,
     timeZone: TimeZone) {
+  import ParsedPartitionValuesCodec._
 
   /**
    * @return a [[CloseableIterator]] of tuple (Action, isLoadedFromCheckpoint) in reverse

--- a/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/actions/actions.scala
@@ -19,7 +19,7 @@ package io.delta.standalone.internal.actions
 import java.net.URI
 import java.sql.Timestamp
 
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude, JsonRawValue}
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonIgnoreType, JsonInclude}
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.{JsonSerializer, SerializerProvider}
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
@@ -176,8 +176,11 @@ private[internal] sealed trait FileAction extends Action {
 /**
  * Used to encode the "partitionValues_parsed" field when writing AddFiles in checkpoints.
  */
-private[internal] case class ParsedPartitionValues(partitionSchema: StructType,
-  partitionValues: Map[String, String])
+@JsonIgnoreType
+private[internal] case class ParsedPartitionValues(
+  partitionSchema: StructType,
+  partitionValues: Map[String, String]
+)
 
 /**
  * Adds a new file to the table. When multiple [[AddFile]] file actions
@@ -191,10 +194,8 @@ private[internal] case class AddFile(
     size: Long,
     modificationTime: Long,
     dataChange: Boolean,
-    @JsonRawValue
     stats: String = null,
     tags: Map[String, String] = null,
-    @JsonIgnore
     partitionValues_parsed: ParsedPartitionValues = null) extends FileAction {
   require(path.nonEmpty)
 

--- a/standalone/src/test/scala/io/delta/standalone/internal/ActionSerializerSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/ActionSerializerSuite.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright (2020-present) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.standalone.internal
+
+import org.scalatest.FunSuite
+
+import io.delta.standalone.types.{IntegerType, StructType}
+
+import io.delta.standalone.internal.actions._
+
+class ActionSerializerSuite extends FunSuite {
+
+  roundTripCompare("Add",
+    AddFile("test", Map.empty, 1, 1, dataChange = true))
+  roundTripCompare("Add with partitions",
+    AddFile("test", Map("a" -> "1"), 1, 1, dataChange = true))
+  roundTripCompare("Add with stats",
+    AddFile("test", Map.empty, 1, 1, dataChange = true, stats = "stats"))
+  roundTripCompare("Add with tags",
+    AddFile("test", Map.empty, 1, 1, dataChange = true, tags = Map("a" -> "1")))
+  roundTripCompare("Add with empty tags",
+    AddFile("test", Map.empty, 1, 1, dataChange = true, tags = Map.empty))
+
+  test("partitionValues_parsed is not serialized") {
+    val addFile = AddFile("foo", Map("x" -> "b"), 0, 0, true)
+      .withPartitionValuesParsed(new StructType().add("x", new IntegerType))
+    assert(!addFile.json.contains("partitionValues_parsed"))
+    assert(Action.fromJson(addFile.json).asInstanceOf[AddFile].partitionValues_parsed == null)
+  }
+
+  roundTripCompare("Remove",
+    RemoveFile("test", Some(2)))
+
+  test("AddFile tags") {
+    val action1 =
+      AddFile(
+        path = "a",
+        partitionValues = Map.empty,
+        size = 1,
+        modificationTime = 2,
+        dataChange = false,
+        stats = null,
+        tags = Map("key1" -> "val1", "key2" -> "val2"))
+    val json1 =
+      """{
+        |  "add": {
+        |    "path": "a",
+        |    "partitionValues": {},
+        |    "size": 1,
+        |    "modificationTime": 2,
+        |    "dataChange": false,
+        |    "tags": {
+        |      "key1": "val1",
+        |      "key2": "val2"
+        |    }
+        |  }
+        |}""".stripMargin
+    assert(action1 === Action.fromJson(json1))
+    assert(action1.json === json1.replaceAll("\\s", ""))
+
+    val json2 =
+      """{
+        |  "add": {
+        |    "path": "a",
+        |    "partitionValues": {},
+        |    "size": 1,
+        |    "modificationTime": 2,
+        |    "dataChange": false,
+        |    "tags": {}
+        |  }
+        |}""".stripMargin
+    val action2 =
+      AddFile(
+        path = "a",
+        partitionValues = Map.empty,
+        size = 1,
+        modificationTime = 2,
+        dataChange = false,
+        stats = null,
+        tags = Map.empty)
+    assert(action2 === Action.fromJson(json2))
+    assert(action2.json === json2.replaceAll("\\s", ""))
+  }
+
+  test("remove file deserialization") {
+    val removeJson = RemoveFile("a", Some(2L)).json
+    assert(removeJson.contains(""""deletionTimestamp":2"""))
+    assert(!removeJson.contains("""delTimestamp"""))
+    val json1 = """{"remove":{"path":"a","deletionTimestamp":2,"dataChange":true}}"""
+    val json2 = """{"remove":{"path":"a","dataChange":false}}"""
+    assert(Action.fromJson(json1) === RemoveFile("a", Some(2L), dataChange = true))
+    assert(Action.fromJson(json2) === RemoveFile("a", None, dataChange = false))
+  }
+
+  roundTripCompare("SetTransaction",
+    SetTransaction("a", 1, Some(1234L)))
+
+  roundTripCompare("SetTransaction without lastUpdated",
+    SetTransaction("a", 1, None))
+
+  roundTripCompare("MetaData",
+    Metadata(
+      "id",
+      "table",
+      "testing",
+      Format("parquet", Map.empty),
+      new StructType().toJson,
+      Seq("a")))
+
+  test("deserialization of CommitInfo without tags") {
+    val expectedCommitInfo = CommitInfo(
+      time = 123L,
+      operation = "CONVERT",
+      operationParameters = Map.empty,
+      commandContext = Map.empty,
+      readVersion = Some(23),
+      isolationLevel = Some("SnapshotIsolation"),
+      isBlindAppend = Some(true),
+      operationMetrics = Some(Map("m1" -> "v1", "m2" -> "v2")),
+      userMetadata = Some("123"),
+      engineInfo = None)
+
+    // json of commit info actions without tag or engineInfo field
+    val json1 =
+      """{"commitInfo":{"timestamp":123,"operation":"CONVERT",""" +
+        """"operationParameters":{},"readVersion":23,""" +
+        """"isolationLevel":"SnapshotIsolation","isBlindAppend":true,""" +
+        """"operationMetrics":{"m1":"v1","m2":"v2"},"userMetadata":"123"}}""".stripMargin
+    assert(Action.fromJson(json1) === expectedCommitInfo)
+  }
+
+  private def roundTripCompare(name: String, actions: Action*) = {
+    test(name) {
+      val asJson = actions.map(_.json)
+      val asObjects = asJson.map(Action.fromJson)
+
+      assert(actions === asObjects)
+    }
+  }
+}

--- a/standalone/src/test/scala/io/delta/standalone/internal/CheckpointsSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/CheckpointsSuite.scala
@@ -1,0 +1,413 @@
+/*
+ * Copyright (2020-present) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.standalone.internal
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.hadoop.util.HadoopInputFile
+import org.apache.parquet.schema.{GroupType, MessageType, PrimitiveType}
+import org.apache.parquet.schema.LogicalTypeAnnotation._
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName._
+import org.scalatest.FunSuite
+
+import io.delta.standalone.{DeltaLog, Operation}
+import io.delta.standalone.actions.{Metadata => MetadataJ}
+import io.delta.standalone.types._
+
+import io.delta.standalone.internal.actions.{AddCDCFile, AddFile, RemoveFile}
+import io.delta.standalone.internal.util.FileNames
+import io.delta.standalone.internal.util.TestUtils._
+
+
+class CheckpointsSuite extends FunSuite {
+
+  import scala.collection.JavaConverters._
+
+  private val engineInfo = "test-engine-info"
+  private val manualUpdate = new Operation(Operation.Name.MANUAL_UPDATE)
+
+  private def getParquetSchema(checkpointPath: Path): MessageType = {
+    val parquetReader = ParquetFileReader.open(
+      HadoopInputFile.fromPath(checkpointPath, new Configuration()))
+    try {
+      val footer = parquetReader.getFooter
+      footer.getFileMetaData.getSchema
+    } finally {
+      parquetReader.close()
+    }
+  }
+
+  test("checkpoint does not contain CDC field or remove.tags") {
+    withTempDir { tempDir =>
+
+      val logPath = new Path(tempDir.getCanonicalPath, "_delta_log")
+      val log = DeltaLog.forTable(new Configuration(), tempDir.getCanonicalPath)
+
+      val txn = log.startTransaction()
+      txn.updateMetadata(
+        MetadataJ.builder()
+          .schema(new StructType().add("x", new IntegerType()))
+          .build())
+      txn.commit(AddFile("foo", Map(), 0, 0, dataChange = true) :: Nil, manualUpdate, engineInfo)
+
+      log.startTransaction().commit(
+        AddFile("foo2", Map(), 0, 0, dataChange = true) ::
+          RemoveFile("foo", Some(System.currentTimeMillis()),
+            extendedFileMetadata = true, tags = Map("foo" -> "value")) ::
+          AddCDCFile("changes", Map(), 0) :: Nil,
+        manualUpdate, engineInfo
+      )
+
+      log.update()
+      log.asInstanceOf[DeltaLogImpl].checkpoint()
+      val checkpointPath = FileNames.checkpointFileSingular(logPath, log.snapshot.getVersion)
+      val schema = getParquetSchema(checkpointPath)
+
+      val expectedParentCols = Set("txn", "add", "remove", "metaData", "protocol")
+      assert(schema.getFields.asScala.map(_.getName).toSet == expectedParentCols)
+      assert(
+        !schema.getType(Seq("remove"): _*).asInstanceOf[GroupType].containsField("tags"))
+    }
+  }
+
+  val tablePropertiesWithStructAndJsonStats = Seq(
+    Map(
+      DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_JSON.key -> "true",
+      DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_STRUCT.key -> "true"
+    ),
+    Map(
+      DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_STRUCT.key -> "true"
+    )
+  )
+
+  val tablePropertiesWithStructWithoutJsonStats = Seq(
+    Map(
+      DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_JSON.key -> "false",
+      DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_STRUCT.key -> "true"
+    )
+  )
+
+  val tablePropertiesWithoutStructWithJsonStats = Seq(
+    Map(
+      DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_JSON.key -> "true",
+      DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_STRUCT.key -> "false"
+    ),
+    Map(
+      DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_STRUCT.key -> "false"
+    )
+  )
+
+  val tablePropertiesWithoutStats = Seq(
+    Map(
+      DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_JSON.key -> "false",
+      DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_STRUCT.key -> "false"
+    )
+  )
+
+  /**
+   * Checks that the checkpoint schema is as expected.
+   * - Parent columns are "txn", "add", "remove", "metaData", "protocol"
+   * - Add schema has "path", "partitionValues", "size", "modificationTime", "dataChange", "tags"
+   *   and they are of the expected type
+   * - The *add* schema *does not* contains any of the `unexpectedAddCols`
+   * - The *overall* schema *does* contain all the `additionalCols` and are of the expected type
+   *
+   * - When `partitioned` = true and `customPartitionColumns` = None: a default partition column
+   *   [part INT] will be used.
+   */
+  private def testCheckpointSchema(
+      tableProperties: Map[String, String],
+      partitioned: Boolean,
+      additionalCols: Seq[(Array[String], PrimitiveType.PrimitiveTypeName)] = Seq.empty,
+      unexpectedAddCols: Seq[String] = Seq.empty,
+      customPartitionColumns: Option[Seq[(String, DataType)]] = None,
+      customPartitionValues: Option[Map[String, String]] = None): Unit = {
+
+    // If customPartitionColumns is provided, customPartitionValues must be provided
+    assert((customPartitionColumns.isEmpty && customPartitionValues.isEmpty) ||
+        (customPartitionColumns.nonEmpty && customPartitionValues.nonEmpty))
+    // If customPartitionColumns is provided, partitioned = true
+    assert(customPartitionColumns.isEmpty || partitioned)
+
+    withTempDir { tempDir =>
+
+      val (partCols, partitionValues) = if (partitioned) {
+        customPartitionColumns.getOrElse(Seq(("part", new IntegerType()))) ->
+          customPartitionValues.getOrElse(Map("part" -> "0"))
+      } else {
+        (Seq.empty, Map.empty[String, String])
+      }
+      val structType = new StructType(
+        Array(new StructField("x", new IntegerType())) ++
+          partCols.map(c => new StructField(c._1, c._2))
+      )
+
+      val log = DeltaLog.forTable(new Configuration(), tempDir.getCanonicalPath)
+      val txn = log.startTransaction()
+      txn.updateMetadata(MetadataJ.builder()
+        .schema(structType)
+        .partitionColumns(partCols.map(_._1).asJava)
+        .configuration(tableProperties.asJava)
+        .build()
+      )
+      txn.commit(AddFile("foo", partitionValues, 0, 0, dataChange = true, stats = "") :: Nil,
+        manualUpdate, engineInfo)
+      log.update()
+      log.asInstanceOf[DeltaLogImpl].checkpoint()
+
+      val checkpointPath = FileNames.checkpointFileSingular(
+        new Path(tempDir.getCanonicalPath, "_delta_log"), log.snapshot.getVersion)
+      val schema = getParquetSchema(checkpointPath)
+
+      // Check the parent schema
+      val expectedParentCols = Set("txn", "add", "remove", "metaData", "protocol")
+      assert(schema.getFields.asScala.map(_.getName).toSet == expectedParentCols)
+
+      // Check the add schema
+      val addType = schema.getType(Seq("add"): _*)
+      assert(addType.isInstanceOf[GroupType],
+        s"add column should be of group type but is: $addType")
+      val addGroup = addType.asInstanceOf[GroupType]
+
+      // These are of the form (name, LogicalTypeAnnotation, PrimitiveTypeName) since some columns
+      // either aren't a primitive type, or don't have a LogicalTypeAnnotation (i.e. dataChange)
+      val requiredAddCols = Seq(
+        ("path", Some(stringType()), Some(BINARY)),
+        ("partitionValues", Some(mapType()), None),
+        ("size", Some(intType(64, true)), Some(INT64)),
+        ("modificationTime", Some(intType(64, true)), Some(INT64)),
+        ("dataChange", None, Some(BOOLEAN)),
+        ("tags", Some(mapType()), None)
+      )
+
+      // Check for the expected required add columns
+      requiredAddCols.foreach {
+        case (expectedField, expectedLogicalType, expectedPrimitiveType) =>
+
+        assert(addGroup.containsField(expectedField))
+        // Check the data type
+        assert(expectedLogicalType.forall(
+          _ == addGroup.getType(expectedField).getLogicalTypeAnnotation))
+        assert(expectedPrimitiveType.forall(
+          _ == addGroup.getType(expectedField).asPrimitiveType().getPrimitiveTypeName))
+      }
+
+      // Check that the unexpectedAddCols do not exist
+      unexpectedAddCols.foreach { colName =>
+        assert(!addGroup.containsField(colName))
+      }
+
+      // Check for the existence and datatype of additionalCols
+      additionalCols.foreach { case (path, expectedDataType) =>
+        assert(schema.containsPath(path))
+        assert(expectedDataType ==
+          schema.getColumnDescription(path).getPrimitiveType.getPrimitiveTypeName)
+      }
+    }
+  }
+
+  test("checkpoint with struct and json stats - unpartitioned") {
+    tablePropertiesWithStructAndJsonStats.foreach { tblProperties =>
+      testCheckpointSchema(
+        tblProperties,
+        partitioned = false,
+        additionalCols = Seq((Array("add", "stats"), BINARY)),
+        unexpectedAddCols = Seq("partitionValues_parsed")
+      )
+    }
+  }
+
+  test("checkpoint with struct and without json stats - unpartitioned") {
+    tablePropertiesWithStructWithoutJsonStats.foreach { tblProperties =>
+      testCheckpointSchema(
+        tblProperties,
+        partitioned = false,
+        unexpectedAddCols = Seq("stats", "partitionValues_parsed")
+      )
+    }
+  }
+
+  test("checkpoint without struct and with json stats - unpartitioned") {
+    tablePropertiesWithoutStructWithJsonStats.foreach { tblProperties =>
+      testCheckpointSchema(
+        tblProperties,
+        partitioned = false,
+        additionalCols = Seq((Array("add", "stats"), BINARY)),
+        unexpectedAddCols = Seq("partitionValues_parsed")
+      )
+    }
+  }
+
+  test("checkpoint without struct and without json stats - unpartitioned") {
+    tablePropertiesWithoutStats.foreach { tblProperties =>
+      testCheckpointSchema(
+        tblProperties,
+        partitioned = false,
+        unexpectedAddCols = Seq("stats", "partitionValues_parsed")
+      )
+    }
+  }
+
+  test("checkpoint with struct and json stats - partitioned") {
+    tablePropertiesWithStructAndJsonStats.foreach { tblProperties =>
+      testCheckpointSchema(
+        tblProperties,
+        partitioned = true,
+        additionalCols = Seq(
+          (Array("add", "stats"), BINARY),
+          (Array("add", "partitionValues_parsed", "part"), INT32))
+      )
+    }
+  }
+
+  test("checkpoint with struct and without json stats - partitioned") {
+    tablePropertiesWithStructWithoutJsonStats.foreach { tblProperties =>
+      testCheckpointSchema(
+        tblProperties,
+        partitioned = true,
+        additionalCols = Seq((Array("add", "partitionValues_parsed", "part"), INT32)),
+        unexpectedAddCols = Seq("stats")
+      )
+    }
+  }
+
+  test("checkpoint without struct and with json stats - partitioned") {
+    tablePropertiesWithoutStructWithJsonStats.foreach { tblProperties =>
+      testCheckpointSchema(
+        tblProperties,
+        partitioned = true,
+        additionalCols = Seq((Array("add", "stats"), BINARY)),
+        unexpectedAddCols = Seq("partitionValues_parsed")
+      )
+    }
+  }
+
+  test("checkpoint without struct and without json stats - partitioned") {
+    tablePropertiesWithoutStats.foreach { tblProperties =>
+      testCheckpointSchema(
+        tblProperties,
+        partitioned = true,
+        unexpectedAddCols = Seq("stats", "partitionValues_parsed")
+      )
+    }
+  }
+
+  test("special characters") {
+    val weirdName1 = "part%!@#_$%^&*-"
+    val weirdName2 = "part?_.+<>|/"
+
+    tablePropertiesWithStructAndJsonStats.foreach { tblProperties =>
+      testCheckpointSchema(
+        tblProperties,
+        partitioned = true,
+        additionalCols = Seq(
+          (Array("add", "stats"), BINARY),
+          (Array("add", "partitionValues_parsed", weirdName1), INT32),
+          (Array("add", "partitionValues_parsed", weirdName2), INT32)
+        ),
+        customPartitionColumns =
+          Some(Seq((weirdName1, new IntegerType()), (weirdName2, new IntegerType()))),
+        customPartitionValues = Some(Map(weirdName1 -> "0", weirdName2 -> "0"))
+      )
+    }
+  }
+
+  test("timestamps as partition values") {
+    tablePropertiesWithStructAndJsonStats.foreach { tblProperties =>
+      testCheckpointSchema(
+        tblProperties,
+        partitioned = true,
+        additionalCols = Seq(
+          (Array("add", "stats"), BINARY),
+          (Array("add", "partitionValues_parsed", "time"), INT96)
+        ),
+        customPartitionColumns = Some(Seq(("time", new TimestampType()))),
+        customPartitionValues = Some(Map("time" -> "2012-12-31 16:00:10.011"))
+      )
+    }
+  }
+
+  test("null partition value") {
+    tablePropertiesWithStructAndJsonStats.foreach { tblProperties =>
+      testCheckpointSchema(
+        tblProperties,
+        partitioned = true,
+        additionalCols = Seq(
+          (Array("add", "stats"), BINARY),
+          (Array("add", "partitionValues_parsed", "part1"), INT32),
+          (Array("add", "partitionValues_parsed", "part2"), BINARY)
+        ),
+        customPartitionColumns =
+          Some(Seq(("part1", new IntegerType()), ("part2", new StringType()))),
+        customPartitionValues = Some(Map("part1" -> null, "part2" -> null))
+      )
+    }
+  }
+
+  test("all partition data types") {
+    tablePropertiesWithStructAndJsonStats.foreach { tblProperties =>
+      testCheckpointSchema(
+        tblProperties,
+        partitioned = true,
+        additionalCols = Seq(
+          (Array("add", "stats"), BINARY),
+          (Array("add", "partitionValues_parsed", "string"), BINARY),
+          (Array("add", "partitionValues_parsed", "long"), INT64),
+          (Array("add", "partitionValues_parsed", "int"), INT32),
+          (Array("add", "partitionValues_parsed", "short"), INT32),
+          (Array("add", "partitionValues_parsed", "byte"), INT32),
+          (Array("add", "partitionValues_parsed", "float"), FLOAT),
+          (Array("add", "partitionValues_parsed", "double"), DOUBLE),
+          (Array("add", "partitionValues_parsed", "decimal"), FIXED_LEN_BYTE_ARRAY),
+          (Array("add", "partitionValues_parsed", "boolean"), BOOLEAN),
+          (Array("add", "partitionValues_parsed", "binary"), BINARY),
+          (Array("add", "partitionValues_parsed", "date"), INT32),
+          (Array("add", "partitionValues_parsed", "timestamp"), INT96)
+        ),
+        customPartitionColumns = Some(Seq(
+          ("string", new StringType()),
+          ("long", new LongType()),
+          ("int", new IntegerType()),
+          ("short", new ShortType()),
+          ("byte", new ByteType()),
+          ("float", new FloatType()),
+          ("double", new DoubleType()),
+          ("decimal", new DecimalType(10, 0)),
+          ("boolean", new BooleanType()),
+          ("binary", new BinaryType()),
+          ("date", new DateType()),
+          ("timestamp", new TimestampType())
+        )),
+        customPartitionValues = Some(Map(
+          "string" -> "foo",
+          "long" -> "0",
+          "int" -> "0",
+          "short" -> "0",
+          "byte" -> "0",
+          "float" -> "0.1",
+          "double" -> "0.1",
+          "decimal" -> "1.0",
+          "boolean" -> "true",
+          "binary" -> "\\u0001",
+          "date" -> "2000-01-01",
+          "timestamp" -> "2000-01-01 00:00:00"
+        ))
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Overview
Updates standalone to respect table properties `checkpoint.writeStatsAsJson` and `checkpoint.writeStatsAsStruct`. Also makes a few fixes uncovered from adding the test suite
- Don't write the "cdc" or "commitInfo" fields (delta-spark does [here](https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala#L548))
- Don't write "remove.tags" (delta-spark does [here](https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala#L548))

Note: This PR includes writing the "add.partitionValues_parsed" field, but not "add.stats_parsed". This will be implemented in a later PR.

## Details

To omit fields from the checkpoint we use `SkippingParquetSchemaResolver`. Further detail on when we skip what fields are provided in the class doc for `Checkpoints.fieldsToSkip`.

To write the "add.partitionValues_parsed" field as a struct, we add a `partitionValues_parsed: ParsedPartitionValues ` field to the `AddFile` action. We introduce a custom encoder for `ParsedPartitionValues` that encodes the partition values as a `RowParquetRecord`.

## Testing

Adds a test suite `CheckpointSuite` and adds a test to `OSSCompatibilitySuite`.

I've also added a basic version of the `ActionSerializerSuite` copied from https://github.com/delta-io/delta/blob/master/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala to make sure we don't serialize the new addfile field. We can add the remaining tests to this suite in a follow-up PR.