### PR TITLE
[Delta-Flink Sink] Compute `txnVersion` lazily to reduce CPU utilization on commit

### DIFF
--- a/flink/src/main/java/io/delta/flink/internal/lang/Lazy.java
+++ b/flink/src/main/java/io/delta/flink/internal/lang/Lazy.java
@@ -29,11 +29,17 @@ public class Lazy<T> {
         this.supplier = supplier;
     }
 
-    public synchronized T get() {
+    public synchronized T threadSafeGet() {
         if (!instance.isPresent()) {
             instance = Optional.of(supplier.get());
         }
+        return instance.get();
+    }
 
+    public T threadUnsafeGet() {
+        if (!instance.isPresent()) {
+            instance = Optional.of(supplier.get());
+        }
         return instance.get();
     }
 }

--- a/flink/src/main/java/io/delta/flink/internal/lang/Lazy.java
+++ b/flink/src/main/java/io/delta/flink/internal/lang/Lazy.java
@@ -29,14 +29,8 @@ public class Lazy<T> {
         this.supplier = supplier;
     }
 
-    public synchronized T threadSafeGet() {
-        if (!instance.isPresent()) {
-            instance = Optional.of(supplier.get());
-        }
-        return instance.get();
-    }
-
-    public T threadUnsafeGet() {
+    /** Not thread safe. */
+    public T get() {
         if (!instance.isPresent()) {
             instance = Optional.of(supplier.get());
         }

--- a/flink/src/main/java/io/delta/flink/internal/lang/Lazy.java
+++ b/flink/src/main/java/io/delta/flink/internal/lang/Lazy.java
@@ -29,8 +29,7 @@ public class Lazy<T> {
         this.supplier = supplier;
     }
 
-    /** Not thread-safe (i.e. may perform duplicate `supplier.get()` calls) */
-    public T get() {
+    public synchronized T get() {
         if (!instance.isPresent()) {
             instance = Optional.of(supplier.get());
         }

--- a/flink/src/main/java/io/delta/flink/internal/lang/Lazy.java
+++ b/flink/src/main/java/io/delta/flink/internal/lang/Lazy.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.flink.internal.lang;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class Lazy<T> {
+    private final Supplier<T> supplier;
+    private Optional<T> instance = Optional.empty();
+
+    public Lazy(Supplier<T> supplier) {
+        this.supplier = supplier;
+    }
+
+    /** Not thread-safe (i.e. may perform duplicate `supplier.get()` calls) */
+    public T get() {
+        if (!instance.isPresent()) {
+            instance = Optional.of(supplier.get());
+        }
+
+        return instance.get();
+    }
+}

--- a/flink/src/main/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitter.java
+++ b/flink/src/main/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitter.java
@@ -273,18 +273,24 @@ public class DeltaGlobalCommitter
             DeltaLog deltaLog) {
 
         // The last committed table version by THIS flink application.
+        //
+        // We can access this value using `threadUnsafeGet` because Flink's threading model
+        // guarantees that GlobalCommitter::commit will be executed by a single thread.
         Lazy<Long> lastCommittedTableVersion =
             new Lazy<>(() -> deltaLog.startTransaction().txnVersion(appId));
 
         // Keep `lastCommittedTableVersion.get() < 0` as the second predicate in the OR statement
         // below since it is expensive and we should avoid computing it if possible.
-        if (!this.firstCommit || lastCommittedTableVersion.get() < 0) {
+        if (!this.firstCommit || lastCommittedTableVersion.threadUnsafeGet() < 0) {
             // normal run
             return groupCommittablesByCheckpointInterval(globalCommittables);
         } else {
             // processing recovery, deduplication on recovered committables.
-            Collection<CheckpointData> deDuplicateData =
-                deduplicateFiles(globalCommittables, deltaLog, lastCommittedTableVersion.get());
+            Collection<CheckpointData> deDuplicateData = deduplicateFiles(
+                globalCommittables,
+                deltaLog,
+                lastCommittedTableVersion.threadUnsafeGet()
+            );
 
             return groupCommittablesByCheckpointInterval(deDuplicateData);
         }

--- a/flink/src/main/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitter.java
+++ b/flink/src/main/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitter.java
@@ -273,12 +273,11 @@ public class DeltaGlobalCommitter
             DeltaLog deltaLog) {
 
         // The last committed table version by THIS flink application.
-        // Even though `Lazy` is thread-unsafe, we know that the GlobalCommitter runs with
-        // parallelism equal to 1, and we are only accessing this local variable in this single
-        // method.
         Lazy<Long> lastCommittedTableVersion =
             new Lazy<>(() -> deltaLog.startTransaction().txnVersion(appId));
 
+        // Keep `lastCommittedTableVersion.get() < 0` as the second predicate in the OR statement
+        // below since it is expensive and we should avoid computing it if possible.
         if (!this.firstCommit || lastCommittedTableVersion.get() < 0) {
             // normal run
             return groupCommittablesByCheckpointInterval(globalCommittables);


### PR DESCRIPTION
Previously, we were calling `deltaLog.startTransaction.txnVersion(appId)` every flink checkpoint (i.e. commit into the delta log). If a full log replay had not already been triggered, then `txnVesion` would trigger a full log replay - an expensive operation.

This is unnecessary as the result of `txnVersion` is only used during the first commit.

This change should reduce the CPU overhead each commit.