### PR TITLE
[FlinkSQL_PR_14] - Add SQL Examples.

### DIFF
--- a/examples/flink-example/pom.xml
+++ b/examples/flink-example/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.-->
         <maven.compiler.target>1.8</maven.compiler.target>
         <staging.repo.url>""</staging.repo.url>
         <scala.main.version>2.12</scala.main.version>
-        <connectors.version>0.6.0</connectors.version>
+        <connectors.version>0.6.0-SNAPSHOT</connectors.version>
         <flink-version>1.16.1</flink-version>
         <hadoop-version>3.1.0</hadoop-version>
         <log4j.version>2.12.1</log4j.version>
@@ -56,7 +56,7 @@ limitations under the License.-->
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-clients</artifactId>
             <version>${flink-version}</version>
-            <scope>test</scope>
+            <scope>${flink.scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -83,6 +83,12 @@ limitations under the License.-->
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-runtime</artifactId>
+            <version>${flink-version}</version>
+            <scope>${flink.scope}</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_2.12</artifactId>
             <version>${flink-version}</version>
             <scope>${flink.scope}</scope>
         </dependency>

--- a/examples/flink-example/src/main/java/org/example/sql/StreamingApiDeltaSourceToTableDeltaSinkJob.java
+++ b/examples/flink-example/src/main/java/org/example/sql/StreamingApiDeltaSourceToTableDeltaSinkJob.java
@@ -1,0 +1,83 @@
+package org.example.sql;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import io.delta.flink.source.DeltaSource;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.data.RowData;
+import org.apache.hadoop.conf.Configuration;
+import org.utils.Utils;
+import static org.utils.job.sql.SqlExampleBase.createTableStreamingEnv;
+import static org.utils.job.sql.SqlExampleBase.createTestStreamEnv;
+
+/**
+ * This is an example of using Delta Connector both in Streaming and Table API. In this example a
+ * Delta Source will be created using Streaming API and will be registered as Flink table. Next we
+ * will use Flink SQL to read data from it using SELECT statement and write back to newly created
+ * Delta table defined by CREATE TABLE statement.
+ */
+public class StreamingApiDeltaSourceToTableDeltaSinkJob {
+
+    private static final String SOURCE_TABLE_PATH = Utils.resolveExampleTableAbsolutePath(
+        "data/source_table_no_partitions");
+
+    private static final String SINK_TABLE_PATH = Utils.resolveExampleTableAbsolutePath(
+        "example_streamingToTableAPI_table_" + UUID.randomUUID().toString().split("-")[0]);
+
+    public static void main(String[] args) throws Exception {
+        StreamExecutionEnvironment streamEnv = createTestStreamEnv(false); // isStreaming = false
+        StreamTableEnvironment tableEnv = createTableStreamingEnv(streamEnv);
+        createPipeline(streamEnv, tableEnv);
+    }
+
+    private static void createPipeline(
+            StreamExecutionEnvironment streamEnv,
+            StreamTableEnvironment tableEnv) throws Exception {
+
+        // Set up a Delta Source using Flink's Streaming API.
+        DeltaSource<RowData> deltaSource = DeltaSource.forBoundedRowData(
+            new Path(SOURCE_TABLE_PATH),
+            new Configuration()
+        ).build();
+
+        // create a source stream from Delta Source connector.
+        DataStreamSource<RowData> sourceStream =
+            streamEnv.fromSource(deltaSource, WatermarkStrategy.noWatermarks(), "delta-source");
+
+        // setup Delta Catalog
+        tableEnv.executeSql("CREATE CATALOG myDeltaCatalog WITH ('type' = 'delta-catalog')");
+        tableEnv.executeSql("USE CATALOG myDeltaCatalog");
+
+        // Convert source stream into Flink's table and register it as temporary view under
+        // "InputTable" name.
+        Table sourceTable = tableEnv.fromDataStream(sourceStream);
+        tableEnv.createTemporaryView("InputTable", sourceTable);
+
+        // Create Sink Delta table using Flink SQL API.
+        tableEnv.executeSql(String.format(""
+                + "CREATE TABLE sinkTable ("
+                + "f1 STRING,"
+                + "f2 STRING,"
+                + "f3 INT"
+                + ") WITH ("
+                + " 'connector' = 'delta',"
+                + " 'table-path' = '%s'"
+                + ")",
+            SINK_TABLE_PATH)
+        );
+
+        // Insert into sinkTable all rows read by Delta Source that is registered as "InputTable"
+        // view.
+        tableEnv.executeSql("INSERT INTO sinkTable SELECT * FROM InputTable")
+            .await(10, TimeUnit.SECONDS);
+
+        // Read and print all rows from sinkTable using Flink SQL.
+        tableEnv.executeSql("SELECT * FROM sinkTable").print();
+    }
+}

--- a/examples/flink-example/src/main/java/org/example/sql/insert/InsertTableExample.java
+++ b/examples/flink-example/src/main/java/org/example/sql/insert/InsertTableExample.java
@@ -1,0 +1,52 @@
+package org.example.sql.insert;
+
+import java.util.UUID;
+
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.utils.Utils;
+import org.utils.job.sql.SqlSinkExampleBase;
+
+/**
+ * This is an example of executing a INSERT query on Delta Table using Flink SQL.
+ */
+public class InsertTableExample extends SqlSinkExampleBase {
+
+    static String TABLE_PATH = Utils.resolveExampleTableAbsolutePath(
+        "example_table_" + UUID.randomUUID().toString().split("-")[0]);
+
+    public static void main(String[] args)
+        throws Exception {
+        new InsertTableExample().run(TABLE_PATH);
+    }
+
+    @Override
+    protected Table runSqlJob(String tablePath, StreamTableEnvironment tableEnv) {
+
+        // setup Delta Catalog
+        tableEnv.executeSql("CREATE CATALOG myDeltaCatalog WITH ('type' = 'delta-catalog')");
+        tableEnv.executeSql("USE CATALOG myDeltaCatalog");
+
+        // SQL definition for Delta Table where we will insert rows.
+        tableEnv.executeSql(String.format(""
+                + "CREATE TABLE sinkTable ("
+                + "f1 STRING,"
+                + "f2 STRING,"
+                + "f3 INT"
+                + ") WITH ("
+                + " 'connector' = 'delta',"
+                + " 'table-path' = '%s'"
+                + ")",
+            tablePath)
+        );
+
+        // A SQL query that inserts three rows (three columns per row) into sinkTable.
+        tableEnv.executeSql(""
+            + "INSERT INTO sinkTable VALUES "
+            + "('a', 'b', 1),"
+            + "('c', 'd', 2),"
+            + "('e', 'f', 3)"
+        );
+        return null;
+    }
+}

--- a/examples/flink-example/src/main/java/org/example/sql/select/bounded/SelectBoundedTableExample.java
+++ b/examples/flink-example/src/main/java/org/example/sql/select/bounded/SelectBoundedTableExample.java
@@ -1,0 +1,44 @@
+package org.example.sql.select.bounded;
+
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.utils.Utils;
+import org.utils.job.sql.BoundedSqlSourceExampleBase;
+
+/**
+ * This is an example of executing a bounded SELECT query on Delta Table using Flink SQL.
+ */
+public class SelectBoundedTableExample extends BoundedSqlSourceExampleBase {
+
+    private static final String TABLE_PATH =
+        Utils.resolveExampleTableAbsolutePath("data/source_table_no_partitions");
+
+    public static void main(String[] args) throws Exception {
+        new SelectBoundedTableExample().run(TABLE_PATH);
+    }
+
+    @Override
+    protected Table runSqlJob(String tablePath, StreamTableEnvironment tableEnv) {
+
+        // setup Delta Catalog
+        tableEnv.executeSql("CREATE CATALOG myDeltaCatalog WITH ('type' = 'delta-catalog')");
+        tableEnv.executeSql("USE CATALOG myDeltaCatalog");
+
+        // SQL definition for Delta Table where we will insert rows.
+        tableEnv.executeSql(String.format(""
+                + "CREATE TABLE sourceTable ("
+                + "f1 STRING,"
+                + "f2 STRING,"
+                + "f3 INT"
+                + ") WITH ("
+                + " 'connector' = 'delta',"
+                + " 'table-path' = '%s'"
+                + ")",
+            tablePath)
+        );
+
+        // A batch SQL query that fetches all columns from sourceTable. The batch mode is a
+        // default mode for SQL queries on Delta Table.
+        return tableEnv.sqlQuery("SELECT * FROM sourceTable");
+    }
+}

--- a/examples/flink-example/src/main/java/org/example/sql/select/bounded/SelectBoundedTableVersionAsOfExample.java
+++ b/examples/flink-example/src/main/java/org/example/sql/select/bounded/SelectBoundedTableVersionAsOfExample.java
@@ -1,0 +1,45 @@
+package org.example.sql.select.bounded;
+
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.utils.Utils;
+import org.utils.job.sql.BoundedSqlSourceExampleBase;
+
+/**
+ * This is an example of executing a bounded SELECT query on Delta Table using Flink SQL
+ * that will read Delta table from version specified by `versionAsOf` option.
+ */
+public class SelectBoundedTableVersionAsOfExample extends BoundedSqlSourceExampleBase {
+
+    private static final String TABLE_PATH =
+        Utils.resolveExampleTableAbsolutePath("data/source_table_no_partitions");
+
+    public static void main(String[] args) throws Exception {
+        new SelectBoundedTableVersionAsOfExample().run(TABLE_PATH);
+    }
+
+    @Override
+    protected Table runSqlJob(String tablePath, StreamTableEnvironment tableEnv) {
+
+        // setup Delta Catalog
+        tableEnv.executeSql("CREATE CATALOG myDeltaCatalog WITH ('type' = 'delta-catalog')");
+        tableEnv.executeSql("USE CATALOG myDeltaCatalog");
+
+        // SQL definition for Delta Table where we will insert rows.
+        tableEnv.executeSql(String.format(""
+                + "CREATE TABLE sourceTable ("
+                + "f1 STRING,"
+                + "f2 STRING,"
+                + "f3 INT"
+                + ") WITH ("
+                + " 'connector' = 'delta',"
+                + " 'table-path' = '%s'"
+                + ")",
+            tablePath)
+        );
+
+        // A SQL query that fetches all columns from sourceTable starting from Delta version 1.
+        // This query runs in batch mode which is a default mode for SQL queries on Delta Table.
+        return tableEnv.sqlQuery("SELECT * FROM sourceTable /*+ OPTIONS('versionAsOf' = '1') */");
+    }
+}

--- a/examples/flink-example/src/main/java/org/example/sql/select/continuous/SelectContinuousTableExample.java
+++ b/examples/flink-example/src/main/java/org/example/sql/select/continuous/SelectContinuousTableExample.java
@@ -1,0 +1,44 @@
+package org.example.sql.select.continuous;
+
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.utils.Utils;
+import org.utils.job.sql.ContinuousSqlSourceExampleBase;
+
+/**
+ * This is an example of executing a continuous SELECT query on Delta Table using Flink SQL.
+ */
+public class SelectContinuousTableExample extends ContinuousSqlSourceExampleBase {
+
+    private static final String TABLE_PATH =
+        Utils.resolveExampleTableAbsolutePath("data/source_table_no_partitions");
+
+    public static void main(String[] args) throws Exception {
+        new SelectContinuousTableExample().run(TABLE_PATH);
+    }
+
+    @Override
+    protected Table runSqlJob(String tablePath, StreamTableEnvironment tableEnv) {
+
+        // setup Delta Catalog
+        tableEnv.executeSql("CREATE CATALOG myDeltaCatalog WITH ('type' = 'delta-catalog')");
+        tableEnv.executeSql("USE CATALOG myDeltaCatalog");
+
+        // SQL definition for Delta Table where we will insert rows.
+        tableEnv.executeSql(String.format(""
+                + "CREATE TABLE sourceTable ("
+                + "f1 STRING,"
+                + "f2 STRING,"
+                + "f3 INT"
+                + ") WITH ("
+                + " 'connector' = 'delta',"
+                + " 'table-path' = '%s'"
+                + ")",
+            tablePath)
+        );
+
+        // A SQL query that fetches all columns from sourceTable.
+        // This query runs in continuous mode.
+        return tableEnv.sqlQuery("SELECT * FROM sourceTable /*+ OPTIONS('mode' = 'streaming') */");
+    }
+}

--- a/examples/flink-example/src/main/java/org/example/sql/select/continuous/SelectContinuousTableStartingVersionExample.java
+++ b/examples/flink-example/src/main/java/org/example/sql/select/continuous/SelectContinuousTableStartingVersionExample.java
@@ -1,0 +1,48 @@
+package org.example.sql.select.continuous;
+
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.utils.Utils;
+import org.utils.job.sql.ContinuousSqlSourceExampleBase;
+
+/**
+ * This is an example of executing a continuous SELECT query on Delta Table using Flink SQL
+ * that will read Delta table from version specified by `startingVersion` option.
+ */
+public class SelectContinuousTableStartingVersionExample extends ContinuousSqlSourceExampleBase {
+
+    private static final String TABLE_PATH =
+        Utils.resolveExampleTableAbsolutePath("data/source_table_no_partitions");
+
+    public static void main(String[] args) throws Exception {
+        new SelectContinuousTableStartingVersionExample().run(TABLE_PATH);
+    }
+
+    @Override
+    protected Table runSqlJob(String tablePath, StreamTableEnvironment tableEnv) {
+
+        // setup Delta Catalog
+        tableEnv.executeSql("CREATE CATALOG myDeltaCatalog WITH ('type' = 'delta-catalog')");
+        tableEnv.executeSql("USE CATALOG myDeltaCatalog");
+
+        // SQL definition for Delta Table where we will insert rows.
+        tableEnv.executeSql(String.format(""
+                + "CREATE TABLE sourceTable ("
+                + "f1 STRING,"
+                + "f2 STRING,"
+                + "f3 INT"
+                + ") WITH ("
+                + " 'connector' = 'delta',"
+                + " 'table-path' = '%s'"
+                + ")",
+            tablePath)
+        );
+
+        // A SQL query that fetches all columns from sourceTable starting from Delta version 10.
+        // This query runs in continuous mode.
+        return tableEnv.sqlQuery(""
+            + "SELECT * FROM sourceTable "
+            + "/*+ OPTIONS('mode' = 'streaming', 'startingVersion' = '10') */"
+        );
+    }
+}

--- a/examples/flink-example/src/main/java/org/utils/Utils.java
+++ b/examples/flink-example/src/main/java/org/utils/Utils.java
@@ -13,12 +13,20 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.Row;
 
+import io.delta.standalone.DeltaLog;
+import io.delta.standalone.Snapshot;
+import io.delta.standalone.data.CloseableIterator;
+import io.delta.standalone.data.RowRecord;
+
 public final class Utils {
+
+    static int PRINT_PAD_LENGTH = 4;
 
     private Utils() {}
 
@@ -34,7 +42,7 @@ public final class Utils {
             // Maven commands are run from the examples/flink-example/ directory
             rootPath + "/src/main/resources/" + resourcesTableDir :
             // while SBT commands are run from the examples/ directory
-            rootPath + "/flink-example/src/main/resources/" + resourcesTableDir;
+            rootPath + "/examples/flink-example/src/main/resources/" + resourcesTableDir;
     }
 
     public static void prepareDirs(String tablePath) throws IOException {
@@ -71,5 +79,50 @@ public final class Utils {
             2,
             TimeUnit.SECONDS
         );
+    }
+
+    public static void printDeltaTableRows(String tablePath) throws InterruptedException {
+        DeltaLog deltaLog =
+            DeltaLog.forTable(new org.apache.hadoop.conf.Configuration(), tablePath);
+
+        for (int i = 0; i < 30; i++) {
+            deltaLog.update();
+            Snapshot snapshot = deltaLog.snapshot();
+
+            System.out.println("===== current snapshot =====");
+            System.out.println("snapshot version: " + snapshot.getVersion());
+            System.out.println("number of total data files: " + snapshot.getAllFiles().size());
+
+            CloseableIterator<RowRecord> iter = snapshot.open();
+            System.out.println("\ntable rows:");
+            System.out.println(StringUtils.rightPad("f1", PRINT_PAD_LENGTH) + "| " +
+                StringUtils.rightPad("f2", PRINT_PAD_LENGTH) + " | " +
+                StringUtils.rightPad("f3", PRINT_PAD_LENGTH));
+            System.out.println(String.join("", Collections.nCopies(4 * PRINT_PAD_LENGTH, "-")));
+
+            RowRecord row = null;
+            int numRows = 0;
+            while (iter.hasNext()) {
+                row = iter.next();
+                numRows++;
+
+                String f1 = row.isNullAt("f1") ? null : row.getString("f1");
+                String f2 = row.isNullAt("f2") ? null : row.getString("f2");
+                Integer f3 = row.isNullAt("f3") ? null : row.getInt("f3");
+
+                System.out.println(StringUtils.rightPad(f1, PRINT_PAD_LENGTH) + "| " +
+                    StringUtils.rightPad(f2, PRINT_PAD_LENGTH) + " | " +
+                    StringUtils.rightPad(String.valueOf(f3), PRINT_PAD_LENGTH));
+            }
+            System.out.println("\nnumber rows: " + numRows);
+            if (row != null) {
+                System.out.println("data schema:");
+                System.out.println(row.getSchema().getTreeString());
+                System.out.println("partition cols:");
+                System.out.println(snapshot.getMetadata().getPartitionColumns());
+            }
+            System.out.println("\n");
+            Thread.sleep(5000);
+        }
     }
 }

--- a/examples/flink-example/src/main/java/org/utils/job/sql/BoundedSqlSourceExampleBase.java
+++ b/examples/flink-example/src/main/java/org/utils/job/sql/BoundedSqlSourceExampleBase.java
@@ -1,0 +1,36 @@
+package org.utils.job.sql;
+
+import java.util.UUID;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.utils.ConsoleSink;
+import org.utils.Utils;
+
+public abstract class BoundedSqlSourceExampleBase extends SqlExampleBase {
+
+    private final String workPath;
+
+    protected final boolean isStreaming;
+
+    protected BoundedSqlSourceExampleBase() {
+        this.isStreaming = false;
+        this.workPath = Utils.resolveExampleTableAbsolutePath("example_table_" +
+            UUID.randomUUID().toString().split("-")[0]);
+    }
+
+    public void run(String tablePath) throws Exception {
+        System.out.println("Will use table path: " + tablePath);
+        Utils.prepareDirs(tablePath, workPath);
+
+        StreamExecutionEnvironment streamEnv = createTestStreamEnv(this.isStreaming);
+        StreamTableEnvironment tableEnv = createTableStreamingEnv(streamEnv);
+        Table table = runSqlJob(workPath, tableEnv);
+        tableEnv.toDataStream(table)
+            .map(new RowMapperFunction(Utils.FULL_SCHEMA_ROW_TYPE))
+            .addSink(new ConsoleSink(Utils.FULL_SCHEMA_ROW_TYPE))
+            .setParallelism(1);
+        streamEnv.execute();
+    }
+}

--- a/examples/flink-example/src/main/java/org/utils/job/sql/ContinuousSqlSourceExampleBase.java
+++ b/examples/flink-example/src/main/java/org/utils/job/sql/ContinuousSqlSourceExampleBase.java
@@ -1,0 +1,37 @@
+package org.utils.job.sql;
+
+import java.util.UUID;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.utils.ConsoleSink;
+import org.utils.Utils;
+
+public abstract class ContinuousSqlSourceExampleBase extends SqlExampleBase {
+
+    private final String workPath = Utils.resolveExampleTableAbsolutePath("example_table_" +
+        UUID.randomUUID().toString().split("-")[0]);
+
+    protected final boolean isStreaming;
+
+    protected ContinuousSqlSourceExampleBase() {
+        this.isStreaming = true;
+    }
+
+    public void run(String tablePath) throws Exception {
+        System.out.println("Will use table path: " + tablePath);
+        Utils.prepareDirs(tablePath, workPath);
+
+        StreamExecutionEnvironment streamEnv = createTestStreamEnv(this.isStreaming);
+        StreamTableEnvironment tableEnv = createTableStreamingEnv(streamEnv);
+        Table table = runSqlJob(workPath, tableEnv);
+        tableEnv.toDataStream(table)
+            .map(new RowMapperFunction(Utils.FULL_SCHEMA_ROW_TYPE))
+            .addSink(new ConsoleSink(Utils.FULL_SCHEMA_ROW_TYPE))
+            .setParallelism(1);
+        streamEnv.executeAsync();
+
+        Utils.runSourceTableUpdater(workPath);
+    }
+}

--- a/examples/flink-example/src/main/java/org/utils/job/sql/RowMapperFunction.java
+++ b/examples/flink-example/src/main/java/org/utils/job/sql/RowMapperFunction.java
@@ -1,0 +1,28 @@
+package org.utils.job.sql;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.util.DataFormatConverters;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+
+/**
+ * A Helper Mapper function to convert Stream of Row element to stream of RowDataElements.
+ */
+public class RowMapperFunction implements MapFunction<Row, RowData> {
+
+    private final DataFormatConverters.DataFormatConverter<RowData, Row> converter;
+
+    public RowMapperFunction(LogicalType logicalType) {
+        this.converter =
+            DataFormatConverters.getConverterForDataType(
+                TypeConversions.fromLogicalToDataType(logicalType)
+            );
+    }
+
+    @Override
+    public RowData map(Row value) {
+        return converter.toInternal(value);
+    }
+}

--- a/examples/flink-example/src/main/java/org/utils/job/sql/SqlExampleBase.java
+++ b/examples/flink-example/src/main/java/org/utils/job/sql/SqlExampleBase.java
@@ -1,0 +1,43 @@
+package org.utils.job.sql;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+public abstract class SqlExampleBase {
+
+    /**
+     * Runs an SQL Flink job. Depending on the context the "tablePath" parameter
+     * can be a source (SELECT) or a sink (INSERT) table.
+     */
+    protected abstract Table runSqlJob(
+        String tablePath,
+        StreamTableEnvironment tableEnv) throws Exception;
+
+    public static StreamExecutionEnvironment createTestStreamEnv(boolean isStreaming) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+
+        if (isStreaming) {
+            env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+            env.enableCheckpointing(1000, CheckpointingMode.EXACTLY_ONCE);
+        } else {
+            env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        }
+
+        return env;
+    }
+
+    public static StreamTableEnvironment createTableStreamingEnv(boolean isStreaming) {
+        return StreamTableEnvironment.create(
+            createTestStreamEnv(isStreaming)
+        );
+    }
+
+    public static StreamTableEnvironment createTableStreamingEnv(StreamExecutionEnvironment env) {
+        return StreamTableEnvironment.create(env);
+    }
+}

