### PR TITLE
[Delta-Standalone] Compute Snapshot protocol and metadata more efficiently

### DIFF
--- a/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
@@ -17,7 +17,6 @@
 package io.delta.standalone.internal
 
 import java.net.URI
-import java.util.concurrent.{Executors, ExecutorService}
 
 import scala.collection.JavaConverters._
 import scala.collection.parallel.ExecutionContextTaskSupport
@@ -40,12 +39,21 @@ import io.delta.standalone.internal.logging.Logging
 import io.delta.standalone.internal.scan.{DeltaScanImpl, FilteredDeltaScanImpl}
 import io.delta.standalone.internal.util.{ConversionUtils, FileNames, JsonUtils}
 
+case class SnapshotProtocolMetadataHint(protocol: Protocol, metadata: Metadata, version: Long)
+
+/** Visible for testing. */
+case class ProtocolMetadataLoadMetrics(fileVersions: Seq[Long])
+
 /**
  * Scala implementation of Java interface [[Snapshot]].
  *
  * @param timestamp The timestamp of the latest commit in milliseconds. Can also be set to -1 if the
  *                  timestamp of the commit is unknown or the table has not been initialized, i.e.
  *                  `version = -1`.
+ * @param protocolMetadataHint The optional protocol, metadata, and table version that can be used
+ *                             to speed up loading *this* Snapshot's protocol and metadata (P&M).
+ *                             Essentially, when computing *this* Snapshot's P&M, we only need to
+ *                             look at the log files *newer* than the hint version.
  */
 private[internal] class SnapshotImpl(
     val hadoopConf: Configuration,
@@ -54,7 +62,9 @@ private[internal] class SnapshotImpl(
     val logSegment: LogSegment,
     val minFileRetentionTimestamp: Long,
     val deltaLog: DeltaLogImpl,
-    val timestamp: Long) extends Snapshot with Logging {
+    val timestamp: Long,
+    protocolMetadataHint: Option[SnapshotProtocolMetadataHint] = Option.empty)
+  extends Snapshot with Logging {
 
   import SnapshotImpl._
 
@@ -124,21 +134,70 @@ private[internal] class SnapshotImpl(
   lazy val transactions: Map[String, Long] =
     setTransactionsScala.map(t => t.appId -> t.version).toMap
 
-  // These values need to be declared lazy. In Scala, strict values (i.e. non-lazy) in superclasses
-  // (e.g. SnapshotImpl) are fully initialized before subclasses (e.g. InitialSnapshotImpl).
-  // If these were 'strict', or 'eager', vals, then `loadTableProtocolAndMetadata` would be called
-  // for all new InitialSnapshotImpl instances, causing an exception.
-  lazy val (protocolScala, metadataScala) = loadTableProtocolAndMetadata()
+  /**
+   * protocolScala, metadataScala are internals APIs.
+   * protocolMetadataLoadMetrics is visible for testing only.
+   *
+   * NOTE: These values need to be declared lazy. In Scala, strict values (i.e. non-lazy) in
+   * superclasses (e.g. SnapshotImpl) are fully initialized before subclasses
+   * (e.g. InitialSnapshotImpl). If these were 'strict', or 'eager', vals, then
+   * `loadTableProtocolAndMetadata` would be called for all new InitialSnapshotImpl instances,
+   * causing an exception.
+   */
+  lazy val (protocolScala, metadataScala, protocolMetadataLoadMetrics) =
+    loadTableProtocolAndMetadata()
 
-  private def loadTableProtocolAndMetadata(): (Protocol, Metadata) = {
+  private def loadTableProtocolAndMetadata(): (Protocol, Metadata, ProtocolMetadataLoadMetrics) = {
+    val fileVersionsScanned = scala.collection.mutable.Set[Long]()
+    def createMetrics = ProtocolMetadataLoadMetrics(fileVersionsScanned.toSeq.sorted.reverse)
+
     var protocol: Protocol = null
     var metadata: Metadata = null
+
     val iter = memoryOptimizedLogReplay.getReverseIterator
 
     try {
       // We replay logs from newest to oldest and will stop when we find the latest Protocol and
-      // Metadata.
-      iter.asScala.foreach { case (action, _) =>
+      // Metadata (P&M).
+      //
+      // If the protocolMetadataHint is defined, then we will only look at log files strictly newer
+      // (>) than the protocolMetadataHint's version. If we don't find any new P&M, then we will
+      // default to those from the protocolMetadataHint.
+      //
+      // If the protocolMetadataHint is not defined, then we must look at all log files. If no
+      // P&M is found, then we fail.
+      iter.asScala.foreach { case (action, _, actionTableVersion) =>
+
+        // We have not yet found the latest P&M. If we had found BOTH, we would have returned
+        // already. Note that we may have already found ONE of them.
+        protocolMetadataHint.foreach { hint =>
+          if (actionTableVersion == hint.version) {
+            // Furthermore, we have already looked at all the actions in all the log files strictly
+            // newer (>) than the hint version. Thus, we can short circuit early and use the P&M
+            // from the hint.
+
+            val newestProtocol = if (protocol == null) {
+              logInfo(s"Using the protocol from the protocolMetadataHint: ${hint.protocol}")
+              hint.protocol
+            } else {
+              logInfo(s"Found a newer protocol: $protocol")
+              protocol
+            }
+
+            val newestMetadata = if (metadata == null) {
+              logInfo(s"Using the metadata from the protocolMetadataHint: ${hint.metadata}")
+              hint.metadata
+            } else {
+              logInfo(s"Found a newer metadata: $metadata")
+              metadata
+            }
+
+            return (newestProtocol, newestMetadata, createMetrics)
+          }
+        }
+
+        fileVersionsScanned += actionTableVersion
+
         action match {
           case p: Protocol if null == protocol =>
             // We only need the latest protocol
@@ -146,14 +205,14 @@ private[internal] class SnapshotImpl(
 
             if (protocol != null && metadata != null) {
               // Stop since we have found the latest Protocol and metadata.
-              return (protocol, metadata)
+              return (protocol, metadata, createMetrics)
             }
           case m: Metadata if null == metadata =>
             metadata = m
 
             if (protocol != null && metadata != null) {
               // Stop since we have found the latest Protocol and metadata.
-              return (protocol, metadata)
+              return (protocol, metadata, createMetrics)
             }
           case _ => // do nothing
         }
@@ -329,6 +388,9 @@ private class InitialSnapshotImpl(
   override lazy val protocolScala: Protocol = Protocol()
 
   override lazy val metadataScala: Metadata = Metadata()
+
+  override lazy val protocolMetadataLoadMetrics: ProtocolMetadataLoadMetrics =
+    ProtocolMetadataLoadMetrics(Seq.empty)
 
   override def scan(): DeltaScan = new DeltaScanImpl(memoryOptimizedLogReplay)
 

--- a/standalone/src/main/scala/io/delta/standalone/internal/scan/DeltaScanImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/scan/DeltaScanImpl.scala
@@ -82,7 +82,7 @@ private[internal] class DeltaScanImpl(replay: MemoryOptimizedLogReplay) extends 
      */
     private def findNextValid(): Option[AddFile] = {
       while (iter.hasNext) {
-        val (action, isCheckpoint) = iter.next()
+        val (action, isCheckpoint, _) = iter.next()
 
         action match {
           case add: AddFile =>

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -31,7 +31,7 @@ import org.apache.hadoop.fs.Path
 import org.scalatest.FunSuite
 
 import io.delta.standalone.{DeltaLog, Operation, Snapshot}
-import io.delta.standalone.actions.{AddFile => AddFileJ, JobInfo => JobInfoJ, Metadata => MetadataJ, NotebookInfo => NotebookInfoJ, RemoveFile => RemoveFileJ}
+import io.delta.standalone.actions.{AddFile => AddFileJ, JobInfo => JobInfoJ, Metadata => MetadataJ, NotebookInfo => NotebookInfoJ, Protocol => ProtocolJ, RemoveFile => RemoveFileJ}
 import io.delta.standalone.exceptions.DeltaStandaloneException
 import io.delta.standalone.types.{BooleanType, IntegerType, LongType, StringType, StructType}
 
@@ -676,6 +676,95 @@ abstract class DeltaLogSuiteBase extends FunSuite {
       } finally {
         iter.close()
       }
+    }
+  }
+
+  test("Snapshot should read the minimal number of log files needed when loading " +
+    "protocol & metadata") {
+    withTempDir { dir =>
+      val conf = new Configuration()
+      def commit(i: Int, deltaLog: DeltaLog): Unit = {
+        val files =
+          ConversionUtils.convertAction(AddFile(i.toString, Map.empty, 1, 1, true)) :: Nil
+        deltaLog.startTransaction().commit(files.asJava, manualUpdate, engineInfo)
+      }
+
+      // V0: Add protocol and metadata
+      val writerLog = DeltaLog.forTable(conf, dir.getCanonicalPath)
+      val metadataV0 = MetadataJ
+        .builder()
+        .schema(new StructType().add("x", new IntegerType()))
+        .build()
+      val protocolV0 = new ProtocolJ(1, 2)
+      writerLog.startTransaction()
+        .commit((metadataV0 :: protocolV0 :: Nil).asJava, manualUpdate, engineInfo)
+
+      // V1-V8: The latest protocol and metadata is still in V0
+      for (i <- 1 to 8) { commit(i, writerLog) }
+
+      val readerLog = DeltaLog.forTable(conf, dir.getCanonicalPath)
+      val metrics1 = readerLog.snapshot().asInstanceOf[SnapshotImpl].protocolMetadataLoadMetrics
+      assert(metrics1.fileVersions.toList.sorted === (0 to 8).toList)
+
+      // V9-13: The latest protocol and metadata is now in V10 (checkpoint)
+      for (i <- 9 to 13) { commit(i, writerLog) }
+      val metrics2 = readerLog.update().asInstanceOf[SnapshotImpl].protocolMetadataLoadMetrics
+      assert(metrics2.fileVersions.toList.sorted === (10 to 13).toList)
+
+      // !!!!! This is the most common case to test !!!!!
+      //
+      // V14-19: The latest protocol and metadata should be saved in the current snapshot at V13
+      //         To emphasize: we should not scan all the way back to V10! We should scan to V14
+      //         and then stop, since we already know the latest protocol and metadata at V13.
+      for (i <- 14 to 19) { commit(i, writerLog) }
+      val metrics3 = readerLog.update().asInstanceOf[SnapshotImpl].protocolMetadataLoadMetrics
+      assert(metrics3.fileVersions.toList.sorted === (14 to 19).toList)
+
+      // V20-22: Again, the latest protocol and metadata is now in the checkpoint
+      for (i <- 20 to 22) { commit(i, writerLog) }
+      val metrics4 = readerLog.update().asInstanceOf[SnapshotImpl].protocolMetadataLoadMetrics
+      assert(metrics4.fileVersions.toList.sorted === (20 to 22).toList)
+
+      // !!!!! Edge case: one newer metadata, but not a newer protocol !!!!!
+      //
+      // V26: Now, this has the latest metadata (but not the latest protocol). The current snapshot
+      //      version is 22, so we should still read the new log files 26 -> 23
+      for (i <- 23 to 25) { commit(i, writerLog) }
+      val metadataV26 = MetadataJ
+        .builder()
+        .schema(metadataV0.getSchema.add("y", new IntegerType()))
+        .build()
+      val txn26 = writerLog.startTransaction()
+      txn26.updateMetadata(metadataV26)
+      txn26.commit(Nil.asJava, manualUpdate, engineInfo)
+
+      val metrics5_snapshot = readerLog.update().asInstanceOf[SnapshotImpl]
+      val metrics5 = metrics5_snapshot.protocolMetadataLoadMetrics
+      assert(metrics5.fileVersions.toList.sorted === (23 to 26).toList)
+      // Check that we actually loaded the correct metadata at V26 instead of the hint at V22
+      assert(metrics5_snapshot.getMetadata.getSchema === metadataV26.getSchema)
+
+      // !!!!! Edge case: newer protocol and metadata !!!!!
+      //
+      // V27: Just adds
+      // V28: This commit contains a new metadata AND protocol.
+      // V29: More adds
+      commit(27, writerLog)
+      val metadataV28 = MetadataJ
+        .builder()
+        .schema(metadataV26.getSchema.add("z", new IntegerType()))
+        .build()
+      // Note: same Protocol versions (1,2) as the previous protocol, due to the limited
+      //       delta-standalone protocol support.
+      val protocolV28 = new ProtocolJ(1, 2)
+      writerLog.startTransaction()
+        .commit((metadataV28 :: protocolV28 :: Nil).asJava, manualUpdate, engineInfo)
+      commit(29, writerLog)
+
+      // The current snapshot is still at V26. We should read V29, V28, see the newest protocol and
+      // metadata, and stop early
+      val metrics6 = readerLog.update().asInstanceOf[SnapshotImpl].protocolMetadataLoadMetrics
+      assert(metrics6.fileVersions.toList.sorted === (28 to 29).toList)
     }
   }
 }

--- a/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/DeltaLogSuite.scala
@@ -679,6 +679,17 @@ abstract class DeltaLogSuiteBase extends FunSuite {
     }
   }
 
+  /**
+   * Handles all the relevant cases for this optimized reverse log replay for protocol & metadata
+   * loading.
+   *
+   * Case 1: Fresh snapshot created with no previous snapshot, replaying back to 0.json
+   * Case 2: Snapshot update, but there is a checkpoint newer than the previous cached snapshot
+   * Case 3: Snapshot update, but there is a cached snapshot newer than the latest checkpoint
+   * Case 4: Same as case 3, but there is also metadata action that's newer than the cached snapshot
+   * Case 5: Same as case 3, but there are metadata and protocol actions newer than the cached
+   *         snapshot
+   */
   test("Snapshot should read the minimal number of log files needed when loading " +
     "protocol & metadata") {
     withTempDir { dir =>
@@ -699,20 +710,20 @@ abstract class DeltaLogSuiteBase extends FunSuite {
       writerLog.startTransaction()
         .commit((metadataV0 :: protocolV0 :: Nil).asJava, manualUpdate, engineInfo)
 
+      // Case 1
       // V1-V8: The latest protocol and metadata is still in V0
       for (i <- 1 to 8) { commit(i, writerLog) }
-
       val readerLog = DeltaLog.forTable(conf, dir.getCanonicalPath)
       val metrics1 = readerLog.snapshot().asInstanceOf[SnapshotImpl].protocolMetadataLoadMetrics
       assert(metrics1.fileVersions.toList.sorted === (0 to 8).toList)
 
+      // Case 2
       // V9-13: The latest protocol and metadata is now in V10 (checkpoint)
       for (i <- 9 to 13) { commit(i, writerLog) }
       val metrics2 = readerLog.update().asInstanceOf[SnapshotImpl].protocolMetadataLoadMetrics
       assert(metrics2.fileVersions.toList.sorted === (10 to 13).toList)
 
-      // !!!!! This is the most common case to test !!!!!
-      //
+      // Case 3
       // V14-19: The latest protocol and metadata should be saved in the current snapshot at V13
       //         To emphasize: we should not scan all the way back to V10! We should scan to V14
       //         and then stop, since we already know the latest protocol and metadata at V13.
@@ -725,8 +736,7 @@ abstract class DeltaLogSuiteBase extends FunSuite {
       val metrics4 = readerLog.update().asInstanceOf[SnapshotImpl].protocolMetadataLoadMetrics
       assert(metrics4.fileVersions.toList.sorted === (20 to 22).toList)
 
-      // !!!!! Edge case: one newer metadata, but not a newer protocol !!!!!
-      //
+      // Case 4
       // V26: Now, this has the latest metadata (but not the latest protocol). The current snapshot
       //      version is 22, so we should still read the new log files 26 -> 23
       for (i <- 23 to 25) { commit(i, writerLog) }
@@ -737,15 +747,13 @@ abstract class DeltaLogSuiteBase extends FunSuite {
       val txn26 = writerLog.startTransaction()
       txn26.updateMetadata(metadataV26)
       txn26.commit(Nil.asJava, manualUpdate, engineInfo)
-
       val metrics5_snapshot = readerLog.update().asInstanceOf[SnapshotImpl]
       val metrics5 = metrics5_snapshot.protocolMetadataLoadMetrics
       assert(metrics5.fileVersions.toList.sorted === (23 to 26).toList)
       // Check that we actually loaded the correct metadata at V26 instead of the hint at V22
       assert(metrics5_snapshot.getMetadata.getSchema === metadataV26.getSchema)
 
-      // !!!!! Edge case: newer protocol and metadata !!!!!
-      //
+      // Case 5
       // V27: Just adds
       // V28: This commit contains a new metadata AND protocol.
       // V29: More adds
@@ -760,11 +768,13 @@ abstract class DeltaLogSuiteBase extends FunSuite {
       writerLog.startTransaction()
         .commit((metadataV28 :: protocolV28 :: Nil).asJava, manualUpdate, engineInfo)
       commit(29, writerLog)
-
       // The current snapshot is still at V26. We should read V29, V28, see the newest protocol and
       // metadata, and stop early
-      val metrics6 = readerLog.update().asInstanceOf[SnapshotImpl].protocolMetadataLoadMetrics
+      val metrics6_snapshot = readerLog.update().asInstanceOf[SnapshotImpl]
+      val metrics6 = metrics6_snapshot.protocolMetadataLoadMetrics
       assert(metrics6.fileVersions.toList.sorted === (28 to 29).toList)
+      assert(metrics6_snapshot.getMetadata.getSchema === metadataV28.getSchema)
+      // useless asserting the protocol, since they are the same
     }
   }
 }


### PR DESCRIPTION
## The problem

`loadProtocolAndMetadata` can be an expensive operation when initializing a snapshot.

![image](https://user-images.githubusercontent.com/59617782/231015621-1541f7bd-3fd7-475b-a4f5-2ebb5e534628.png)


## The solution

This PR passes in a `previousSnapshotHint` into the `Snapshot` constructor, to be used during reverse log replay (when we calculate the latest protocol and metadata for the table).

At a high level, here is the logic that this PR implements:

Suppose the latest version of the table is V24 and we perform our first snapshot creation, i.e. `DeltaLog.forTable(...).snapshot()`. We will, as usual, scan files `0024.json`, `0023.json`, `0022.json`, `0021.json`, until we get to `0020.checkpoint.parquet` where we will find the protocol and metadata. (assuming no recent protocol and metadata updates in the json files).

Suppose some time later we call `log.update()`, and that versions 25-29 have been added to the table.

This PR changes the reverse replay logic so that we ONLY read files 29-25 to look for new protocol or metadata updates.

If we don't find any, then we just use the already-saved protocol and metadata values from the current log's snapshot at V25. That is, we do not read versions 24-20.

Thus, this PR reduces the amount of file scanning and processing we have to do during snapshot initialization.

![image](https://user-images.githubusercontent.com/59617782/231016152-3972460e-0910-4f5b-ab7a-11f6a3589720.png)

