### PR TITLE
[FlinkSQL_PR_3] - Delta catalog skeleton

### DIFF
--- a/flink/src/main/java/io/delta/flink/internal/table/BaseCatalog.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/BaseCatalog.java
@@ -1,0 +1,160 @@
+package io.delta.flink.internal.table;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.flink.table.catalog.AbstractCatalog;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.FunctionNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.factories.Factory;
+
+/**
+ * Base implementation of Flink catalog. This class handles Catalog operations for Delta tables that
+ * do not require interaction with _delta_log, for example view, database operations etc.
+ */
+public abstract class BaseCatalog extends AbstractCatalog {
+
+    protected final Catalog decoratedCatalog;
+
+    public BaseCatalog(
+            String name,
+            String defaultDatabase,
+            Catalog decoratedCatalog) {
+        super(name, defaultDatabase);
+
+        this.decoratedCatalog = decoratedCatalog;
+    }
+
+    //////////////////////////////////////
+    // Important, Delta related methods //
+    //////////////////////////////////////
+
+    @Override
+    public Optional<Factory> getFactory() {
+        // TODO FlinkSQL_PR_5
+        //return Optional.of(DeltaDynamicTableFactory.fromCatalog());
+        return Optional.empty();
+    }
+
+    // By design, we will remove only metastore information during drop table.
+    // No filesystem information (for example _delta_log folder) will be removed.
+    @Override
+    public void dropTable(ObjectPath tablePath, boolean ignoreIfNotExists)
+        throws TableNotExistException, CatalogException {
+        this.decoratedCatalog.dropTable(tablePath, ignoreIfNotExists);
+    }
+
+    /////////////////////////////////////////////////////
+    // Obvious, not Delta related pass-through methods //
+    /////////////////////////////////////////////////////
+
+    @Override
+    public void open() throws CatalogException {
+        this.decoratedCatalog.open();
+    }
+
+    @Override
+    public void close() throws CatalogException {
+        this.decoratedCatalog.close();
+    }
+
+    @Override
+    public List<String> listDatabases() throws CatalogException {
+        return this.decoratedCatalog.listDatabases();
+    }
+
+    @Override
+    public CatalogDatabase getDatabase(String databaseName)
+        throws DatabaseNotExistException, CatalogException {
+        return this.decoratedCatalog.getDatabase(databaseName);
+    }
+
+    @Override
+    public boolean databaseExists(String databaseName) throws CatalogException {
+        return this.decoratedCatalog.databaseExists(databaseName);
+    }
+
+    @Override
+    public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists)
+        throws DatabaseAlreadyExistException, CatalogException {
+        this.decoratedCatalog.createDatabase(name, database, ignoreIfExists);
+    }
+
+    @Override
+    public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade)
+        throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
+        this.decoratedCatalog.dropDatabase(name, ignoreIfNotExists, cascade);
+
+    }
+
+    @Override
+    public void alterDatabase(String name, CatalogDatabase newDatabase, boolean ignoreIfNotExists)
+        throws DatabaseNotExistException, CatalogException {
+        this.decoratedCatalog.alterDatabase(name, newDatabase, ignoreIfNotExists);
+    }
+
+    @Override
+    public List<String> listTables(String databaseName)
+        throws DatabaseNotExistException, CatalogException {
+        return this.decoratedCatalog.listTables(databaseName);
+    }
+
+    @Override
+    public void renameTable(ObjectPath tablePath, String newTableName, boolean ignoreIfNotExists)
+        throws TableNotExistException, TableAlreadyExistException, CatalogException {
+        this.decoratedCatalog.renameTable(tablePath, newTableName, ignoreIfNotExists);
+    }
+
+    @Override
+    public List<String> listViews(String databaseName)
+        throws DatabaseNotExistException, CatalogException {
+        return this.decoratedCatalog.listViews(databaseName);
+    }
+
+    @Override
+    public List<String> listFunctions(String dbName)
+        throws DatabaseNotExistException, CatalogException {
+        return this.decoratedCatalog.listFunctions(dbName);
+    }
+
+    @Override
+    public CatalogFunction getFunction(ObjectPath functionPath)
+        throws FunctionNotExistException, CatalogException {
+        return this.decoratedCatalog.getFunction(functionPath);
+    }
+
+    @Override
+    public boolean functionExists(ObjectPath functionPath) throws CatalogException {
+        return this.decoratedCatalog.functionExists(functionPath);
+    }
+
+    @Override
+    public void createFunction(ObjectPath functionPath, CatalogFunction function,
+        boolean ignoreIfExists)
+        throws FunctionAlreadyExistException, DatabaseNotExistException, CatalogException {
+        this.decoratedCatalog.createFunction(functionPath, function, ignoreIfExists);
+    }
+
+    @Override
+    public void alterFunction(ObjectPath functionPath, CatalogFunction newFunction,
+        boolean ignoreIfNotExists) throws FunctionNotExistException, CatalogException {
+        this.decoratedCatalog.alterFunction(functionPath, newFunction, ignoreIfNotExists);
+    }
+
+    @Override
+    public void dropFunction(ObjectPath functionPath, boolean ignoreIfNotExists)
+        throws FunctionNotExistException, CatalogException {
+        this.decoratedCatalog.dropFunction(functionPath, ignoreIfNotExists);
+    }
+
+}