--- a/examples/flink-example/src/main/java/org/utils/job/sql/SqlSinkExampleBase.java
+++ b/examples/flink-example/src/main/java/org/utils/job/sql/SqlSinkExampleBase.java
@@ -1,0 +1,16 @@
+package org.utils.job.sql;
+
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.utils.Utils;
+
+public abstract class SqlSinkExampleBase extends SqlExampleBase {
+
+    public void run(String tablePath) throws Exception {
+        System.out.println("Will use table path: " + tablePath);
+
+        Utils.prepareDirs(tablePath);
+        StreamTableEnvironment tableEnv = createTableStreamingEnv(false); // streamingMode = false
+        runSqlJob(tablePath, tableEnv);
+        Utils.printDeltaTableRows(tablePath);
+    }
+}

--- a/examples/run_flink_examples.sh
+++ b/examples/run_flink_examples.sh
@@ -12,11 +12,17 @@ declare -a source_tests=(
 	"org.example.source.continuous.DeltaContinuousSourceExample"
 	"org.example.source.continuous.DeltaContinuousSourceStartingVersionExample"
 	"org.example.source.continuous.DeltaContinuousSourceUserColumnsExample"
+	"org.example.sql.select.bounded.SelectBoundedTableExample"
+  "org.example.sql.select.bounded.SelectBoundedTableVersionAsOfExample"
+  "org.example.sql.select.continuous.SelectContinuousTableExample"
+  "org.example.sql.select.continuous.SelectContinuousTableStartingVersionExample"
 )
 
 declare -a sink_tests=(
 	"org.example.sink.DeltaSinkExample"
 	"org.example.sink.DeltaSinkPartitionedTableExample"
+	"org.example.sql.insert.InsertTableExample"
+	"org.example.sql.StreamingApiDeltaSourceToTableDeltaSinkJob"
 )
 
 echo "============= Running Delta/Flink Integration Tests ============="


