### PR TITLE
[FlinkSQL_PR_4] - Delta catalog interactions with DeltaLog. CreateTable and GetTable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -754,7 +754,7 @@ lazy val flink = (project in file("flink"))
     Compile / sourceGenerators += Def.task {
       val file = (Compile / sourceManaged).value / "meta" / "Meta.java"
       IO.write(file,
-        s"""package io.delta.flink.sink.internal.committer;
+        s"""package io.delta.flink.internal;
            |
            |final class Meta {
            |  public static final String FLINK_VERSION = "${flinkVersion}";

--- a/flink/src/main/java/io/delta/flink/internal/ConnectorUtils.java
+++ b/flink/src/main/java/io/delta/flink/internal/ConnectorUtils.java
@@ -1,9 +1,16 @@
 package io.delta.flink.internal;
 
+import java.util.HashSet;
+import java.util.List;
+
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 public class ConnectorUtils {
+
+    public static final String ENGINE_INFO =
+        "flink-engine/" + io.delta.flink.internal.Meta.FLINK_VERSION +
+            " flink-delta-connector/" + io.delta.flink.internal.Meta.CONNECTOR_VERSION;
 
     /**
      * Given a path `child`: 1. Returns `child` if the path is already relative 2. Tries
@@ -28,6 +35,10 @@ public class ConnectorUtils {
             }
         }
         return child.toString();
+    }
+
+    public static <T> boolean listEqualsIgnoreOrder(List<T> list1, List<T> list2) {
+        return new HashSet<>(list1).equals(new HashSet<>(list2));
     }
 
 }

--- a/flink/src/main/java/io/delta/flink/internal/table/BaseCatalog.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/BaseCatalog.java
@@ -41,7 +41,7 @@ public abstract class BaseCatalog extends AbstractCatalog {
 
     @Override
     public Optional<Factory> getFactory() {
-        // TODO FlinkSQL_PR_5
+        // TODO FlinkSQL_PR_7
         //return Optional.of(DeltaDynamicTableFactory.fromCatalog());
         return Optional.empty();
     }

--- a/flink/src/main/java/io/delta/flink/internal/table/CatalogExceptionHelper.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/CatalogExceptionHelper.java
@@ -1,0 +1,114 @@
+package io.delta.flink.internal.table;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.StringJoiner;
+
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+
+import io.delta.standalone.actions.Metadata;
+import io.delta.standalone.types.StructType;
+
+// TODO DC - consider extending CatalogException for more concrete types like
+//  "DeltaSchemaMismatchException" etc.
+public final class CatalogExceptionHelper {
+
+    private CatalogExceptionHelper() {}
+
+    static CatalogException deltaLogAndDdlSchemaMismatchException(
+            ObjectPath catalogTablePath,
+            String deltaTablePath,
+            Metadata deltaMetadata,
+            StructType ddlDeltaSchema,
+            List<String> ddlPartitions) {
+
+        String deltaSchemaString = (deltaMetadata.getSchema() == null)
+            ? "null"
+            : deltaMetadata.getSchema().getTreeString();
+
+        return new CatalogException(
+            String.format(
+                " Delta table [%s] from filesystem path [%s] has different schema or partition "
+                    + "spec that one defined in CREATE TABLE DDL.\n"
+                    + "DDL schema:\n[%s],\nDelta table schema:\n[%s]\n"
+                    + "DDL partition spec:\n[%s],\nDelta Log partition spec\n[%s]\n",
+                catalogTablePath,
+                deltaTablePath,
+                ddlDeltaSchema.getTreeString(),
+                deltaSchemaString,
+                ddlPartitions,
+                deltaMetadata.getPartitionColumns())
+        );
+    }
+
+    public static CatalogException mismatchedDdlOptionAndDeltaTablePropertyException(
+            ObjectPath catalogTablePath,
+            List<MismatchedDdlOptionAndDeltaTableProperty> invalidOptions) {
+
+        StringJoiner invalidOptionsString = new StringJoiner("\n");
+        for (MismatchedDdlOptionAndDeltaTableProperty invalidOption : invalidOptions) {
+            invalidOptionsString.add(
+                String.join(
+                    " | ",
+                    invalidOption.optionName,
+                    invalidOption.ddlOptionValue,
+                    invalidOption.deltaLogPropertyValue
+                )
+            );
+        }
+
+        return new CatalogException(
+            String.format(
+                "Invalid DDL options for table [%s]. "
+                    + "DDL options for Delta table connector cannot override table properties "
+                    + "already defined in _delta_log.\n"
+                    + "DDL option name | DDL option value | Delta option value \n%s",
+                catalogTablePath.getFullName(),
+                invalidOptionsString
+            )
+        );
+    }
+
+    public static CatalogException unsupportedColumnType(Collection<Column> unsupportedColumns) {
+        StringJoiner sj = new StringJoiner("\n");
+        for (Column unsupportedColumn : unsupportedColumns) {
+            sj.add(
+                String.join(
+                    " -> ",
+                    unsupportedColumn.getName(),
+                    unsupportedColumn.getClass().getSimpleName()
+                )
+            );
+        }
+
+        return new CatalogException(String.format(
+            "Table definition contains unsupported column types. "
+                + "Currently, only physical columns are supported by Delta Flink connector.\n"
+                + "Invalid columns and types:\n%s", sj)
+        );
+    }
+
+    /**
+     * A container class that contains DDL and _delta_log property values for given DDL option.
+     */
+    public static class MismatchedDdlOptionAndDeltaTableProperty {
+
+        private final String optionName;
+
+        private final String ddlOptionValue;
+
+        private final String deltaLogPropertyValue;
+
+        public MismatchedDdlOptionAndDeltaTableProperty(
+                String optionName,
+                String ddlOptionValue,
+                String deltaLogPropertyValue) {
+            this.optionName = optionName;
+            this.ddlOptionValue = ddlOptionValue;
+            this.deltaLogPropertyValue = deltaLogPropertyValue;
+        }
+    }
+
+}

--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaCatalog.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaCatalog.java
@@ -1,13 +1,30 @@
 package io.delta.flink.internal.table;
 
+import java.util.List;
+import java.util.Map;
+
+import io.delta.flink.internal.table.DeltaCatalogTableHelper.DeltaMetastoreTable;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+import io.delta.standalone.DeltaLog;
+import io.delta.standalone.Operation;
+import io.delta.standalone.actions.Metadata;
+import io.delta.standalone.types.StructType;
 
 /**
  * Delta Catalog implementation. This class executes calls to _delta_log for catalog operations such
@@ -21,14 +38,32 @@ public class DeltaCatalog {
 
     private final String catalogName;
 
+    /**
+     * A Flink's {@link Catalog} implementation to which all Metastore related actions will be
+     * redirected. The {@link DeltaCatalog} will not call {@link Catalog#open()} on this instance.
+     * If it is required to call this method it should be done before passing this reference to
+     * {@link DeltaCatalog}.
+     */
     private final Catalog decoratedCatalog;
 
-    private final Configuration hadoopConfiguration;
+    private final Configuration hadoopConf;
 
-    DeltaCatalog(String catalogName, Catalog decoratedCatalog, Configuration hadoopConfiguration) {
+    /**
+     * Creates instance of {@link DeltaCatalog} for given decorated catalog and catalog name.
+     *
+     * @param catalogName         catalog name.
+     * @param decoratedCatalog    A Flink's {@link Catalog} implementation to which all Metastore
+     *                            related actions will be redirected. The {@link DeltaCatalog} will
+     *                            not call {@link Catalog#open()} on this instance. If it is
+     *                            required to call this method it should be done before passing this
+     *                            reference to {@link DeltaCatalog}.
+     * @param hadoopConf The {@link Configuration} object that will be used for {@link
+     *                            DeltaLog} initialization.
+     */
+    DeltaCatalog(String catalogName, Catalog decoratedCatalog, Configuration hadoopConf) {
         this.catalogName = catalogName;
         this.decoratedCatalog = decoratedCatalog;
-        this.hadoopConfiguration = hadoopConfiguration;
+        this.hadoopConf = hadoopConf;
 
         checkArgument(
             !StringUtils.isNullOrWhitespaceOnly(catalogName),
@@ -37,31 +72,220 @@ public class DeltaCatalog {
         checkArgument(decoratedCatalog != null,
             "The decoratedCatalog cannot be null."
         );
-        checkArgument(hadoopConfiguration != null,
+        checkArgument(hadoopConf != null,
             "The Hadoop Configuration object - 'hadoopConfiguration' cannot be null."
         );
     }
 
-    public CatalogBaseTable getTable(DeltaCatalogBaseTable catalogTable) {
-        // TODO FlinkSQL_PR_4
-        throw new UnsupportedOperationException("Not yet implemented.");
-    }
-
-    public boolean tableExists(DeltaCatalogBaseTable catalogTable) throws CatalogException {
-        // TODO FlinkSQL_PR_4
-        throw new UnsupportedOperationException("Not yet implemented.");
-    }
-
+    /**
+     * Creates a new table in metastore and _delta_log if not already exists under given table Path.
+     * The information stored in metastore will contain only catalog path (database.tableName) and
+     * connector type. DDL options and table schema will be stored in _delta_log.
+     * <p>
+     * If _delta_log already exists under DDL's table-path option this method will throw an
+     * exception if DDL scheme does not match _delta_log schema or DDL options override existing
+     * _delta_log table properties or Partition specification defined in `PARTITION BY` does not
+     * match _delta_log partition specification.
+     * <p>
+     * <p>
+     * The framework will make sure to call this method with fully validated ResolvedCatalogTable or
+     * ResolvedCatalogView.
+     *
+     * @param catalogTable   the {@link DeltaCatalogBaseTable} with describing new table that should
+     *                       be added to the catalog.
+     * @param ignoreIfExists specifies behavior when a table or view already exists at the given
+     *                       path: if set to false, it throws a TableAlreadyExistException, if set
+     *                       to true, do nothing.
+     * @throws TableAlreadyExistException if table already exists and ignoreIfExists is false
+     * @throws DatabaseNotExistException  if the database in tablePath doesn't exist
+     * @throws CatalogException           in case of any runtime exception
+     */
     public void createTable(DeltaCatalogBaseTable catalogTable, boolean ignoreIfExists)
-            throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
+        throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
 
-        // TODO FlinkSQL_PR_4
-        throw new UnsupportedOperationException("Not yet implemented.");
+        checkNotNull(catalogTable);
+        ObjectPath tableCatalogPath = catalogTable.getTableCatalogPath();
+        // First we need to check if table exists in Metastore and if so, throw exception.
+        if (this.decoratedCatalog.tableExists(tableCatalogPath) && !ignoreIfExists) {
+            throw new TableAlreadyExistException(this.catalogName, tableCatalogPath);
+        }
+
+        if (!databaseExists(catalogTable.getDatabaseName())) {
+            throw new DatabaseNotExistException(
+                this.catalogName,
+                catalogTable.getDatabaseName()
+            );
+        }
+
+        Map<String, String> ddlOptions = catalogTable.getOptions();
+        String deltaTablePath = ddlOptions.get(DeltaTableConnectorOptions.TABLE_PATH.key());
+        if (StringUtils.isNullOrWhitespaceOnly(deltaTablePath)) {
+            throw new CatalogException("Path to Delta table cannot be null or empty.");
+        }
+
+        // TODO FlinkSQL_PR_5 add DDL option validation
+        // DeltaCatalogTableHelper.validateDdlOptions(ddlOptions);
+        // Map<String, String> deltaDdlOptions =
+        //    DeltaCatalogTableHelper.filterMetastoreDdlOptions(ddlOptions);
+
+        CatalogBaseTable table = catalogTable.getCatalogTable();
+
+        // Get Partition columns from DDL;
+        List<String> ddlPartitionColumns = ((CatalogTable) table).getPartitionKeys();
+
+        // Get Delta schema from Flink DDL.
+        StructType ddlDeltaSchema =
+            DeltaCatalogTableHelper.resolveDeltaSchemaFromDdl((ResolvedCatalogTable) table);
+
+        DeltaLog deltaLog = DeltaLog.forTable(hadoopConf, deltaTablePath);
+        if (deltaLog.tableExists()) {
+            // Table was not present in metastore however it is present on Filesystem, we have to
+            // verify if schema, partition spec and properties stored in _delta_log match with DDL.
+            Metadata deltaMetadata = deltaLog.update().getMetadata();
+
+            // Validate ddl schema and partition spec matches _delta_log's.
+            DeltaCatalogTableHelper.validateDdlSchemaAndPartitionSpecMatchesDelta(
+                deltaTablePath,
+                tableCatalogPath,
+                ddlPartitionColumns,
+                ddlDeltaSchema,
+                deltaMetadata
+            );
+
+            // Add new properties to Delta's metadata.
+            // Throw if DDL Delta table properties override previously defined properties from
+            // _delta_log.
+            Map<String, String> deltaLogProperties =
+                DeltaCatalogTableHelper.prepareDeltaTableProperties(
+                    ddlOptions, // TODO FlinkSQL_PR_5 use deltaDdlOptions here
+                    tableCatalogPath,
+                    deltaMetadata,
+                    false // allowOverride = false
+                );
+
+            // deltaLogProperties will have same properties than original metadata + new one,
+            // defined in DDL. In that case we want to update _delta_log metadata.
+            if (deltaLogProperties.size() != deltaMetadata.getConfiguration().size()) {
+                Metadata updatedMetadata = deltaMetadata.copyBuilder()
+                    .configuration(deltaLogProperties)
+                    .build();
+
+                // add properties to _delta_log
+                DeltaCatalogTableHelper
+                    .commitToDeltaLog(
+                        deltaLog,
+                        updatedMetadata,
+                        Operation.Name.SET_TABLE_PROPERTIES
+                );
+            }
+
+            // Add table to metastore
+            DeltaMetastoreTable metastoreTable =
+                DeltaCatalogTableHelper.prepareMetastoreTable(table, deltaTablePath);
+            this.decoratedCatalog.createTable(tableCatalogPath, metastoreTable, ignoreIfExists);
+        } else {
+            // Table does not exist on filesystem, we have to create a new _delta_log
+            Metadata metadata = Metadata.builder()
+                .schema(ddlDeltaSchema)
+                .partitionColumns(ddlPartitionColumns)
+                .configuration(ddlOptions) // TODO FlinkSQL_PR_5 use deltaDdlOptions here
+                .name(tableCatalogPath.getObjectName())
+                .build();
+
+            // create _delta_log
+            DeltaCatalogTableHelper.commitToDeltaLog(
+                deltaLog,
+                metadata,
+                Operation.Name.CREATE_TABLE
+            );
+
+            DeltaMetastoreTable metastoreTable =
+                DeltaCatalogTableHelper.prepareMetastoreTable(table, deltaTablePath);
+
+            // add table to metastore
+            this.decoratedCatalog.createTable(tableCatalogPath, metastoreTable, ignoreIfExists);
+        }
+    }
+
+    /**
+     * Returns a {@link CatalogBaseTable} identified by the given
+     * {@link DeltaCatalogBaseTable#getCatalogTable()}.
+     * This method assumes that provided {@link DeltaCatalogBaseTable#getCatalogTable()} table
+     * already exists in metastore hence no extra metastore checks will be executed.
+     *
+     * @throws TableNotExistException if the target does not exist
+     */
+    public CatalogBaseTable getTable(DeltaCatalogBaseTable catalogTable)
+            throws TableNotExistException {
+        CatalogBaseTable metastoreTable = catalogTable.getCatalogTable();
+
+        String tablePath =
+            metastoreTable.getOptions().get(DeltaTableConnectorOptions.TABLE_PATH.key());
+
+        DeltaLog deltaLog = DeltaLog.forTable(this.hadoopConf, tablePath);
+        if (!deltaLog.tableExists()) {
+            // TableNotExistException does not accept custom message, but we would like to meet
+            // API contracts from Flink's Catalog::getTable interface and throw
+            // TableNotExistException but with information that what was missing was _delta_log.
+            throw new TableNotExistException(
+                this.catalogName,
+                catalogTable.getTableCatalogPath(),
+                new CatalogException(
+                    String.format(
+                        "Table %s exists in metastore but _delta_log was not found under path %s",
+                        catalogTable.getTableCatalogPath().getFullName(),
+                        tablePath
+                    )
+                )
+            );
+        }
+        Metadata deltaMetadata = deltaLog.update().getMetadata();
+        StructType deltaSchema = deltaMetadata.getSchema();
+        if (deltaSchema == null) {
+            // This should not happen, but if it did for some reason it mens there is something
+            // wong with _delta_log.
+            throw new CatalogException(String.format(""
+                    + "Delta schema is null for table %s and table path %s. Please contact your "
+                    + "administrator.",
+                catalogTable.getCatalogTable(),
+                tablePath
+            ));
+        }
+
+        Pair<String[], DataType[]> flinkTypesFromDelta =
+            DeltaCatalogTableHelper.resolveFlinkTypesFromDelta(deltaSchema);
+
+        return CatalogTable.of(
+            Schema.newBuilder()
+                .fromFields(flinkTypesFromDelta.getKey(), flinkTypesFromDelta.getValue())
+                .build(), // Table Schema is not stored in metastore, we take it from _delta_log.
+            metastoreTable.getComment(),
+            deltaMetadata.getPartitionColumns(),
+            metastoreTable.getOptions()
+        );
+    }
+
+    /**
+     * Checks if _delta_log folder exists for table described by {@link
+     * DeltaCatalogBaseTable#getCatalogTable()} metastore entry. This method assumes that table
+     * exists in metastore thus not execute any checks there.
+     *
+     * @return true if _delta_log exists for given {@link DeltaCatalogBaseTable}, false if not.
+     */
+    public boolean tableExists(DeltaCatalogBaseTable catalogTable) {
+        CatalogBaseTable metastoreTable = catalogTable.getCatalogTable();
+        String deltaTablePath =
+            metastoreTable.getOptions().get(DeltaTableConnectorOptions.TABLE_PATH.key());
+        return DeltaLog.forTable(hadoopConf, deltaTablePath).tableExists();
     }
 
     public void alterTable(DeltaCatalogBaseTable newCatalogTable) throws CatalogException {
 
-        // TODO FlinkSQL_PR_4
+        // TODO FlinkSQL_PR_6
         throw new UnsupportedOperationException("Not yet implemented.");
+    }
+
+    private boolean databaseExists(String databaseName) {
+        return this.decoratedCatalog.databaseExists(databaseName);
     }
 }

--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaCatalogFactory.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaCatalogFactory.java
@@ -35,7 +35,7 @@ public class DeltaCatalogFactory implements CatalogFactory {
      */
     @Override
     public Catalog createCatalog(Context context) {
-        // TODO FlinkSQL_PR_6 - inject proper decorated catalog based on catalog properties
+        // TODO FlinkSQL_PR_9 - inject proper decorated catalog based on catalog properties
         Catalog decoratedCatalog = new GenericInMemoryCatalog(context.getName(), "default");
         Configuration hadoopConfiguration =
             HadoopUtils.getHadoopConfiguration(GlobalConfiguration.loadConfiguration());

--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaCatalogTableHelper.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaCatalogTableHelper.java
@@ -1,0 +1,364 @@
+package io.delta.flink.internal.table;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.delta.flink.internal.ConnectorUtils;
+import io.delta.flink.internal.table.CatalogExceptionHelper.MismatchedDdlOptionAndDeltaTableProperty;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.Column.ComputedColumn;
+import org.apache.flink.table.catalog.Column.MetadataColumn;
+import org.apache.flink.table.catalog.Column.PhysicalColumn;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.LogicalTypeDataTypeConverter;
+
+import io.delta.standalone.DeltaLog;
+import io.delta.standalone.Operation;
+import io.delta.standalone.OptimisticTransaction;
+import io.delta.standalone.actions.Metadata;
+import io.delta.standalone.types.StructField;
+import io.delta.standalone.types.StructType;
+
+public final class DeltaCatalogTableHelper {
+
+    private DeltaCatalogTableHelper() {}
+
+    /**
+     * Converts Delta's {@link StructType} to Flink's {@link DataType}. The turned objet is a {@link
+     * Pair} where {@link Pair#getLeft()} returns an array of column names extracted from given
+     * tableSchema Struct, and {@link Pair#getRight()} returns an array of Flink's {@link DataType}
+     * objects converted from given tableSchema Struct.
+     *
+     * @param tableSchema Delta's {@link StructType} that will be converted to FLink's {@link
+     *                    DataType} array with column names.
+     * @return a pair of column names and Flink {@link DataType} converted from given {@link
+     * StructType}
+     */
+    public static Pair<String[], DataType[]> resolveFlinkTypesFromDelta(StructType tableSchema) {
+        StructField[] fields = tableSchema.getFields();
+        String[] columnNames = new String[fields.length];
+        DataType[] columnTypes = new DataType[fields.length];
+        int i = 0;
+        for (StructField field : fields) {
+            columnNames[i] = field.getName();
+            columnTypes[i] = LogicalTypeDataTypeConverter.toDataType(
+                io.delta.flink.source.internal.SchemaConverter.toFlinkDataType(field.getDataType(),
+                    field.isNullable()));
+            i++;
+        }
+
+        return Pair.of(columnNames, columnTypes);
+    }
+
+    public static StructType resolveDeltaSchemaFromDdl(ResolvedCatalogTable table) {
+
+        // contains physical, computed and metadata columns that were defined in DDL
+        List<Column> columns = table.getResolvedSchema().getColumns();
+        validateNoDuplicateColumns(columns);
+
+        List<String> names = new LinkedList<>();
+        List<LogicalType> types = new LinkedList<>();
+        List<Column> invalidColumns = new LinkedList<>();
+
+        for (Column column : columns) {
+            // We care only about physical columns. As stated in Flink doc - metadata columns and
+            // computed columns are excluded from persisting. Therefore, a computed column cannot
+            // be the target of an INSERT INTO statement.
+            if (column instanceof PhysicalColumn) {
+                names.add(column.getName());
+                types.add(column.getDataType().getLogicalType());
+            }
+
+            if (column instanceof ComputedColumn || column instanceof MetadataColumn) {
+                invalidColumns.add(column);
+            }
+        }
+
+        if (invalidColumns.isEmpty()) {
+            return io.delta.flink.sink.internal.SchemaConverter.toDeltaDataType(
+                RowType.of(types.toArray(new LogicalType[0]), names.toArray(new String[0]))
+            );
+        } else {
+            throw CatalogExceptionHelper.unsupportedColumnType(invalidColumns);
+        }
+    }
+
+    public static void validateNoDuplicateColumns(List<Column> columns) {
+        final List<String> names =
+            columns.stream().map(Column::getName).collect(Collectors.toList());
+        final List<String> duplicates =
+            names.stream()
+                .filter(name -> Collections.frequency(names, name) > 1)
+                .distinct()
+                .collect(Collectors.toList());
+        if (duplicates.size() > 0) {
+            throw new CatalogException(
+                String.format(
+                    "Schema must not contain duplicate column names. Found duplicates: %s",
+                    duplicates));
+        }
+    }
+
+    public static void validateDdlSchemaAndPartitionSpecMatchesDelta(
+            String deltaTablePath,
+            ObjectPath tableCatalogPath,
+            List<String> ddlPartitionColumns,
+            StructType ddlDeltaSchema,
+            Metadata deltaMetadata) {
+
+        StructType deltaSchema = deltaMetadata.getSchema();
+        boolean isEqualPartitionSpec = ConnectorUtils.listEqualsIgnoreOrder(
+            ddlPartitionColumns,
+            deltaMetadata.getPartitionColumns()
+        );
+        if (!(ddlDeltaSchema.equals(deltaSchema) && isEqualPartitionSpec)) {
+            throw CatalogExceptionHelper.deltaLogAndDdlSchemaMismatchException(
+                tableCatalogPath,
+                deltaTablePath,
+                deltaMetadata,
+                ddlDeltaSchema,
+                ddlPartitionColumns
+            );
+        }
+    }
+
+    public static void commitToDeltaLog(
+        DeltaLog deltaLog,
+        Metadata newdMetadata,
+        Operation.Name setTableProperties) {
+
+        OptimisticTransaction transaction = deltaLog.startTransaction();
+        transaction.updateMetadata(newdMetadata);
+        Operation opName =
+            prepareDeltaLogOperation(setTableProperties, newdMetadata);
+        transaction.commit(
+            Collections.singletonList(newdMetadata),
+            opName,
+            ConnectorUtils.ENGINE_INFO
+        );
+    }
+
+    /**
+     * Prepares {@link Operation} object for current transaction
+     *
+     * @param opName name of the operation.
+     * @param metadata Delta Table Metadata action.
+     * @return {@link Operation} object for current transaction.
+     */
+    public static Operation prepareDeltaLogOperation(Operation.Name opName, Metadata metadata) {
+        Map<String, String> operationParameters = new HashMap<>();
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            switch (opName) {
+                case CREATE_TABLE:
+                    // We need to perform mapping to JSON object twice for partition columns.
+                    // First to map the list to string type and then again to make this string
+                    // JSON encoded e.g. java array of ["a", "b"] will be mapped as string
+                    // "[\"a\",\"c\"]". Delta seems to expect "[]" and "{} rather then [] and {}.
+                    operationParameters.put("isManaged", objectMapper.writeValueAsString(false));
+                    operationParameters.put("description",
+                        objectMapper.writeValueAsString(metadata.getDescription()));
+                    operationParameters.put("properties",
+                        objectMapper.writeValueAsString(
+                            objectMapper.writeValueAsString(metadata.getConfiguration()))
+                    );
+                    operationParameters.put("partitionBy", objectMapper.writeValueAsString(
+                        objectMapper.writeValueAsString(metadata.getPartitionColumns()))
+                    );
+                    break;
+                case SET_TABLE_PROPERTIES:
+                    operationParameters.put("properties",
+                        objectMapper.writeValueAsString(
+                            objectMapper.writeValueAsString(metadata.getConfiguration()))
+                    );
+                    break;
+                default:
+                    throw new CatalogException(String.format(
+                        "Trying to use unsupported Delta Operation [%s]",
+                        opName.name())
+                    );
+            }
+
+        } catch (JsonProcessingException e) {
+            throw new CatalogException("Cannot map object to JSON", e);
+        }
+
+        return new Operation(opName, operationParameters, Collections.emptyMap());
+    }
+
+    /**
+     * Prepare catalog table to store in metastore. This table will have only selected
+     * options from DDL and an empty schema.
+     */
+    public static DeltaMetastoreTable prepareMetastoreTable(
+            CatalogBaseTable table,
+            String deltaTablePath) {
+        // Store only path, table name and connector type in metastore.
+        // For computed and meta columns are not supported.
+        Map<String, String> optionsToStoreInMetastore = new HashMap<>();
+        optionsToStoreInMetastore.put(FactoryUtil.CONNECTOR.key(),
+            DeltaDynamicTableFactory.IDENTIFIER);
+        optionsToStoreInMetastore.put(DeltaTableConnectorOptions.TABLE_PATH.key(),
+            deltaTablePath);
+
+        // Flink's Hive catalog calls CatalogTable::getSchema method (deprecated) and apply null
+        // check on the resul.
+        // The default implementation for this method returns null, and the DefaultCatalogTable
+        // returned by CatalogTable.of( ) does not override it,
+        // hence we need to have our own wrapper that will return empty TableSchema when
+        // getSchema method is called.
+        return new DeltaMetastoreTable(
+            CatalogTable.of(
+                // by design don't store schema in metastore. Also watermark and primary key will
+                // not be stored in metastore and for now it will not be supported by Delta
+                // connector SQL.
+                Schema.newBuilder().build(),
+                table.getComment(),
+                Collections.emptyList(),
+                optionsToStoreInMetastore
+            )
+        );
+    }
+
+    /**
+     * Validates DDL options against existing delta table properties. If there is any mismatch (i.e.
+     * same key, different value) and `allowOverride` is set to false throws an exception. Else,
+     * returns a Map of the union of the existing delta table properties along with any new table
+     * properties taken from the DDL options.
+     *
+     * @param filteredDdlOptions DDL options that should be added to _delta_log. It is expected that
+     *                           this options will not contain "table-path" and "connector" options
+     *                           since those should not be added to _delta_log.
+     * @param tableCatalogPath   a database name and object name combo in a catalog.
+     * @param deltaMetadata      the {@link Metadata} object to be stored in _delta_log.
+     * @param allowOverride      if set to true, allows overriding table properties in Delta's table
+     *                           metadata if filteredDdlOptions contains same key. Such case would
+     *                           happen for example in ALTER statement. Throw Exception if set to
+     *                           false.
+     * @return a map of deltaLogProperties that will have same properties than original metadata
+     * plus new ones that were defined in DDL.
+     */
+    public static Map<String, String> prepareDeltaTableProperties(
+            Map<String, String> filteredDdlOptions,
+            ObjectPath tableCatalogPath,
+            Metadata deltaMetadata,
+            boolean allowOverride) {
+
+        // TODO FlinkSQL_PR_5 add asserts to ensure that "table-path" and "connector" options are
+        //  not included in filteredDdlOptions
+
+        List<MismatchedDdlOptionAndDeltaTableProperty> invalidDdlOptions = new LinkedList<>();
+        Map<String, String> deltaLogProperties = new HashMap<>(deltaMetadata.getConfiguration());
+        for (Entry<String, String> ddlOption : filteredDdlOptions.entrySet()) {
+            // will return the previous value for the key, else `null` if no such previous value
+            // existed
+            String existingDeltaPropertyValue =
+                deltaLogProperties.putIfAbsent(ddlOption.getKey(), ddlOption.getValue());
+
+            if (!allowOverride
+                && existingDeltaPropertyValue != null
+                && !existingDeltaPropertyValue.equals(ddlOption.getValue())) {
+                // _delta_log contains property defined in ddl but with different value.
+                invalidDdlOptions.add(
+                    new MismatchedDdlOptionAndDeltaTableProperty(
+                        ddlOption.getKey(),
+                        ddlOption.getValue(),
+                        existingDeltaPropertyValue
+                    )
+                );
+            }
+        }
+
+        if (!invalidDdlOptions.isEmpty()) {
+            throw CatalogExceptionHelper.mismatchedDdlOptionAndDeltaTablePropertyException(
+                tableCatalogPath,
+                invalidDdlOptions
+            );
+        }
+        return deltaLogProperties;
+    }
+
+    /**
+     * This class is used to store table information in Metastore. It basically ensures that {@link
+     * CatalogTable#getSchema()} and {@link CatalogTable#getUnresolvedSchema()} will return an empty
+     * schema objects since we don't want to store any schema information in metastore for Delta
+     * tables.
+     */
+    public static class DeltaMetastoreTable implements CatalogTable {
+
+        private final CatalogTable decoratedTable;
+
+        private DeltaMetastoreTable(CatalogTable decoratedTable) {
+            this.decoratedTable = decoratedTable;
+        }
+
+        @Override
+        public boolean isPartitioned() {
+            return decoratedTable.isPartitioned();
+        }
+
+        @Override
+        public List<String> getPartitionKeys() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public CatalogTable copy(Map<String, String> map) {
+            return decoratedTable.copy(map);
+        }
+
+        @Override
+        public Map<String, String> getOptions() {
+            return decoratedTable.getOptions();
+        }
+
+        @Override
+        public TableSchema getSchema() {
+            return TableSchema.builder().build();
+        }
+
+        @Override
+        public Schema getUnresolvedSchema() {
+            return Schema.newBuilder().build();
+        }
+
+        @Override
+        public String getComment() {
+            return decoratedTable.getComment();
+        }
+
+        @Override
+        public CatalogBaseTable copy() {
+            return decoratedTable.copy();
+        }
+
+        @Override
+        public Optional<String> getDescription() {
+            return decoratedTable.getDescription();
+        }
+
+        @Override
+        public Optional<String> getDetailedDescription() {
+            return decoratedTable.getDetailedDescription();
+        }
+    }
+}

--- a/flink/src/main/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitter.java
+++ b/flink/src/main/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitter.java
@@ -49,6 +49,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import static io.delta.flink.internal.ConnectorUtils.ENGINE_INFO;
 
 import io.delta.standalone.DeltaLog;
 import io.delta.standalone.Operation;
@@ -59,6 +60,7 @@ import io.delta.standalone.actions.AddFile;
 import io.delta.standalone.actions.Metadata;
 import io.delta.standalone.actions.SetTransaction;
 import io.delta.standalone.types.StructType;
+
 
 /**
  * A {@link GlobalCommitter} implementation for
@@ -88,9 +90,6 @@ public class DeltaGlobalCommitter
 
     private static final Logger LOG = LoggerFactory.getLogger(DeltaGlobalCommitter.class);
     private static final String APPEND_MODE = "Append";
-    private static final String ENGINE_INFO =
-        "flink-engine/" + io.delta.flink.sink.internal.committer.Meta.FLINK_VERSION +
-        " flink-delta-connector/" + io.delta.flink.sink.internal.committer.Meta.CONNECTOR_VERSION;
 
     /**
      * Hadoop configuration that is passed to {@link DeltaLog} instance when creating it

--- a/flink/src/test/java/io/delta/flink/internal/table/DeltaCatalogTableHelperTest.java
+++ b/flink/src/test/java/io/delta/flink/internal/table/DeltaCatalogTableHelperTest.java
@@ -1,0 +1,85 @@
+package io.delta.flink.internal.table;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.delta.standalone.Operation;
+import io.delta.standalone.Operation.Name;
+import io.delta.standalone.actions.Metadata;
+import io.delta.standalone.types.StringType;
+import io.delta.standalone.types.StructField;
+import io.delta.standalone.types.StructType;
+
+class DeltaCatalogTableHelperTest {
+
+    @Test
+    public void testCreateTableOperation() {
+
+        Metadata metadata = Metadata.builder()
+            .schema(
+                new StructType(new StructField[]{new StructField("col1", new StringType())})
+            )
+            .partitionColumns(Collections.singletonList("col1"))
+            .configuration(Collections.singletonMap("customKey", "myVal"))
+            .description("test description").build();
+
+        Operation operation =
+            DeltaCatalogTableHelper.prepareDeltaLogOperation(Name.CREATE_TABLE, metadata);
+
+        Map<String, String> expectedOperationParameters = new HashMap<>();
+        expectedOperationParameters.put("partitionBy", "\"[\\\"col1\\\"]\"");
+        expectedOperationParameters.put("description", "\"test description\"");
+        expectedOperationParameters.put("properties", "\"{\\\"customKey\\\":\\\"myVal\\\"}\"");
+        expectedOperationParameters.put("isManaged", "false");
+
+        assertThat(operation.getParameters())
+            .containsExactlyInAnyOrderEntriesOf(expectedOperationParameters);
+    }
+
+    @Test
+    public void testAlterPropertiesTableOperation() {
+
+        Metadata metadata = Metadata.builder()
+            .schema(
+                new StructType(new StructField[]{new StructField("col1", new StringType())})
+            )
+            .partitionColumns(Collections.singletonList("col1"))
+            .configuration(Collections.singletonMap("customKey", "myVal"))
+            .description("test description").build();
+
+        Operation operation =
+            DeltaCatalogTableHelper.prepareDeltaLogOperation(Name.SET_TABLE_PROPERTIES, metadata);
+
+        Map<String, String> expectedOperationParameters =
+            Collections.singletonMap("properties", "\"{\\\"customKey\\\":\\\"myVal\\\"}\"");
+
+        assertThat(operation.getParameters())
+            .containsExactlyInAnyOrderEntriesOf(expectedOperationParameters);
+    }
+
+    @Test
+    public void testThrowOnNotCreateTableNorSetTblPropOperation() {
+
+        Metadata metadata = Metadata.builder()
+            .schema(
+                new StructType(new StructField[]{new StructField("col1", new StringType())})
+            )
+            .partitionColumns(Collections.singletonList("col1"))
+            .configuration(Collections.singletonMap("customKey", "myVal"))
+            .description("test description").build();
+
+        CatalogException catalogException = assertThrows(CatalogException.class, () ->
+            DeltaCatalogTableHelper.prepareDeltaLogOperation(Name.DELETE, metadata));
+
+        assertThat(catalogException.getMessage())
+            .isEqualTo("Trying to use unsupported Delta Operation [DELETE]");
+
+    }
+}
+


### PR DESCRIPTION
Delta catalog interactions with DeltaLog - craeteTable, getTable.
This is a 4th PR aimed to implement https://github.com/delta-io/connectors/issues/238

**High level Catalog design:**
![image](https://user-images.githubusercontent.com/7932805/217529224-d841a1b8-8447-47c8-8dbc-afb2a9989eae.png)

**PR Overview:**
Added implementation for `DeltaCatalog::getTable` and `DeltaCatalog::createTable` with helper methods and classes.

**PR PLAN:**
[FlinkSQL_PR_1] Flink Delta Sink - Table API - MERGED
[FlinkSQL_PR_2] Flink Delta Source- Table API - MERGED
[FlinkSQL_PR_3] Delta Catalog Skeleton - Delegate to InMmeory Catalog - MERGED
**[FlinkSQL_PR_4] Delta Catalog - interactions with Delta Log (CraeteTable and GetTable operations) - IN PROGRESS**
[FlinkSQL_PR_5] Delta Catalog - DDL option valiadation
[FlinkSQL_PR_6] Delta Catalog - interactions with Delta Log (AlterTable operation)
[FlinkSQL_PR_7] Delta Catalog - Restrict Table factory to work only with Delta Catalog
[FlinkSQL_PR_8] Delta Catalog - DDL/Query hint validation
[FlinkSQL_PR_9] Delta Catalog - support for Hive metastore/delegate to hive catalog.