### PR TITLE
Block adding a new column with nullable=false for existing tables

### DIFF
--- a/flink/src/test/java/io/delta/flink/sink/utils/DeltaSinkTestUtils.java
+++ b/flink/src/test/java/io/delta/flink/sink/utils/DeltaSinkTestUtils.java
@@ -115,8 +115,12 @@ public class DeltaSinkTestUtils {
     }
 
     public static RowType addNewColumnToSchema(RowType schema) {
+        return addNewColumnToSchema(schema, true);
+    }
+
+    public static RowType addNewColumnToSchema(RowType schema, boolean isNullable) {
         List<RowType.RowField> fields = new ArrayList<>(schema.getFields());
-        fields.add(new RowType.RowField("someNewField", new IntType()));
+        fields.add(new RowType.RowField("someNewField", new IntType(isNullable)));
         return new RowType(fields);
     }
 

--- a/standalone/src/main/java/io/delta/standalone/types/StructType.java
+++ b/standalone/src/main/java/io/delta/standalone/types/StructType.java
@@ -210,6 +210,7 @@ public final class StructType extends DataType {
      *     <li>Drops any column that is present in the current schema</li>
      *     <li>Converts nullable=true to nullable=false for any column</li>
      *     <li>Changes any datatype</li>
+     *     <li>Adds a new column with nullable=false</li>
      * </ul>
      *
      * @param newSchema  the new schema to update the table with

--- a/standalone/src/test/scala/io/delta/standalone/internal/SchemaUtilsSuite.scala
+++ b/standalone/src/test/scala/io/delta/standalone/internal/SchemaUtilsSuite.scala
@@ -309,8 +309,8 @@ class SchemaUtilsSuite extends FunSuite {
     test(s"adding a nullable field should not fail write compatibility - $scenario") {
       assert(withoutExtra.isWriteCompatible(withExtraNullable))
     }
-    test(s"adding a non-nullable field should not fail write compatibility - $scenario") {
-      assert(withoutExtra.isWriteCompatible(withExtraNonNullable))
+    test(s"adding a non-nullable field should fail write compatibility - $scenario") {
+      assert(!withoutExtra.isWriteCompatible(withExtraNonNullable))
     }
     test(s"case variation of field name should fail write compatibility - $scenario") {
       assert(!withExtraNullable.isWriteCompatible(withExtraMixedCase))


### PR DESCRIPTION
### Changes proposed
For a non-empty table we should block adding a new non-null column (when the current commit does NOT remove all existing data).

Adding a non-null column corrupts the table since any existing rows will have null values for the new column.

### Testing

Updates test in delta standalone and adds a test for the flink sink.