### PR TITLE
[FlinkSQL_PR_11] - Delta Catalog - cache DeltaLog instances in DeltaCatalog.

### DIFF
--- a/flink/src/main/java/io/delta/flink/internal/table/BaseCatalog.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/BaseCatalog.java
@@ -44,14 +44,6 @@ public abstract class BaseCatalog extends AbstractCatalog {
         return Optional.of(DeltaDynamicTableFactory.fromCatalog());
     }
 
-    // By design, we will remove only metastore information during drop table.
-    // No filesystem information (for example _delta_log folder) will be removed.
-    @Override
-    public void dropTable(ObjectPath tablePath, boolean ignoreIfNotExists)
-        throws TableNotExistException, CatalogException {
-        this.decoratedCatalog.dropTable(tablePath, ignoreIfNotExists);
-    }
-
     /////////////////////////////////////////////////////
     // Obvious, not Delta related pass-through methods //
     /////////////////////////////////////////////////////

--- a/flink/src/main/java/io/delta/flink/internal/table/CatalogProxy.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/CatalogProxy.java
@@ -73,6 +73,18 @@ public class CatalogProxy extends BaseCatalog {
     }
 
     @Override
+    public void dropTable(ObjectPath tablePath, boolean ignoreIfNotExists)
+        throws TableNotExistException, CatalogException {
+
+        DeltaCatalogBaseTable catalogTable = getCatalogTable(tablePath);
+        if (catalogTable.isDeltaTable()) {
+            this.deltaCatalog.dropTable(catalogTable, ignoreIfNotExists);
+        } else {
+            this.decoratedCatalog.dropTable(tablePath, ignoreIfNotExists);
+        }
+    }
+
+    @Override
     public void alterTable(
             ObjectPath tablePath,
             CatalogBaseTable newTable,

--- a/flink/src/test/java/io/delta/flink/internal/table/DeltaCatalogTest.java
+++ b/flink/src/test/java/io/delta/flink/internal/table/DeltaCatalogTest.java
@@ -1,21 +1,26 @@
 package io.delta.flink.internal.table;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.delta.flink.internal.table.DeltaCatalog.DeltaLogCacheKey;
 import io.delta.flink.utils.DeltaTestUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.flink.table.api.Schema;
-import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,6 +52,8 @@ class DeltaCatalogTest {
 
     private DeltaCatalog deltaCatalog;
 
+    private GenericInMemoryCatalog decoratedCatalog;
+
     // Resets every test.
     private Map<String, String> ddlOptions;
 
@@ -62,9 +69,13 @@ class DeltaCatalogTest {
 
     @BeforeEach
     public void setUp() throws IOException {
-        Catalog decoratedCatalog = new GenericInMemoryCatalog(CATALOG_NAME, DATABASE);
-        decoratedCatalog.open();
-        this.deltaCatalog = new DeltaCatalog(CATALOG_NAME, decoratedCatalog, new Configuration());
+        this.decoratedCatalog = new GenericInMemoryCatalog(CATALOG_NAME, DATABASE);
+        this.decoratedCatalog.open();
+        this.deltaCatalog = new DeltaCatalog(
+            CATALOG_NAME,
+            this.decoratedCatalog,
+            new Configuration()
+        );
         this.ddlOptions = new HashMap<>();
         this.ddlOptions.put(
             DeltaTableConnectorOptions.TABLE_PATH.key(),
@@ -233,13 +244,181 @@ class DeltaCatalogTest {
         validateCreateTableOptions(mismatchedOptions, expectedValidationMessage);
     }
 
+    /**
+     * This test verifies that cached DeltaLog instance will be refreshed making getTable() method
+     * throws an exception in subsequent getTable() calls after deleting _delta_log folder.
+     */
+    @Test
+    public void shouldRefreshDeltaCache_deltaLogDeleted() throws Exception {
+
+        String tablePath = this.ddlOptions.get(
+            DeltaTableConnectorOptions.TABLE_PATH.key()
+        );
+
+        // GIVEN setup _delta_log on disk.
+        DeltaLog deltaLog = DeltaTestUtils.setupDeltaTable(
+            tablePath,
+            Collections.emptyMap(),
+            Metadata.builder()
+                .schema(new StructType(TestTableData.DELTA_FIELDS))
+                .build()
+        );
+
+        assertThat(deltaLog.tableExists())
+            .withFailMessage(
+                "There should be Delta table files in test folder before calling DeltaCatalog.")
+            .isTrue();
+
+        // Get table from DeltaCatalog. This is the first call for this table, so it will initialize
+        // the DeltaLog entry in catalog's cache.
+        // As stated in DeltaCatalog::getTable Javadoc, this method assumes that table is already
+        // present in metastore, hence no extra metastore checks are done and "createTable"
+        // method doesn't have to be called prior to this method.
+        DeltaCatalogBaseTable baseTable = setUpCatalogTable(ddlOptions);
+        assertThat(deltaCatalog.getTable(baseTable)).isNotNull();
+
+        // Remove _delta_log files
+        FileUtils.cleanDirectory(new File(tablePath));
+
+        // If DeltaCatalog DeltaLog instance would not be refreshed, this method would not throw
+        // an exception since DeltaLog instance would not know that _delta_log was deleted.
+        TableNotExistException exception =
+            assertThrows(TableNotExistException.class, () -> deltaCatalog.getTable(baseTable));
+
+        assertThat(exception.getCause().getMessage())
+            .contains(
+                "Table default.testTable exists in metastore but "
+                    + "_delta_log was not found under path");
+
+    }
+
+    /**
+     * This test verifies that cached DeltaLog instance will be refreshed making getTable() method
+     * stop throwing an exception in subsequent getTable() calls after creating _delta_log folder.
+     */
+    @Test
+    public void shouldRefreshDeltaCache_createDeltaLog() throws Exception {
+
+        // GIVEN setup _delta_log on disk.
+        String tablePath = this.ddlOptions.get(
+            DeltaTableConnectorOptions.TABLE_PATH.key()
+        );
+
+        assertThat(DeltaLog.forTable(DeltaTestUtils.getHadoopConf(), tablePath).tableExists())
+            .withFailMessage(
+                "There should be no Delta table files in test folder before calling DeltaCatalog.")
+            .isFalse();
+
+        DeltaCatalogBaseTable baseTable = setUpCatalogTable(ddlOptions);
+        // Get table from DeltaCatalog. This is the first call for this table, so it will initialize
+        // the DeltaLog entry in catalog's cache.
+        // As stated in DeltaCatalog::getTable Javadoc, this method assumes that table is already
+        // present in metastore, hence no extra metastore checks are done and "createTable"
+        // method doesn't have to be called prior to this method.
+        TableNotExistException exception =
+            assertThrows(TableNotExistException.class, () -> deltaCatalog.getTable(baseTable));
+
+        // Since there was no _delta_log on the filesystem we except exception when calling
+        // getTable()
+        assertThat(exception.getCause().getMessage())
+            .contains(
+                "Table default.testTable exists in metastore but "
+                    + "_delta_log was not found under path");
+
+        // setup _delta_log on disk.
+        DeltaTestUtils.setupDeltaTable(
+            tablePath,
+            Collections.emptyMap(),
+            Metadata.builder()
+                .schema(new StructType(TestTableData.DELTA_FIELDS))
+                .build()
+        );
+
+        // If DeltaCatalog DeltaLog instance would not be refreshed, this method would throw
+        // an exception since DeltaLog instance would not know that _delta_log was created.
+        assertThat(deltaCatalog.getTable(baseTable)).isNotNull();
+    }
+
+    @Test
+    public void shouldAddTableToMetastoreAndCache() throws Exception {
+        String tablePath = this.ddlOptions.get(
+            DeltaTableConnectorOptions.TABLE_PATH.key()
+        );
+
+        // GIVEN setup _delta_log on disk.
+        DeltaTestUtils.setupDeltaTable(
+            tablePath,
+            Collections.emptyMap(),
+            Metadata.builder()
+                .schema(new StructType(TestTableData.DELTA_FIELDS))
+                .build()
+        );
+
+        DeltaCatalogBaseTable baseTable = setUpCatalogTable(ddlOptions);
+        ObjectPath tableCatalogPath = baseTable.getTableCatalogPath();
+        deltaCatalog.createTable(baseTable, false); // ignoreIfExists = false
+
+        // Validate entry in metastore
+        CatalogBaseTable metastoreTable = decoratedCatalog.getTable(tableCatalogPath);
+        assertThat(metastoreTable).withFailMessage("Missing table entry in metastore.").isNotNull();
+        assertThat(metastoreTable.getOptions())
+            .withFailMessage(
+                "Metastore should contain only connector and table-path options for table.")
+            .containsOnlyKeys(Arrays.asList("connector", "table-path"));
+        assertThat(metastoreTable.getUnresolvedSchema())
+            .withFailMessage("Metastore contains non-empty schema information.")
+            .isEqualTo(Schema.newBuilder().build());
+
+        // Validate that cache entry was created for Delta table.
+        assertThat(deltaCatalog.getDeltaLogCache().getIfPresent(
+            new DeltaLogCacheKey(tableCatalogPath, tablePath))
+        ).isNotNull();
+    }
+
+    @Test
+    public void shouldRemoveFromCacheAfterTableDrop() throws Exception {
+        String tablePath = this.ddlOptions.get(
+            DeltaTableConnectorOptions.TABLE_PATH.key()
+        );
+
+        // GIVEN setup _delta_log on disk.
+        DeltaTestUtils.setupDeltaTable(
+            tablePath,
+            Collections.emptyMap(),
+            Metadata.builder()
+                .schema(new StructType(TestTableData.DELTA_FIELDS))
+                .build()
+        );
+
+        DeltaCatalogBaseTable baseTable = setUpCatalogTable(ddlOptions);
+        ObjectPath tableCatalogPath = baseTable.getTableCatalogPath();
+
+        deltaCatalog.createTable(baseTable, false); // ignoreIfExists = false
+        assertThat(decoratedCatalog.getTable(tableCatalogPath))
+            .withFailMessage("Metastore is missing created table.")
+            .isNotNull();
+        assertThat(deltaCatalog.getDeltaLogCache().getIfPresent(
+            new DeltaLogCacheKey(tableCatalogPath, tablePath)))
+            .withFailMessage("DeltaCatalog Cache has no entry for created Table.")
+            .isNotNull();
+
+        // Drop table
+        deltaCatalog.dropTable(baseTable, false); // ignoreIfExists = false
+        assertThrows(
+            TableNotExistException.class,
+            () -> decoratedCatalog.getTable(tableCatalogPath)
+        );
+        assertThat(deltaCatalog.getDeltaLogCache().getIfPresent(
+            new DeltaLogCacheKey(tableCatalogPath, tablePath)))
+            .withFailMessage("DeltaCatalog cache contains entry for dropped table.")
+            .isNull();
+    }
+
     private void validateCreateTableOptions(
         Map<String, String> invalidOptions,
         String expectedValidationMessage) {
         ddlOptions.putAll(invalidOptions);
-        DeltaCatalogBaseTable deltaCatalogTable = setUpCatalogTable(
-            ddlOptions
-        );
+        DeltaCatalogBaseTable deltaCatalogTable = setUpCatalogTable(ddlOptions);
 
         CatalogException exception = assertThrows(CatalogException.class, () ->
             deltaCatalog.createTable(deltaCatalogTable, ignoreIfExists)


### PR DESCRIPTION
This is a 11th PR aimed to implement https://github.com/delta-io/connectors/issues/238

This PR adds cache in DeltaCatalog.java that caches DeltaLog instances. 
Creating DeltaLog instance for big table's can be CPU intensive and time consuming task. This is because DeltaLog has to compute Delta Snapshot. To mitigate problem, a cache was introduced. This case will keep up to 100 DeltaLog instances without any other eviction policies. When cache will reach its maximum size, the lest recently used entry will be replaced
(LRU eviction policy).

The Cache entry for given table will be invalidated if "DROP TABLE" SQL statement will be executed.

**Tests:**
Added new test cases to `DeltaCatalogTest.java` and `DeltaCatalogTestSuite.java`

**High level Catalog design:**
![image](https://user-images.githubusercontent.com/7932805/217529224-d841a1b8-8447-47c8-8dbc-afb2a9989eae.png)

**PR PLAN:**
[FlinkSQL_PR_1] Flink Delta Sink - Table API - MERGED
[FlinkSQL_PR_2] Flink Delta Source- Table API - MERGED
[FlinkSQL_PR_3] Delta Catalog Skeleton - Delegate to InMmeory Catalog - MERGED
[FlinkSQL_PR_4] Delta Catalog - interactions with Delta Log (CraeteTable and GetTable operations) - MERGED
[FlinkSQL_PR_5] Delta Catalog - DDL option valiadation - MERGED
[FlinkSQL_PR_6] Delta Catalog - AlterTable operation + IT tests (1st round) - MERGED
[FlinkSQL_PR_7] Delta Catalog - Restrict Table factory to work only with Delta Catalog - MERGED
[FlinkSQL_PR_8] Delta Catalog - DDL/Query hint validation - MERGED
[FlinkSQL_PR_9] Delta Catalog - support for Hive metastore/delegate to hive catalog. - MERGED
[FlinkSQL_PR_10] Delta Catalog - add tests for reading with partition filter - support filter for partitions. - MERGED
**[FlinkSQL_PR_11] Delta Catalog - add cache for DeltaLog instances in Delta Catalog. - IN PROGRESS**
[FlinkSQL_PR_12] Delta Table API - UML diagrams
[FlinkSQL_PR_13] Delta Catalog - support Table and column comments similar to Spark.
[FlinkSQL_PR_14] SQL - remove support for "mergeSchema" option
[FlinkSQL PR_15] SQL - add README.md for using SQL and Catalog support.