### PR TITLE
Flink_1.16.1 - update Flink version to 1.16.1 for Flink connector.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -694,7 +694,7 @@ def flinkScalaVersion(scalaBinaryVersion: String): String = {
   }
 }
 
-val flinkVersion = "1.15.3"
+val flinkVersion = "1.16.1"
 lazy val flink = (project in file("flink"))
   .dependsOn(standaloneCosmetic % "provided")
   .enablePlugins(GenJavadocPlugin, JavaUnidocPlugin)

--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -59,7 +59,7 @@ lazy val helloWorld = (project in file("hello-world")) settings (
   extraMavenRepo
 )
 
-val flinkVersion = "1.15.3"
+val flinkVersion = "1.16.1"
 val flinkHadoopVersion = "3.1.0"
 lazy val flinkExample = (project in file("flink-example")) settings (
   name := "flink",

--- a/examples/flink-example/pom.xml
+++ b/examples/flink-example/pom.xml
@@ -29,7 +29,7 @@ limitations under the License.-->
         <staging.repo.url>""</staging.repo.url>
         <scala.main.version>2.12</scala.main.version>
         <connectors.version>0.6.0</connectors.version>
-        <flink-version>1.15.3</flink-version>
+        <flink-version>1.16.1</flink-version>
         <hadoop-version>3.1.0</hadoop-version>
         <log4j.version>2.12.1</log4j.version>
     </properties>

--- a/flink/README.md
+++ b/flink/README.md
@@ -331,7 +331,7 @@ Scala 2.12:
     <properties>
         <scala.main.version>2.12</scala.main.version>
         <delta-connectors-version>0.6.0</delta-connectors-version>
-        <flink-version>1.15.3</flink-version>
+        <flink-version>1.16.1</flink-version>
         <hadoop-version>3.1.0</hadoop-version>
     </properties>
 

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
@@ -56,7 +56,6 @@ import org.apache.flink.api.connector.sink.GlobalCommitter;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
-import org.apache.flink.connector.file.sink.StreamingExecutionFileSinkITCase;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
@@ -406,7 +405,7 @@ public class DeltaSinkStreamingExecutionITCase extends DeltaSinkExecutionITCaseB
 
     /**
      * Implementation idea and some functions is borrowed from 'StreamingExecutionTestSource' in
-     * {@link StreamingExecutionFileSinkITCase}
+     * {@code org.apache.flink.connector.file.sink.StreamingExecutionFileSinkITCase}
      */
     private static class DeltaStreamingExecutionTestSource
         extends RichParallelSourceFunction<RowData>

--- a/flink/src/test/java/io/delta/flink/sink/internal/writer/DeltaWriterTest.java
+++ b/flink/src/test/java/io/delta/flink/sink/internal/writer/DeltaWriterTest.java
@@ -39,7 +39,6 @@ import io.delta.flink.sink.utils.DeltaSinkTestUtils;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.connector.file.sink.writer.FileWriterTest;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.MetricGroup;
@@ -181,7 +180,9 @@ public class DeltaWriterTest {
     }
 
     /**
-     * Just following {@link FileWriterTest#testContextPassingNormalExecution()} here.
+     * Just following {@code org.apache.flink.connector.file.sink.writer
+     * .FileWriterTest#testContextPassingNormalExecution()}
+     * here.
      */
     @Test
     public void testContextPassingNormalExecution() throws Exception {
@@ -189,7 +190,9 @@ public class DeltaWriterTest {
     }
 
     /**
-     * Just following {@link FileWriterTest#testContextPassingNullTimestamp()} here.
+     * Just following {@code org.apache.flink.connector.file.sink.writer
+     * .FileWriterTest#testContextPassingNullTimestamp()}
+     * here.
      */
     @Test
     public void testContextPassingNullTimestamp() throws Exception {
@@ -320,7 +323,7 @@ public class DeltaWriterTest {
     }
 
     /**
-     * Borrowed from {@link org.apache.flink.connector.file.sink.writer.FileWriterTest}
+     * Borrowed from {@code org.apache.flink.connector.file.sink.writer.FileWriterTest}
      */
     private static class ContextImpl implements SinkWriter.Context {
         private final long watermark;
@@ -347,7 +350,7 @@ public class DeltaWriterTest {
     }
 
     /**
-     * Borrowed from {@link org.apache.flink.connector.file.sink.writer.FileWriterTest}
+     * Borrowed from {@code org.apache.flink.connector.file.sink.writer.FileWriterTest}
      */
     private static class ManuallyTriggeredProcessingTimeService
         implements Sink.ProcessingTimeService {


### PR DESCRIPTION
Update Flink version for Delta Flink connector to 1.16.1

No code/API changes were required. Only few minor Javadoc fixes where `@link` tag was used on Flink classes that become packaged protected in 1.16.1.

version update was verified by:
1. running CI build on Delta repository (unit tests including Integration tests with Minicluster)
2. manual execution of `connectors/examples/run_flink_examples.sh`
3. running sample Sink/Source job on real, Flink 1.16.1 docker based cluster

An example of batch Sink job:
![image](https://user-images.githubusercontent.com/7932805/217351525-ad419904-31cc-4c4f-b57c-71c5dc830d47.png)
[BatchSinkTable.zip](https://github.com/delta-io/connectors/files/10678883/BatchSinkTable.zip)






