### PR TITLE
Delta/Flink Sink and Delta Standalone - allow disabling of delta checkpointing

### DIFF
--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
@@ -220,6 +220,31 @@ public class DeltaSinkStreamingExecutionITCase extends DeltaSinkExecutionITCaseB
         );
     }
 
+    @Test
+    void can_disable_delta_checkpointing() throws Exception {
+        final org.apache.hadoop.conf.Configuration hadoopConf =
+            new org.apache.hadoop.conf.Configuration();
+        hadoopConf.set("io.delta.standalone.checkpointing.enabled", "false");
+
+        DeltaTestUtils.initTestForNonPartitionedTable(deltaTablePath);
+
+        StreamExecutionEnvironment env = getTestStreamEnv(false); // no failover
+        env.addSource(new CheckpointCountingSource(1_000, 12))
+            .setParallelism(1)
+            .sinkTo(DeltaSinkTestUtils.createDeltaSink(deltaTablePath, false, hadoopConf))
+            .setParallelism(3);
+
+        StreamGraph streamGraph = env.getStreamGraph();
+        try (MiniCluster miniCluster = DeltaSinkTestUtils.getMiniCluster()) {
+            miniCluster.start();
+            miniCluster.executeJobBlocking(streamGraph.getJobGraph());
+        }
+
+        List<String> deltaCheckpointFiles = getDeltaCheckpointFiles(deltaTablePath);
+
+        assertThat("There should be no delta checkpoint written", deltaCheckpointFiles.isEmpty());
+    }
+
     /**
      * This test verifies if Flink Delta Source created Delta checkpoint after 10 commits.
      * This tests produces records using {@link CheckpointCountingSource} until at most 12 Flink

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
@@ -221,7 +221,7 @@ public class DeltaSinkStreamingExecutionITCase extends DeltaSinkExecutionITCaseB
     }
 
     @Test
-    void can_disable_delta_checkpointing() throws Exception {
+    public void canDisableDeltaCheckpointing() throws Exception {
         final org.apache.hadoop.conf.Configuration hadoopConf =
             new org.apache.hadoop.conf.Configuration();
         hadoopConf.set("io.delta.standalone.checkpointing.enabled", "false");

--- a/flink/src/test/java/io/delta/flink/sink/utils/DeltaSinkTestUtils.java
+++ b/flink/src/test/java/io/delta/flink/sink/utils/DeltaSinkTestUtils.java
@@ -359,6 +359,13 @@ public class DeltaSinkTestUtils {
     public static DeltaSinkInternal<RowData> createDeltaSink(
             String deltaTablePath,
             boolean isTablePartitioned) {
+        return createDeltaSink(deltaTablePath, isTablePartitioned, DeltaTestUtils.getHadoopConf());
+    }
+
+    public static DeltaSinkInternal<RowData> createDeltaSink(
+            String deltaTablePath,
+            boolean isTablePartitioned,
+            org.apache.hadoop.conf.Configuration hadoopConf) {
 
         if (isTablePartitioned) {
             DeltaSinkBuilder<RowData> builder = new DeltaSinkBuilder.DefaultDeltaFormatBuilder<>(
@@ -366,7 +373,7 @@ public class DeltaSinkTestUtils {
                 DeltaTestUtils.getHadoopConf(),
                 ParquetRowDataBuilder.createWriterFactory(
                     DeltaSinkTestUtils.TEST_ROW_TYPE,
-                    DeltaTestUtils.getHadoopConf(),
+                    hadoopConf,
                     true // utcTimestamp
                 ),
                 new BasePathBucketAssigner<>(),
@@ -382,7 +389,7 @@ public class DeltaSinkTestUtils {
         return DeltaSink
             .forRowData(
                 new Path(deltaTablePath),
-                DeltaTestUtils.getHadoopConf(),
+                hadoopConf,
                 DeltaSinkTestUtils.TEST_ROW_TYPE).build();
     }
 

--- a/standalone/src/main/scala/io/delta/standalone/internal/Checkpoints.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/Checkpoints.scala
@@ -30,6 +30,7 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import io.delta.standalone.internal.actions.SingleAction
 import io.delta.standalone.internal.exception.DeltaErrors
 import io.delta.standalone.internal.logging.Logging
+import io.delta.standalone.internal.sources.StandaloneHadoopConf.CHECKPOINTING_ENABLED
 import io.delta.standalone.internal.util.FileNames._
 import io.delta.standalone.internal.util.JsonUtils
 
@@ -119,6 +120,10 @@ private[internal] trait Checkpoints {
    * Creates a checkpoint using snapshotToCheckpoint. By default it uses the current log version.
    */
   def checkpoint(snapshotToCheckpoint: SnapshotImpl): Unit = {
+    if (!hadoopConf.getBoolean(CHECKPOINTING_ENABLED, true)) {
+      logInfo(s"Skipping writing Delta checkpoint for version ${snapshotToCheckpoint.version}")
+      return
+    }
     if (snapshotToCheckpoint.version < 0) {
       throw DeltaErrors.checkpointNonExistTable(dataPath)
     }

--- a/standalone/src/main/scala/io/delta/standalone/internal/sources/StandaloneHadoopConf.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/sources/StandaloneHadoopConf.scala
@@ -37,4 +37,10 @@ private[internal] object StandaloneHadoopConf {
    */
   val PARTITION_FILTER_RECORD_CACHING_KEY =
     "io.delta.standalone.partitionFilterRecordCaching.enabled"
+
+  /**
+   * When set to true, Delta Standalone will checkpoint as normal. When set to false, Delta
+   * Standalone will explicitly skip checkpointing.
+   */
+  val CHECKPOINTING_ENABLED = "io.delta.standalone.checkpointing.enabled"
 }


### PR DESCRIPTION
There may be some cases when the delta checkpointing (every 10th delta commit, where we write the latest active files and un-expired tombstones into a parquet file(s)) is a bottleneck for applications.

e.g. One scenario might be that a user wants to ingest using the Flink/Delta Sink, and use Delta Lake + Apache Spark to create the delta checkpoints in a distributed manner, thus not bottlenecking the flink application.

This PR enables setting the hadoopConf flag (used when you instantiate delta-standalone and the delta-flink sink) `io.delta.standalone.checkpointing.enabled` to `false` to disable checkpointing.