### PR TITLE
Fixing powerbi connector tutorial

### DIFF
--- a/powerbi/README.md
+++ b/powerbi/README.md
@@ -35,7 +35,7 @@ let
     #"Filtered Rows" = Table.SelectRows(Source, each Text.StartsWith([Name], "powerbi_delta/FactInternetSales_part.delta/"))
 in
     #"Filtered Rows"
-    ```
+```
 
 6. Open your query that contains the function and select `Blob_Content` in the parameter `DeltaTableFolderContent`
 7. Click `Invoke`


### PR DESCRIPTION
The markdown was considering the items 6 to 8 in usage as they were part of the code as in per image below:

<img width="918" alt="image" src="https://user-images.githubusercontent.com/57838698/216201932-349e52b9-a282-4190-9418-0263f2a8eee9.png">

The readme file after changes:

<img width="915" alt="image" src="https://user-images.githubusercontent.com/57838698/216201815-25757950-2533-46a7-bbb7-1ef1570b16ee.png">

