### PR TITLE
Avoid null classloader

### DIFF
--- a/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
@@ -55,8 +55,13 @@ private[internal] trait LogStoreProvider {
       new DelegatingLogStore(hadoopConf)
     } else {
       // scalastyle:off classforname
+      // Do not pass a null class loader
+      // - https://github.com/netty/netty/issues/7290
+      // - https://bugs.openjdk.java.net/browse/JDK-7008595
+      val classLoader: java.lang.ClassLoader = Option(Thread.currentThread().getContextClassLoader)
+        .getOrElse(this.getClass().getClassLoader)
       val logStoreClass =
-        Class.forName(className, true, Thread.currentThread().getContextClassLoader)
+        Class.forName(className, true, classLoader)
       // scalastyle:on classforname
 
       if (classOf[LogStore].isAssignableFrom(logStoreClass)) {


### PR DESCRIPTION
Netty likes to keep thread class loaders set to null.  If the thread class loader is null, then use the calling class.