### PR TITLE
[FlinkSQL_PR_13] - Remove mergeSchema option from SQL API.

### DIFF
--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaDynamicTableFactory.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaDynamicTableFactory.java
@@ -125,7 +125,6 @@ public class DeltaDynamicTableFactory implements DynamicTableSinkFactory,
             new Path(options.get(DeltaTableConnectorOptions.TABLE_PATH)),
             conf,
             rowType,
-            false, // mergeSchema = false,
             context.getCatalogTable()
         );
     }

--- a/flink/src/main/java/io/delta/flink/internal/table/DeltaTableConnectorOptions.java
+++ b/flink/src/main/java/io/delta/flink/internal/table/DeltaTableConnectorOptions.java
@@ -34,13 +34,4 @@ public class DeltaTableConnectorOptions {
             .stringType()
             .noDefaultValue();
 
-    /**
-     * Indicator whether we should try to update table's schema with stream's schema in case
-     * those will not match. The update is not guaranteed as there will be still some checks
-     * performed whether the updates to the schema are compatible.
-     */
-    public static final ConfigOption<Boolean> MERGE_SCHEMA =
-        ConfigOptions.key("mergeSchema")
-            .booleanType()
-            .defaultValue(false);
 }


### PR DESCRIPTION
This is a 13th PR aimed to implement https://github.com/delta-io/connectors/issues/238

This PR removes a `mergeSchema` option from DynamicTableSink since with Delta Catalog we cannot have a SQL query that will add columns that do not match delta table's schema.

**PR PLAN:**
[FlinkSQL_PR_1] Flink Delta Sink - Table API - MERGED
[FlinkSQL_PR_2] Flink Delta Source- Table API - MERGED
[FlinkSQL_PR_3] Delta Catalog Skeleton - Delegate to InMmeory Catalog - MERGED
[FlinkSQL_PR_4] Delta Catalog - interactions with Delta Log (CraeteTable and GetTable operations) - MERGED
[FlinkSQL_PR_5] Delta Catalog - DDL option valiadation - MERGED
[FlinkSQL_PR_6] Delta Catalog - AlterTable operation + IT tests (1st round) - MERGED
[FlinkSQL_PR_7] Delta Catalog - Restrict Table factory to work only with Delta Catalog - MERGED
[FlinkSQL_PR_8] Delta Catalog - DDL/Query hint validation - MERGED
[FlinkSQL_PR_9] Delta Catalog - support for Hive metastore/delegate to hive catalog. - MERGED
[FlinkSQL_PR_10] Delta Catalog - add tests for reading with partition filter - support filter for partitions. - MERGED
[FlinkSQL_PR_11] Delta Catalog - add cache for DeltaLog instances in Delta Catalog. - MERGED
**[FlinkSQL_PR_12] Delta Table API - UML diagrams - IN PROGRESS**
~~[FlinkSQL_PR_13] Delta Catalog - support Table and column comments similar to Spark.~~
**[FlinkSQL_PR_13] SQL - remove support for "mergeSchema" option - IN PROGRESS**
**[FlinkSQL PR_14] SQL - add SQL Examples - IN PROGRESS.**
[FlinkSQL PR_15] SQL - add README.md for using SQL and Catalog support.

--------------------------------------------------------------------------------------------------------
Extras after finishing above plan + integration tests on a real cluster + S3/GCP
- Delta Catalog - support Table and column comments similar to Spark