--- a/flink/src/main/java/io/delta/flink/internal/table/CatalogProxy.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/CatalogProxy.java
@@ -1,0 +1,379 @@
+package io.delta.flink.internal.table;
+
+import java.util.List;
+
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogPartition;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.PartitionAlreadyExistsException;
+import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
+import org.apache.flink.table.catalog.exceptions.PartitionSpecInvalidException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
+import org.apache.flink.table.catalog.exceptions.TablePartitionedException;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
+import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * A proxy class that redirects calls to Delta Catalog or decorated catalog depending on table type.
+ */
+public class CatalogProxy extends BaseCatalog {
+
+    private final DeltaCatalog deltaCatalog;
+
+    public CatalogProxy(
+            String catalogName,
+            String defaultDatabase,
+            Catalog decoratedCatalog,
+            Configuration hadoopConfiguration) {
+        super(catalogName, defaultDatabase, decoratedCatalog);
+
+        this.deltaCatalog = new DeltaCatalog(catalogName, decoratedCatalog, hadoopConfiguration);
+    }
+
+    @Override
+    public CatalogBaseTable getTable(ObjectPath tablePath) throws TableNotExistException {
+        DeltaCatalogBaseTable catalogTable = getCatalogTableUnchecked(tablePath);
+        if (catalogTable.isDeltaTable()) {
+            return this.deltaCatalog.getTable(catalogTable);
+        } else {
+            return catalogTable.getCatalogTable();
+        }
+    }
+
+    @Override
+    public boolean tableExists(ObjectPath tablePath) throws CatalogException {
+
+        DeltaCatalogBaseTable catalogTable = getCatalogTable(tablePath);
+        if (catalogTable.isDeltaTable()) {
+            return this.deltaCatalog.tableExists(catalogTable);
+        } else {
+            return this.decoratedCatalog.tableExists(tablePath);
+        }
+    }
+
+    @Override
+    public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
+        throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
+
+        DeltaCatalogBaseTable catalogTable = new DeltaCatalogBaseTable(tablePath, table);
+        if (catalogTable.isDeltaTable()) {
+            this.deltaCatalog.createTable(catalogTable, ignoreIfExists);
+        } else {
+            this.decoratedCatalog.createTable(tablePath, table, ignoreIfExists);
+        }
+    }
+
+    @Override
+    public void alterTable(
+            ObjectPath tablePath,
+            CatalogBaseTable newTable,
+            boolean ignoreIfNotExists) throws TableNotExistException, CatalogException {
+
+        DeltaCatalogBaseTable newCatalogTable = new DeltaCatalogBaseTable(tablePath, newTable);
+        if (newCatalogTable.isDeltaTable()) {
+            this.deltaCatalog.alterTable(newCatalogTable);
+        } else {
+            this.decoratedCatalog.alterTable(tablePath, newTable, ignoreIfNotExists);
+        }
+    }
+
+    @Override
+    public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath)
+        throws TableNotExistException, TableNotPartitionedException, CatalogException {
+
+        DeltaCatalogBaseTable catalogTable = getCatalogTable(tablePath);
+        if (catalogTable.isDeltaTable()) {
+            // Delta standalone Metadata does not provide information about partition value.
+            // This information is needed to build CatalogPartitionSpec
+            throw new CatalogException(
+                "Delta table connector does not support partition listing.");
+        } else {
+            return this.decoratedCatalog.listPartitions(tablePath);
+        }
+    }
+
+    @Override
+    public List<CatalogPartitionSpec> listPartitions(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec)
+        throws CatalogException, TableNotPartitionedException, TableNotExistException,
+        PartitionSpecInvalidException {
+
+        DeltaCatalogBaseTable catalogTable = getCatalogTable(tablePath);
+        if (catalogTable.isDeltaTable()) {
+            // Delta standalone Metadata does not provide information about partition value.
+            // This information is needed to build CatalogPartitionSpec
+            throw new CatalogException(
+                "Delta table connector does not support partition listing.");
+        } else {
+            return this.decoratedCatalog.listPartitions(tablePath, partitionSpec);
+        }
+    }
+
+    @Override
+    public List<CatalogPartitionSpec> listPartitionsByFilter(
+            ObjectPath tablePath,
+            List<Expression> filters) throws TableNotExistException, TableNotPartitionedException,
+        CatalogException {
+
+        DeltaCatalogBaseTable catalogTable = getCatalogTable(tablePath);
+        if (catalogTable.isDeltaTable()) {
+            // Delta standalone Metadata does not provide information about partition value.
+            // This information is needed to build CatalogPartitionSpec
+            throw new CatalogException(
+                "Delta table connector does not support partition listing by filter.");
+        } else {
+            return this.decoratedCatalog.listPartitionsByFilter(tablePath, filters);
+        }
+    }
+
+    @Override
+    public CatalogPartition getPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+        throws PartitionNotExistException, CatalogException {
+
+        DeltaCatalogBaseTable catalogTable = getCatalogTable(tablePath);
+        if (catalogTable.isDeltaTable()) {
+            // Delta standalone Metadata does not provide information about partition value.
+            // This information is needed to build CatalogPartitionSpec
+            throw new CatalogException(
+                "Delta table connector does not support partition listing.");
+        } else {
+            return this.decoratedCatalog.getPartition(tablePath, partitionSpec);
+        }
+    }
+
+    @Override
+    public boolean partitionExists(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+        throws CatalogException {
+
+        DeltaCatalogBaseTable catalogTable = getCatalogTable(tablePath);
+        if (catalogTable.isDeltaTable()) {
+            // Delta standalone Metadata does not provide information about partition value.
+            // This information is needed to build CatalogPartitionSpec
+            throw new CatalogException(
+                "Delta table connector does not support partition listing.");
+        } else {
+            return this.decoratedCatalog.partitionExists(tablePath, partitionSpec);
+        }
+    }
+
+    @Override
+    public void createPartition(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogPartition partition,
+            boolean ignoreIfExists) throws TableNotExistException, TableNotPartitionedException,
+        PartitionSpecInvalidException, PartitionAlreadyExistsException, CatalogException {
+
+        DeltaCatalogBaseTable catalogTable = getCatalogTable(tablePath);
+        if (catalogTable.isDeltaTable()) {
+            throw new CatalogException(
+                "Delta table connector does not support partition creation.");
+        } else {
+            this.decoratedCatalog.createPartition(
+                tablePath,
+                partitionSpec,
+                partition,
+                ignoreIfExists
+            );
+        }
+    }
+
+    @Override
+    public void dropPartition(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            boolean ignoreIfNotExists) throws PartitionNotExistException, CatalogException {
+
+        DeltaCatalogBaseTable catalogTable = getCatalogTable(tablePath);
+        if (catalogTable.isDeltaTable()) {
+            throw new CatalogException(
+                "Delta table connector does not support partition drop operation.");
+        } else {
+            this.decoratedCatalog.dropPartition(
+                tablePath,
+                partitionSpec,
+                ignoreIfNotExists
+            );
+        }
+    }
+
+    @Override
+    public void alterPartition(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogPartition newPartition,
+            boolean ignoreIfNotExists) throws PartitionNotExistException, CatalogException {
+
+        DeltaCatalogBaseTable catalogTable = getCatalogTable(tablePath);
+        if (catalogTable.isDeltaTable()) {
+            throw new CatalogException(
+                "Delta table connector does not support alter partition operation.");
+        } else {
+            this.decoratedCatalog.alterPartition(
+                tablePath,
+                partitionSpec,
+                newPartition,
+                ignoreIfNotExists
+            );
+        }
+    }
+
+    @Override
+    public CatalogTableStatistics getTableStatistics(ObjectPath tablePath)
+        throws TableNotExistException, CatalogException {
+
+        if (getCatalogTable(tablePath).isDeltaTable()) {
+            // Table statistic call is used by flink-table-planner module to get Table schema, so
+            // we cannot throw from this method.
+            return CatalogTableStatistics.UNKNOWN;
+        } else {
+            return this.decoratedCatalog.getTableStatistics(tablePath);
+        }
+    }
+
+    @Override
+    public CatalogColumnStatistics getTableColumnStatistics(ObjectPath tablePath)
+        throws TableNotExistException, CatalogException {
+
+        if (getCatalogTable(tablePath).isDeltaTable()) {
+            // Table statistic call is used by flink-table-planner module to get Table schema, so
+            // we cannot throw from this method.
+            return CatalogColumnStatistics.UNKNOWN;
+        } else {
+            return this.decoratedCatalog.getTableColumnStatistics(tablePath);
+        }
+    }
+
+    @Override
+    public CatalogTableStatistics getPartitionStatistics(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec)
+        throws PartitionNotExistException, CatalogException {
+
+        if (getCatalogTable(tablePath).isDeltaTable()) {
+            throw new CatalogException(
+                "Delta table connector does not support partition statistics.");
+        } else {
+            return this.decoratedCatalog.getPartitionStatistics(tablePath, partitionSpec);
+        }
+    }
+
+    @Override
+    public CatalogColumnStatistics getPartitionColumnStatistics(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec)
+        throws PartitionNotExistException, CatalogException {
+
+        if (getCatalogTable(tablePath).isDeltaTable()) {
+            throw new CatalogException(
+                "Delta table connector does not support partition column statistics.");
+        } else {
+            return this.decoratedCatalog.getPartitionColumnStatistics(tablePath, partitionSpec);
+        }
+    }
+
+    @Override
+    public void alterTableStatistics(
+            ObjectPath tablePath,
+            CatalogTableStatistics tableStatistics,
+            boolean ignoreIfNotExists) throws TableNotExistException, CatalogException {
+
+        if (getCatalogTable(tablePath).isDeltaTable()) {
+            throw new CatalogException(
+                "Delta table connector does not support alter table statistics.");
+        } else {
+            this.decoratedCatalog.alterTableStatistics(
+                tablePath,
+                tableStatistics,
+                ignoreIfNotExists
+            );
+        }
+    }
+
+    @Override
+    public void alterTableColumnStatistics(
+            ObjectPath tablePath,
+            CatalogColumnStatistics columnStatistics,
+            boolean ignoreIfNotExists)
+            throws TableNotExistException, CatalogException, TablePartitionedException {
+
+        if (getCatalogTable(tablePath).isDeltaTable()) {
+            throw new CatalogException(
+                "Delta table connector does not support alter table column statistics.");
+        } else {
+            this.decoratedCatalog.alterTableColumnStatistics(
+                tablePath,
+                columnStatistics,
+                ignoreIfNotExists
+            );
+        }
+    }
+
+    @Override
+    public void alterPartitionStatistics(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogTableStatistics partitionStatistics,
+            boolean ignoreIfNotExists) throws PartitionNotExistException, CatalogException {
+
+        if (getCatalogTable(tablePath).isDeltaTable()) {
+            throw new CatalogException(
+                "Delta table connector does not support alter partition statistics.");
+        } else {
+            this.decoratedCatalog.alterPartitionStatistics(
+                tablePath,
+                partitionSpec,
+                partitionStatistics,
+                ignoreIfNotExists
+            );
+        }
+    }
+
+    @Override
+    public void alterPartitionColumnStatistics(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogColumnStatistics columnStatistics,
+            boolean ignoreIfNotExists) throws PartitionNotExistException, CatalogException {
+
+        if (getCatalogTable(tablePath).isDeltaTable()) {
+            throw new CatalogException(
+                "Delta table connector does not support alter partition column statistics.");
+        } else {
+            this.decoratedCatalog.alterPartitionColumnStatistics(
+                tablePath,
+                partitionSpec,
+                columnStatistics,
+                ignoreIfNotExists
+            );
+        }
+    }
+
+    private DeltaCatalogBaseTable getCatalogTable(ObjectPath tablePath) {
+        try {
+            return getCatalogTableUnchecked(tablePath);
+        } catch (TableNotExistException e) {
+            throw new CatalogException(e);
+        }
+    }
+
+    /**
+     * In some cases like {@link Catalog#getTable(ObjectPath)} Flink runtime expects
+     * TableNotExistException. In those cases we cannot throw checked exception because it could
+     * break some table planner logic.
+     */
+    private DeltaCatalogBaseTable getCatalogTableUnchecked(ObjectPath tablePath)
+        throws TableNotExistException {
+        CatalogBaseTable table = this.decoratedCatalog.getTable(tablePath);
+        return new DeltaCatalogBaseTable(tablePath, table);
+    }
+}

