### PR TITLE
[FlinkSQL_PR_5] - Delta catalog DDL option validation

### DIFF
--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaFlinkJobSpecificOptions.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaFlinkJobSpecificOptions.java
@@ -17,6 +17,11 @@
  */
 package io.delta.flink.internal.table;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.delta.flink.source.internal.DeltaSourceOptions;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.core.fs.Path;
@@ -48,6 +53,21 @@ public class DeltaFlinkJobSpecificOptions {
             .enumType(TableMode.class)
             .defaultValue(TableMode.BATCH);
 
+    /**
+     * Set of allowed Job specific options for SELECT statements that can be passed used Flink's
+     * query hint.
+     */
+    public static final Set<String> SOURCE_JOB_OPTIONS = Stream.of(
+        MODE.key(),
+        DeltaSourceOptions.VERSION_AS_OF.key(),
+        DeltaSourceOptions.TIMESTAMP_AS_OF.key(),
+        DeltaSourceOptions.STARTING_VERSION.key(),
+        DeltaSourceOptions.STARTING_TIMESTAMP.key(),
+        DeltaSourceOptions.UPDATE_CHECK_INTERVAL.key(),
+        DeltaSourceOptions.UPDATE_CHECK_INITIAL_DELAY.key(),
+        DeltaSourceOptions.IGNORE_DELETES.key(),
+        DeltaSourceOptions.IGNORE_CHANGES.key()
+    ).collect(Collectors.toSet());
 
     /**
      * Expected values for {@link DeltaFlinkJobSpecificOptions#MODE} job specific option. Based on

--- a/flink/src/test/java/io/delta/flink/internal/table/DeltaCatalogTest.java
+++ b/flink/src/test/java/io/delta/flink/internal/table/DeltaCatalogTest.java
@@ -1,0 +1,267 @@
+package io.delta.flink.internal.table;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.delta.flink.utils.DeltaTestUtils;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.delta.standalone.DeltaLog;
+import io.delta.standalone.types.StructType;
+
+@ExtendWith(MockitoExtension.class)
+class DeltaCatalogTest {
+
+    private static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    private static final boolean ignoreIfExists = false;
+
+    private static final String DATABASE = "default";
+
+    public static final String CATALOG_NAME = "testCatalog";
+
+    private DeltaCatalog deltaCatalog;
+
+    // Resets every test.
+    private Map<String, String> ddlOptions;
+
+    @BeforeAll
+    public static void beforeAll() throws IOException {
+        TEMPORARY_FOLDER.create();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        TEMPORARY_FOLDER.delete();
+    }
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        Catalog decoratedCatalog = new GenericInMemoryCatalog(CATALOG_NAME, DATABASE);
+        decoratedCatalog.open();
+        this.deltaCatalog = new DeltaCatalog(CATALOG_NAME, decoratedCatalog, new Configuration());
+        this.ddlOptions = new HashMap<>();
+        this.ddlOptions.put(
+            DeltaTableConnectorOptions.TABLE_PATH.key(),
+            TEMPORARY_FOLDER.newFolder().getAbsolutePath()
+        );
+    }
+
+    @ParameterizedTest
+    @NullSource  // pass a null value
+    @ValueSource(strings = {"", " "})
+    public void testThrowCreateTableInvalidTablePath(String deltaTablePath) {
+
+        DeltaCatalogBaseTable deltaCatalogTable = setUpCatalogTable(
+            (deltaTablePath == null) ? Collections.emptyMap() : Collections.singletonMap(
+                DeltaTableConnectorOptions.TABLE_PATH.key(),
+                deltaTablePath
+            )
+        );
+
+        CatalogException exception = assertThrows(CatalogException.class, () ->
+            deltaCatalog.createTable(deltaCatalogTable, ignoreIfExists)
+        );
+
+        assertThat(exception.getMessage())
+            .isEqualTo("Path to Delta table cannot be null or empty.");
+    }
+
+    @Test
+    public void testThrowCreateTableIfInvalidTableOptionUsed() {
+
+        Map<String, String> invalidOptions = Stream.of(
+                "spark.some.option",
+                "delta.logStore",
+                "io.delta.storage.S3DynamoDBLogStore.ddb.region",
+                "parquet.writer.max-padding"
+            )
+            .collect(Collectors.toMap(optionName -> optionName, s -> "aValue"));
+
+        String expectedValidationMessage = ""
+            + "DDL contains invalid properties. DDL can have only delta table properties or "
+            + "arbitrary user options only.\n"
+            + "Invalid options used:\n"
+            + " - 'spark.some.option'\n"
+            + " - 'delta.logStore'\n"
+            + " - 'io.delta.storage.S3DynamoDBLogStore.ddb.region'\n"
+            + " - 'parquet.writer.max-padding'";
+
+        validateCreateTableOptions(invalidOptions, expectedValidationMessage);
+    }
+
+    @Test
+    public void testThrowCreateTableIfJobSpecificOptionUsed() {
+
+        // This test will not check if options are mutual excluded.
+        // This is covered by table Factory and Source builder tests.
+        Map<String, String> invalidOptions = Stream.of(
+                "startingVersion",
+                "startingTimestamp",
+                "updateCheckIntervalMillis",
+                "updateCheckDelayMillis",
+                "ignoreDeletes",
+                "ignoreChanges",
+                "versionAsOf",
+                "timestampAsOf",
+                // This will be treated as arbitrary user-defined table property and will not be
+                // part of the exception message since we don't
+                // do case-sensitive checks.
+                "TIMESTAMPASOF"
+            )
+            .collect(Collectors.toMap(optionName -> optionName, s -> "aValue"));
+
+        String expectedValidationMessage = ""
+            + "DDL contains invalid properties. DDL can have only delta table properties or "
+            + "arbitrary user options only.\n"
+            + "DDL contains job specific options. Job specific options can be used only via Query"
+            + " hints.\n"
+            + "Used Job specific options:\n"
+            + " - 'ignoreDeletes'\n"
+            + " - 'startingTimestamp'\n"
+            + " - 'updateCheckIntervalMillis'\n"
+            + " - 'startingVersion'\n"
+            + " - 'ignoreChanges'\n"
+            + " - 'versionAsOf'\n"
+            + " - 'updateCheckDelayMillis'\n"
+            + " - 'timestampAsOf'";
+
+        validateCreateTableOptions(invalidOptions, expectedValidationMessage);
+    }
+
+    @Test
+    public void testThrowCreateTableIfJobSpecificOptionAndInvalidTableOptionsAreUsed() {
+
+        // This test will not check if options are mutual excluded.
+        // This is covered by table Factory and Source builder tests.
+        Map<String, String> invalidOptions = Stream.of(
+                "spark.some.option",
+                "delta.logStore",
+                "io.delta.storage.S3DynamoDBLogStore.ddb.region",
+                "parquet.writer.max-padding",
+                "startingVersion",
+                "startingTimestamp",
+                "updateCheckIntervalMillis",
+                "updateCheckDelayMillis",
+                "ignoreDeletes",
+                "ignoreChanges",
+                "versionAsOf",
+                "timestampAsOf"
+            )
+            .collect(Collectors.toMap(optionName -> optionName, s -> "aValue"));
+
+        String expectedValidationMessage = ""
+            + "DDL contains invalid properties. DDL can have only delta table properties or "
+            + "arbitrary user options only.\n"
+            + "Invalid options used:\n"
+            + " - 'spark.some.option'\n"
+            + " - 'delta.logStore'\n"
+            + " - 'io.delta.storage.S3DynamoDBLogStore.ddb.region'\n"
+            + " - 'parquet.writer.max-padding'\n"
+            + "DDL contains job specific options. Job specific options can be used only via Query"
+            + " hints.\n"
+            + "Used Job specific options:\n"
+            + " - 'startingTimestamp'\n"
+            + " - 'ignoreDeletes'\n"
+            + " - 'updateCheckIntervalMillis'\n"
+            + " - 'startingVersion'\n"
+            + " - 'ignoreChanges'\n"
+            + " - 'versionAsOf'\n"
+            + " - 'updateCheckDelayMillis'\n"
+            + " - 'timestampAsOf'";
+
+        validateCreateTableOptions(invalidOptions, expectedValidationMessage);
+    }
+
+    @Test
+    public void testThrowIfMismatchedDdlOptionAndDeltaTableProperty() {
+
+        String tablePath = this.ddlOptions.get(
+            DeltaTableConnectorOptions.TABLE_PATH.key()
+        );
+
+        Map<String, String> configuration = Collections.singletonMap("delta.appendOnly", "false");
+
+        DeltaLog deltaLog = DeltaTestUtils.setupDeltaTable(
+            tablePath,
+            configuration,
+            new StructType(TestTableData.DELTA_FIELDS)
+        );
+
+        assertThat(deltaLog.tableExists())
+            .withFailMessage(
+                "There should be Delta table files in test folder before calling DeltaCatalog.")
+            .isTrue();
+
+        Map<String, String> mismatchedOptions =
+            Collections.singletonMap("delta.appendOnly", "true");
+
+
+        String expectedValidationMessage = ""
+            + "Invalid DDL options for table [default.testTable]. DDL options for Delta table"
+            + " connector cannot override table properties already defined in _delta_log.\n"
+            + "DDL option name | DDL option value | Delta option value \n"
+            + "delta.appendOnly | true | false";
+
+        validateCreateTableOptions(mismatchedOptions, expectedValidationMessage);
+    }
+
+    private void validateCreateTableOptions(
+        Map<String, String> invalidOptions,
+        String expectedValidationMessage) {
+        ddlOptions.putAll(invalidOptions);
+        DeltaCatalogBaseTable deltaCatalogTable = setUpCatalogTable(
+            ddlOptions
+        );
+
+        CatalogException exception = assertThrows(CatalogException.class, () ->
+            deltaCatalog.createTable(deltaCatalogTable, ignoreIfExists)
+        );
+
+        assertThat(exception.getMessage()).isEqualTo(expectedValidationMessage);
+    }
+
+    private DeltaCatalogBaseTable setUpCatalogTable(Map<String, String> options) {
+
+        CatalogTable catalogTable = CatalogTable.of(
+            Schema.newBuilder()
+                .fromFields(TestTableData.COLUMN_NAMES, TestTableData.COLUMN_TYPES)
+                .build(),
+            "comment",
+            Collections.emptyList(), // partitionKeys
+            options // options
+        );
+
+        return new DeltaCatalogBaseTable(
+            new ObjectPath(DATABASE, "testTable"),
+            new ResolvedCatalogTable(
+                catalogTable,
+                ResolvedSchema.physical(TestTableData.COLUMN_NAMES, TestTableData.COLUMN_TYPES)
+            )
+        );
+    }
+}

--- a/flink/src/test/java/io/delta/flink/internal/table/TestTableData.java
+++ b/flink/src/test/java/io/delta/flink/internal/table/TestTableData.java
@@ -1,0 +1,40 @@
+package io.delta.flink.internal.table;
+
+import java.util.stream.IntStream;
+
+import io.delta.flink.sink.internal.SchemaConverter;
+import org.apache.flink.table.types.AtomicDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import io.delta.standalone.types.StructField;
+
+/**
+ * Dictionary class for Table tests. Contains information about column names and types used for
+ * Table tests.
+ */
+public final class TestTableData {
+
+    public static final String[] COLUMN_NAMES = new String[] {"col1", "col2", "col3"};
+
+    /**
+     * Flink data types for {@link TestTableData#COLUMN_NAMES} columns.
+     */
+    public static final DataType[] COLUMN_TYPES = new DataType[] {
+        new AtomicDataType(new BooleanType()),
+        new AtomicDataType(new IntType()),
+        new AtomicDataType(new VarCharType())
+    };
+
+    /**
+     * Delta Table scheme created based on {@link TestTableData#COLUMN_NAMES} and {@link
+     * TestTableData#COLUMN_TYPES}
+     */
+    public static final StructField[] DELTA_FIELDS = IntStream.range(0, COLUMN_NAMES.length)
+        .mapToObj(value -> new StructField(COLUMN_NAMES[value],
+            SchemaConverter.toDeltaDataType(COLUMN_TYPES[value].getLogicalType())))
+        .toArray(StructField[]::new);
+
+}


### PR DESCRIPTION
This is a 5th PR aimed to implement https://github.com/delta-io/connectors/issues/238
adding validation for DDL options.

**High level Catalog design:**
![image](https://user-images.githubusercontent.com/7932805/217529224-d841a1b8-8447-47c8-8dbc-afb2a9989eae.png)

**PR PLAN:**
[FlinkSQL_PR_1] Flink Delta Sink - Table API - MERGED
[FlinkSQL_PR_2] Flink Delta Source- Table API - MERGED
[FlinkSQL_PR_3] Delta Catalog Skeleton - Delegate to InMmeory Catalog - MERGED
[FlinkSQL_PR_4] Delta Catalog - interactions with Delta Log (CraeteTable and GetTable operations) - MERGED
**[FlinkSQL_PR_5] Delta Catalog - DDL option valiadation - IN PROGRESS**
[FlinkSQL_PR_6] Delta Catalog - interactions with Delta Log (AlterTable operation)
[FlinkSQL_PR_7] Delta Catalog - Restrict Table factory to work only with Delta Catalog
[FlinkSQL_PR_8] Delta Catalog - DDL/Query hint validation
[FlinkSQL_PR_9] Delta Catalog - support for Hive metastore/delegate to hive catalog.