### PR TITLE
Avoid null classloader in LogStoreProvider

### DIFF
--- a/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
@@ -55,8 +55,15 @@ private[internal] trait LogStoreProvider {
       new DelegatingLogStore(hadoopConf)
     } else {
       // scalastyle:off classforname
+      // Do not pass a null class loader
+      // - https://github.com/netty/netty/issues/7290
+      // - https://bugs.openjdk.java.net/browse/JDK-7008595
+      var loader = Thread.currentThread().getContextClassLoader
+      if (loader == null) {
+        loader = this.getClass().getClassLoader
+      }
       val logStoreClass =
-        Class.forName(className, true, Thread.currentThread().getContextClassLoader)
+        Class.forName(className, true, loader)
       // scalastyle:on classforname
 
       if (classOf[LogStore].isAssignableFrom(logStoreClass)) {

--- a/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
@@ -61,7 +61,7 @@ private[internal] trait LogStoreProvider {
       val classLoader = Option(Thread.currentThread().getContextClassLoader)
         .getOrElse(this.getClass().getClassLoader)
       val logStoreClass =
-        Class.forName(className, true, loader)
+        Class.forName(className, true, logStoreClass)
       // scalastyle:on classforname
 
       if (classOf[LogStore].isAssignableFrom(logStoreClass)) {

--- a/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
@@ -61,7 +61,7 @@ private[internal] trait LogStoreProvider {
       val classLoader: java.lang.ClassLoader = Option(Thread.currentThread().getContextClassLoader)
         .getOrElse(this.getClass().getClassLoader)
       val logStoreClass =
-        Class.forName(className, true, logStoreClass)
+        Class.forName(className, true, classLoader)
       // scalastyle:on classforname
 
       if (classOf[LogStore].isAssignableFrom(logStoreClass)) {

--- a/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
@@ -58,7 +58,7 @@ private[internal] trait LogStoreProvider {
       // Do not pass a null class loader
       // - https://github.com/netty/netty/issues/7290
       // - https://bugs.openjdk.java.net/browse/JDK-7008595
-      val classLoader = Option(Thread.currentThread().getContextClassLoader)
+      val classLoader: java.lang.ClassLoader = Option(Thread.currentThread().getContextClassLoader)
         .getOrElse(this.getClass().getClassLoader)
       val logStoreClass =
         Class.forName(className, true, logStoreClass)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.6.0-SNAPSHOT"
+ThisBuild / version := "0.6.1-SNAPSHOT"


### PR DESCRIPTION
Thread class loaders are not required to be set.  Netty prefers to keep them null to avoid leaks.
Check if the Thread class loader is null.  If so use the class loader of the current class.