--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaCatalog.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaCatalog.java
@@ -1,0 +1,67 @@
+package io.delta.flink.internal.table;
+
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.util.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Delta Catalog implementation. This class executes calls to _delta_log for catalog operations such
+ * as createTable, getTable etc. This class also prepares, persists and uses data store in metastore
+ * using decorated catalog implementation.
+ * <p>
+ * Catalog operations that are not in scope of Delta Table or do not require _delta_log operations
+ * will be handled by {@link CatalogProxy} and {@link BaseCatalog} classes.
+ */
+public class DeltaCatalog {
+
+    private final String catalogName;
+
+    private final Catalog decoratedCatalog;
+
+    private final Configuration hadoopConfiguration;
+
+    DeltaCatalog(String catalogName, Catalog decoratedCatalog, Configuration hadoopConfiguration) {
+        this.catalogName = catalogName;
+        this.decoratedCatalog = decoratedCatalog;
+        this.hadoopConfiguration = hadoopConfiguration;
+
+        checkArgument(
+            !StringUtils.isNullOrWhitespaceOnly(catalogName),
+            "Catalog name cannot be null or empty."
+        );
+        checkArgument(decoratedCatalog != null,
+            "The decoratedCatalog cannot be null."
+        );
+        checkArgument(hadoopConfiguration != null,
+            "The Hadoop Configuration object - 'hadoopConfiguration' cannot be null."
+        );
+    }
+
+    public CatalogBaseTable getTable(DeltaCatalogBaseTable catalogTable) {
+        // TODO FlinkSQL_PR_4
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
+
+    public boolean tableExists(DeltaCatalogBaseTable catalogTable) throws CatalogException {
+        // TODO FlinkSQL_PR_4
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
+
+    public void createTable(DeltaCatalogBaseTable catalogTable, boolean ignoreIfExists)
+            throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
+
+        // TODO FlinkSQL_PR_4
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
+
+    public void alterTable(DeltaCatalogBaseTable newCatalogTable) throws CatalogException {
+
+        // TODO FlinkSQL_PR_4
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
+}

--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaCatalogBaseTable.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaCatalogBaseTable.java
@@ -1,0 +1,61 @@
+package io.delta.flink.internal.table;
+
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.factories.FactoryUtil;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Data object used by Delta Catalog implementation API that wraps Flink's {@link ObjectPath}
+ * represented by databaseName.tableName and {@link CatalogBaseTable} containing table properties
+ * and schema from DDL.
+ */
+public class DeltaCatalogBaseTable {
+
+    /**
+     * A database name and table name combo in catalog's metastore.
+     */
+    @Nonnull
+    private final ObjectPath tableCatalogPath;
+
+    /**
+     * A catalog table identified by {@link #tableCatalogPath}
+     */
+    @Nonnull
+    private final CatalogBaseTable catalogTable;
+
+    private final boolean isDeltaTable;
+
+    public DeltaCatalogBaseTable(ObjectPath tableCatalogPath, CatalogBaseTable catalogTable) {
+        checkNotNull(tableCatalogPath, "Object path cannot be null for DeltaCatalogBaseTable.");
+        checkNotNull(catalogTable, "Catalog table cannot be null for DeltaCatalogBaseTable.");
+        this.tableCatalogPath = tableCatalogPath;
+        this.catalogTable = catalogTable;
+
+        String connectorType = catalogTable.getOptions().get(FactoryUtil.CONNECTOR.key());
+        this.isDeltaTable = DeltaDynamicTableFactory.IDENTIFIER.equals(connectorType);
+    }
+
+    public ObjectPath getTableCatalogPath() {
+        return tableCatalogPath;
+    }
+
+    public CatalogBaseTable getCatalogTable() {
+        return catalogTable;
+    }
+
+    public boolean isDeltaTable() {
+        return isDeltaTable;
+    }
+
+    public Map<String, String> getOptions() {
+        return catalogTable.getOptions();
+    }
+
+    public String getDatabaseName() {
+        return tableCatalogPath.getDatabaseName();
+    }
+}

--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaCatalogFactory.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaCatalogFactory.java
@@ -1,0 +1,51 @@
+package io.delta.flink.internal.table;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CommonCatalogOptions;
+import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.factories.CatalogFactory;
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * The catalog factory implementation for Delta Catalog. This factory will be discovered by Flink
+ * runtime using Java’s Service Provider Interfaces (SPI) based on
+ * resources/META-INF/services/org.apache.flink.table.factories.Factory file.
+ * <p>
+ * Flink runtime will call {@link #createCatalog(Context)} method that will return new Delta Catalog
+ * instance.
+ */
+public class DeltaCatalogFactory implements CatalogFactory {
+
+    /**
+     * Property with default database name used for metastore entries.
+     */
+    public static final ConfigOption<String> DEFAULT_DATABASE =
+        ConfigOptions.key(CommonCatalogOptions.DEFAULT_DATABASE_KEY)
+            .stringType()
+            .defaultValue("default");
+
+    /**
+     * Creates and configures a Catalog using the given context
+     *
+     * @param context {@link Context} object containing catalog properties.
+     * @return new instance of Delta Catalog.
+     */
+    @Override
+    public Catalog createCatalog(Context context) {
+        // TODO FlinkSQL_PR_6 - inject proper decorated catalog based on catalog properties
+        Catalog decoratedCatalog = new GenericInMemoryCatalog(context.getName(), "default");
+        Configuration hadoopConfiguration =
+            HadoopUtils.getHadoopConfiguration(GlobalConfiguration.loadConfiguration());
+        return new CatalogProxy(context.getName(), "default", decoratedCatalog,
+            hadoopConfiguration);
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return "delta-catalog";
+    }
+
+}

--- a/flink/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -13,4 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+io.delta.flink.internal.table.DeltaCatalogFactory
 io.delta.flink.internal.table.DeltaDynamicTableFactory


### PR DESCRIPTION
Delta catalog skeleton implementation. 
This is a third PR aimed to implement https://github.com/delta-io/connectors/issues/238

**High level Catalog design:**
![image](https://user-images.githubusercontent.com/7932805/217529224-d841a1b8-8447-47c8-8dbc-afb2a9989eae.png)

**PR Overview:**
CatalogProxy - redirects catalog operations to straight to decorated catalog for non delta table operations and to DeltaCatalog for Delta table operations.

DeltaCatalogBase - base Catalog implementation for Delta tables. Contains logic for operations that do not require interactions with _delta_log.

DeltaCatalog - Catalog implementation for Delta tables. Handles Catalog operations that do require interaction with _delta_log.


**PR PLAN:**
[FlinkSQL_PR_1] Flink Delta Sink - Table API - MERGED
[FlinkSQL_PR_2] Flink Delta Source- Table API - MERGED
**[FlinkSQL_PR_3] Delta Catalog Skeleton - Delegate to InMmeory Catalog - IN PROGRESS**
[FlinkSQL_PR_4] Delta Catalog - interactions with Delta Log
[FlinkSQL_PR_5] Delta Catalog - Restrict Table factory to work only with Delta Catalog
[FlinkSQL_PR_6] Delta Catalog - DDL/Query hint validation
[FlinkSQL_PR_7] Delta Catalog - support for Hive metastore/delegate to hive catalog.