### PR TITLE
[Flink][DeltaSink][Perf] Small performance improvements for Delta sink's DeltaGlobalCommitter

### DIFF
--- a/flink/src/main/java/io/delta/flink/sink/internal/committables/DeltaCommittable.java
+++ b/flink/src/main/java/io/delta/flink/sink/internal/committables/DeltaCommittable.java
@@ -21,8 +21,6 @@ package io.delta.flink.sink.internal.committables;
 import java.io.Serializable;
 
 import org.apache.flink.streaming.api.functions.sink.filesystem.DeltaPendingFile;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -64,8 +62,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class DeltaCommittable implements Serializable {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DeltaCommittable.class);
-
     private final DeltaPendingFile deltaPendingFile;
 
     /**
@@ -82,14 +78,10 @@ public class DeltaCommittable implements Serializable {
      */
     private final long checkpointId;
 
-    public DeltaCommittable(DeltaPendingFile deltaPendingFile,
-                            String appId,
-                            long checkpointId) {
-        LOG.info("Creating committable object for: " +
-            "appId=" + appId +
-            " checkpointId=" + checkpointId +
-            " deltaPendingFile=" + deltaPendingFile
-        );
+    public DeltaCommittable(
+            DeltaPendingFile deltaPendingFile,
+            String appId,
+            long checkpointId) {
         this.deltaPendingFile = checkNotNull(deltaPendingFile);
         this.appId = appId;
         this.checkpointId = checkpointId;

--- a/flink/src/main/java/io/delta/flink/sink/internal/committables/DeltaGlobalCommittable.java
+++ b/flink/src/main/java/io/delta/flink/sink/internal/committables/DeltaGlobalCommittable.java
@@ -62,13 +62,6 @@ public class DeltaGlobalCommittable {
     private final List<DeltaCommittable> deltaCommittables;
 
     public DeltaGlobalCommittable(List<DeltaCommittable> deltaCommittables) {
-        for (DeltaCommittable committable : deltaCommittables) {
-            LOG.info("Creating global committable object with committable for: " +
-                "appId=" + committable.getAppId() +
-                " checkpointId=" + committable.getCheckpointId() +
-                " deltaPendingFile=" + committable.getDeltaPendingFile()
-            );
-        }
         this.deltaCommittables = checkNotNull(deltaCommittables);
     }
 

--- a/flink/src/main/java/io/delta/flink/sink/internal/writer/DeltaWriterBucket.java
+++ b/flink/src/main/java/io/delta/flink/sink/internal/writer/DeltaWriterBucket.java
@@ -214,10 +214,18 @@ public class DeltaWriterBucket<IN> {
         }
 
         List<DeltaCommittable> committables = new ArrayList<>();
-        pendingFiles.forEach(pendingFile -> committables.add(
-            new DeltaCommittable(pendingFile, appId, checkpointId)));
-        pendingFiles.clear();
 
+        for (DeltaPendingFile pendingFile : pendingFiles) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Creating committable object for: " +
+                    "appId=" + appId +
+                    " checkpointId=" + checkpointId +
+                    " deltaPendingFile=" + pendingFile
+                );
+            }
+            committables.add(new DeltaCommittable(pendingFile, appId, checkpointId));
+        }
+        pendingFiles.clear();
         return committables;
     }
 


### PR DESCRIPTION
This PR contains small performance improvements for DeltaGlobalCommitter from Delta Sink.

the improvements are:
1. remove unnecessary logging from `GlobalCommittable` and `DeltaCommittable` constructors (item 1 from picture below).
2. make `DeltaLog` instance a class member field in `DeltaGlobalCommitter` instead creating this object foe every Flink checkpoint (item 2 from picture below).

This PR fix first two items from initial `DeltaGlobalCommitter` performance analysis. The attached flame graph was acquired from Flink cluster (Flink UI) and represent results for GlobalCommitter task. The graph does not show performance analysis during Delta Checkpoint.
![image](https://user-images.githubusercontent.com/7932805/223778596-6b0b74e1-c636-480a-a35c-db5f8571daf5.png)

After Fix we have only two last items,
Delta transaction commit and delta transaction::txnVersion
![image](https://user-images.githubusercontent.com/7932805/223787539-5735e3ac-845d-4c70-b1f3-935498f1a306.png)
