### PR TITLE
Avoid null class loader in LogStoreProvider

### DIFF
--- a/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
@@ -55,8 +55,15 @@ private[internal] trait LogStoreProvider {
       new DelegatingLogStore(hadoopConf)
     } else {
       // scalastyle:off classforname
+      // Do not pass a null class loader
+      // - https://github.com/netty/netty/issues/7290
+      // - https://bugs.openjdk.java.net/browse/JDK-7008595
+      var loader = Thread.currentThread().getContextClassLoader
+      if (loader == null) {
+        loader = this.getClass().getClassLoader
+      }
       val logStoreClass =
-        Class.forName(className, true, Thread.currentThread().getContextClassLoader)
+        Class.forName(className, true, loader)
       // scalastyle:on classforname
 
       if (classOf[LogStore].isAssignableFrom(logStoreClass)) {

--- a/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
@@ -61,7 +61,7 @@ private[internal] trait LogStoreProvider {
       val classLoader = Option(Thread.currentThread().getContextClassLoader)
         .getOrElse(this.getClass().getClassLoader)
       val logStoreClass =
-        Class.forName(className, true, loader)
+        Class.forName(className, true, logStoreClass)
       // scalastyle:on classforname
 
       if (classOf[LogStore].isAssignableFrom(logStoreClass)) {


### PR DESCRIPTION
Class.forName passed a null class loader will use the bootstrap loader and not the system class loader. This happens when using the Armeria server for example.
Signed-off-by: Shannon Noe <snoe925@gmail.com>