### PR DESCRIPTION
This is a 14th PR aimed to implement https://github.com/delta-io/connectors/issues/238

This PR removes adds SQL examples.

**PR PLAN:**
[FlinkSQL_PR_1] Flink Delta Sink - Table API - MERGED
[FlinkSQL_PR_2] Flink Delta Source- Table API - MERGED
[FlinkSQL_PR_3] Delta Catalog Skeleton - Delegate to InMmeory Catalog - MERGED
[FlinkSQL_PR_4] Delta Catalog - interactions with Delta Log (CraeteTable and GetTable operations) - MERGED
[FlinkSQL_PR_5] Delta Catalog - DDL option valiadation - MERGED
[FlinkSQL_PR_6] Delta Catalog - AlterTable operation + IT tests (1st round) - MERGED
[FlinkSQL_PR_7] Delta Catalog - Restrict Table factory to work only with Delta Catalog - MERGED
[FlinkSQL_PR_8] Delta Catalog - DDL/Query hint validation - MERGED
[FlinkSQL_PR_9] Delta Catalog - support for Hive metastore/delegate to hive catalog. - MERGED
[FlinkSQL_PR_10] Delta Catalog - add tests for reading with partition filter - support filter for partitions. - MERGED
[FlinkSQL_PR_11] Delta Catalog - add cache for DeltaLog instances in Delta Catalog. - MERGED
**[FlinkSQL_PR_12] Delta Table API - UML diagrams - IN PROGRESS**
~~[FlinkSQL_PR_13] Delta Catalog - support Table and column comments similar to Spark.~~
**[FlinkSQL_PR_13] SQL - remove support for "mergeSchema" option - IN PROGRESS**
**[FlinkSQL PR_14] SQL - add SQL Examples - IN PROGRESS.**
[FlinkSQL PR_15] SQL - add README.md for using SQL and Catalog support.

--------------------------------------------------------------------------------------------------------
Extras after finishing above plan + integration tests on a real cluster + S3/GCP
- Delta Catalog - support Table and column comments similar to Spark