### PR TITLE
[Flink-TableInfo][delta-499] - Refactor IT tests. Introduce TableInfo class 

### DIFF
--- a/flink/src/test/java/io/delta/flink/DeltaEndToEndExecutionITCaseTest.java
+++ b/flink/src/test/java/io/delta/flink/DeltaEndToEndExecutionITCaseTest.java
@@ -147,7 +147,7 @@ public class DeltaEndToEndExecutionITCaseTest {
     )
     @EnumSource(FailoverType.class)
     public void testEndToEndContinuousStream(FailoverType failoverType) throws Exception {
-        TableInfo sourceTableInfo = NonPartitionedTableInfo.create(TMP_FOLDER);
+        TableInfo sourceTableInfo = NonPartitionedTableInfo.createWithInitData(TMP_FOLDER);
 
         // Making sure that we are using path with schema to file system "file://"
         Configuration hadoopConfiguration = DeltaTestUtils.getConfigurationWithMockFs();

--- a/flink/src/test/java/io/delta/flink/DeltaEndToEndExecutionITCaseTest.java
+++ b/flink/src/test/java/io/delta/flink/DeltaEndToEndExecutionITCaseTest.java
@@ -262,7 +262,7 @@ public class DeltaEndToEndExecutionITCaseTest {
 
                 RowRecord row = iterator.next();
                 LOG.info("Row Content: " + row.toString());
-                String[] columnNames = tableInfo.getDataColumnNames();
+                String[] columnNames = tableInfo.getColumnNames();
                 assertAll(() -> {
                         assertThat(
                             row.getByte(columnNames[0]),

--- a/flink/src/test/java/io/delta/flink/DeltaEndToEndExecutionITCaseTest.java
+++ b/flink/src/test/java/io/delta/flink/DeltaEndToEndExecutionITCaseTest.java
@@ -94,7 +94,7 @@ public class DeltaEndToEndExecutionITCaseTest {
     )
     @EnumSource(FailoverType.class)
     public void testEndToEndBoundedStream(FailoverType failoverType) throws Exception {
-        TableInfo sourceTableInfo = LargeNonPartitionedTableInfo.create(TMP_FOLDER);
+        TableInfo sourceTableInfo = LargeNonPartitionedTableInfo.createWithInitData(TMP_FOLDER);
 
         // Making sure that we are using path with schema to file system "file://"
         Configuration hadoopConfiguration = DeltaTestUtils.getConfigurationWithMockFs();

--- a/flink/src/test/java/io/delta/flink/internal/table/DeltaDynamicTableSourceTest.java
+++ b/flink/src/test/java/io/delta/flink/internal/table/DeltaDynamicTableSourceTest.java
@@ -9,6 +9,8 @@ import io.delta.flink.internal.table.DeltaFlinkJobSpecificOptions.QueryMode;
 import io.delta.flink.source.DeltaSource;
 import io.delta.flink.source.internal.DeltaSourceOptions;
 import io.delta.flink.utils.DeltaTestUtils;
+import io.delta.flink.utils.resources.TableInfo;
+import io.delta.flink.utils.resources.VersionedNonPartitionedTable;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.table.connector.source.ScanTableSource.ScanContext;
 import org.apache.flink.table.connector.source.SourceProvider;
@@ -31,8 +33,6 @@ public class DeltaDynamicTableSourceTest {
 
     private Configuration hadoopConf;
 
-    private String tablePath;
-
     private ScanContext context;
 
     @BeforeAll
@@ -49,7 +49,6 @@ public class DeltaDynamicTableSourceTest {
     public void setUp() throws IOException {
         this.context = new ScanRuntimeProviderContext();
         this.hadoopConf = DeltaTestUtils.getHadoopConf();
-        this.tablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
     }
 
     @SuppressWarnings("unchecked")
@@ -62,7 +61,8 @@ public class DeltaDynamicTableSourceTest {
     })
     public void shouldCreateBoundedSourceWithOptions(String name, String value) throws IOException {
 
-        DeltaTestUtils.initTestForVersionedTable(tablePath);
+        TableInfo tableInfo = VersionedNonPartitionedTable.createWithInitData(TEMPORARY_FOLDER);
+        String tablePath = tableInfo.getTablePath();
 
         if (name.equals("timestampAsOf")) {
             DeltaTestUtils.changeDeltaLogLastModifyTimestamp(tablePath, new String[] {value});
@@ -106,7 +106,8 @@ public class DeltaDynamicTableSourceTest {
     public void shouldCreateContinuousSourceWithOptions(String name, String value)
         throws IOException {
 
-        DeltaTestUtils.initTestForVersionedTable(tablePath);
+        TableInfo tableInfo = VersionedNonPartitionedTable.createWithInitData(TEMPORARY_FOLDER);
+        String tablePath = tableInfo.getTablePath();
 
         // Continuous mode has more options that can be used together comparing to BATCH mode.
         Map<String, String> jobOptions = new HashMap<>();

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkExecutionITCaseBase.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkExecutionITCaseBase.java
@@ -9,26 +9,23 @@ import io.delta.flink.sink.internal.committables.DeltaCommittable;
 import io.delta.flink.sink.internal.committables.DeltaGlobalCommittable;
 import io.delta.flink.sink.internal.committer.DeltaGlobalCommitter;
 import io.delta.flink.sink.internal.writer.DeltaWriterBucketState;
-import io.delta.flink.utils.DeltaTestUtils;
+import io.delta.flink.utils.resources.NonPartitionedTableInfo;
+import io.delta.flink.utils.resources.PartitionedTableInfo;
+import io.delta.flink.utils.resources.TableInfo;
 import org.apache.flink.api.connector.sink.Committer;
 import org.apache.flink.api.connector.sink.GlobalCommitter;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.junit.rules.TemporaryFolder;
 
 public abstract class DeltaSinkExecutionITCaseBase {
 
-    protected String initSourceFolder(boolean isPartitioned, String deltaTablePath) {
-        try {
-            if (isPartitioned) {
-                DeltaTestUtils.initTestForPartitionedTable(deltaTablePath);
-            } else {
-                DeltaTestUtils.initTestForNonPartitionedTable(deltaTablePath);
-            }
-
-            return deltaTablePath;
-        } catch (IOException e) {
-            throw new RuntimeException("Weren't able to setup the test dependencies", e);
+    protected TableInfo initSourceFolder(boolean isPartitioned, TemporaryFolder tmpFolder) {
+        if (isPartitioned) {
+            return PartitionedTableInfo.createWithInitData(tmpFolder);
+        } else {
+            return NonPartitionedTableInfo.createWithInitData(tmpFolder);
         }
     }
 

--- a/flink/src/test/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitterTestParametrized.java
+++ b/flink/src/test/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitterTestParametrized.java
@@ -110,8 +110,7 @@ public class DeltaGlobalCommitterTestParametrized {
             }
         }
         deltaLog = DeltaLog.forTable(DeltaTestUtils.getHadoopConf(), tableInfo.getTablePath());
-        RowType rowType = (partitionSpec.isEmpty()) ?
-            DeltaSinkTestUtils.TEST_ROW_TYPE : DeltaSinkTestUtils.TEST_PARTITIONED_ROW_TYPE;
+        RowType rowType = tableInfo.getRowType();
 
         rowTypeToCommit = mergeSchema ?
             DeltaSinkTestUtils.addNewColumnToSchema(rowType) : rowType;

--- a/flink/src/test/java/io/delta/flink/source/DeltaSourceBoundedExecutionITCaseTest.java
+++ b/flink/src/test/java/io/delta/flink/source/DeltaSourceBoundedExecutionITCaseTest.java
@@ -16,6 +16,7 @@ import io.delta.flink.utils.RecordCounterToFail.FailCheck;
 import io.delta.flink.utils.TestDescriptor;
 import io.delta.flink.utils.TestDescriptor.Descriptor;
 import io.delta.flink.utils.resources.TableInfo;
+import io.delta.flink.utils.resources.VersionedNonPartitionedTable;
 import io.github.artsok.ParameterizedRepeatedIfExceptionsTest;
 import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.flink.api.common.RuntimeExecutionMode;
@@ -138,8 +139,8 @@ public class DeltaSourceBoundedExecutionITCaseTest extends DeltaSourceITBase {
         Descriptor update = new Descriptor(
             RowType.of(
                 true, // nullable = true;
-                nonPartitionedTable.getDataColumnTypes(),
-                nonPartitionedTable.getDataColumnNames()
+                nonPartitionedTable.getColumnTypes(),
+                nonPartitionedTable.getColumnNames()
             ),
             Collections.singletonList(Row.of("John-K", "Wick-P", 1410))
         );
@@ -188,12 +189,11 @@ public class DeltaSourceBoundedExecutionITCaseTest extends DeltaSourceITBase {
 
         // this test uses test-non-partitioned-delta-table-4-versions table. See README.md from
         // table's folder for detail information about this table.
-        String sourceTablePath = TMP_FOLDER.newFolder().getAbsolutePath();
-        DeltaTestUtils.initTestForVersionedTable(sourceTablePath);
+        TableInfo tableInfo = VersionedNonPartitionedTable.createWithInitData(TMP_FOLDER);
 
         DeltaSource<RowData> deltaSource = DeltaSource
             .forBoundedRowData(
-                new Path(sourceTablePath),
+                new Path(tableInfo.getTablePath()),
                 DeltaTestUtils.getHadoopConf())
             .versionAsOf(versionAsOf)
             .build();
@@ -246,8 +246,8 @@ public class DeltaSourceBoundedExecutionITCaseTest extends DeltaSourceITBase {
 
         // this test uses test-non-partitioned-delta-table-4-versions table. See README.md from
         // table's folder for detail information about this table.
-        String sourceTablePath = TMP_FOLDER.newFolder().getAbsolutePath();
-        DeltaTestUtils.initTestForVersionedTable(sourceTablePath);
+        TableInfo tableInfo = VersionedNonPartitionedTable.createWithInitData(TMP_FOLDER);
+        String sourceTablePath = tableInfo.getTablePath();
 
         // Delta standalone uses "last modification time" file attribute for providing commits
         // before/after or at timestamp. It Does not use an actually commits creation timestamp

--- a/flink/src/test/java/io/delta/flink/source/DeltaSourceContinuousExecutionITCaseTest.java
+++ b/flink/src/test/java/io/delta/flink/source/DeltaSourceContinuousExecutionITCaseTest.java
@@ -25,6 +25,7 @@ import io.delta.flink.utils.TableUpdateDescriptor;
 import io.delta.flink.utils.TestDescriptor;
 import io.delta.flink.utils.TestDescriptor.Descriptor;
 import io.delta.flink.utils.resources.TableInfo;
+import io.delta.flink.utils.resources.VersionedNonPartitionedTable;
 import io.github.artsok.ParameterizedRepeatedIfExceptionsTest;
 import io.github.artsok.RepeatedIfExceptionsTest;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
@@ -228,8 +229,8 @@ public class DeltaSourceContinuousExecutionITCaseTest extends DeltaSourceITBase 
         Descriptor versionOneUpdate = new Descriptor(
             RowType.of(
                 true, // nullable = true;
-                nonPartitionedTable.getDataColumnTypes(),
-                nonPartitionedTable.getDataColumnNames()
+                nonPartitionedTable.getColumnTypes(),
+                nonPartitionedTable.getColumnNames()
             ),
             Arrays.asList(
                 Row.of("John-K", "Wick-P", 1410),
@@ -250,8 +251,8 @@ public class DeltaSourceContinuousExecutionITCaseTest extends DeltaSourceITBase 
         Descriptor versionTwoUpdate = new Descriptor(
             RowType.of(
                 true, // nullable = true;
-                nonPartitionedTable.getDataColumnTypes(),
-                nonPartitionedTable.getDataColumnNames()
+                nonPartitionedTable.getColumnTypes(),
+                nonPartitionedTable.getColumnNames()
             ),
             Arrays.asList(
                 Row.of("John-K", "Wick-P", 1510),
@@ -366,8 +367,8 @@ public class DeltaSourceContinuousExecutionITCaseTest extends DeltaSourceITBase 
 
         // this test uses test-non-partitioned-delta-table-4-versions table. See README.md from
         // table's folder for detail information about this table.
-        String sourceTablePath = TMP_FOLDER.newFolder().getAbsolutePath();
-        DeltaTestUtils.initTestForVersionedTable(sourceTablePath);
+        TableInfo tableInfo = VersionedNonPartitionedTable.createWithInitData(TMP_FOLDER);
+        String sourceTablePath = tableInfo.getTablePath();
 
         DeltaSource<RowData> deltaSource = DeltaSource
             .forContinuousRowData(
@@ -429,8 +430,8 @@ public class DeltaSourceContinuousExecutionITCaseTest extends DeltaSourceITBase 
             + startingTimestamp);
         // this test uses test-non-partitioned-delta-table-4-versions table. See README.md from
         // table's folder for detail information about this table.
-        String sourceTablePath = TMP_FOLDER.newFolder().getAbsolutePath();
-        DeltaTestUtils.initTestForVersionedTable(sourceTablePath);
+        TableInfo tableInfo = VersionedNonPartitionedTable.createWithInitData(TMP_FOLDER);
+        String sourceTablePath = tableInfo.getTablePath();
 
         // Delta standalone uses "last modification time" file attribute for providing commits
         // before/after or at timestamp. It Does not use an actually commits creation timestamp

--- a/flink/src/test/java/io/delta/flink/source/DeltaSourceITBase.java
+++ b/flink/src/test/java/io/delta/flink/source/DeltaSourceITBase.java
@@ -51,7 +51,7 @@ public abstract class DeltaSourceITBase extends TestLogger {
 
     protected TableInfo largeNonPartitionedTable;
 
-    protected TableInfo partitionedTable;
+    protected PartitionedTableInfo partitionedTable;
 
     public static void beforeAll() throws IOException {
         TMP_FOLDER.create();

--- a/flink/src/test/java/io/delta/flink/source/DeltaSourceITBase.java
+++ b/flink/src/test/java/io/delta/flink/source/DeltaSourceITBase.java
@@ -65,7 +65,7 @@ public abstract class DeltaSourceITBase extends TestLogger {
         try {
             miniClusterResource.before();
             nonPartitionedTable = NonPartitionedTableInfo.createWithInitData(TMP_FOLDER);
-            largeNonPartitionedTable = LargeNonPartitionedTableInfo.create(TMP_FOLDER);
+            largeNonPartitionedTable = LargeNonPartitionedTableInfo.createWithInitData(TMP_FOLDER);
             partitionedTable = PartitionedTableInfo.createWithInitData(TMP_FOLDER);
         } catch (Exception e) {
             throw new RuntimeException("Weren't able to setup the test dependencies", e);

--- a/flink/src/test/java/io/delta/flink/source/DeltaSourceITBase.java
+++ b/flink/src/test/java/io/delta/flink/source/DeltaSourceITBase.java
@@ -64,9 +64,9 @@ public abstract class DeltaSourceITBase extends TestLogger {
     public void setup() {
         try {
             miniClusterResource.before();
-            nonPartitionedTable = NonPartitionedTableInfo.create(TMP_FOLDER);
+            nonPartitionedTable = NonPartitionedTableInfo.createWithInitData(TMP_FOLDER);
             largeNonPartitionedTable = LargeNonPartitionedTableInfo.create(TMP_FOLDER);
-            partitionedTable = PartitionedTableInfo.create(TMP_FOLDER);
+            partitionedTable = PartitionedTableInfo.createWithInitData(TMP_FOLDER);
         } catch (Exception e) {
             throw new RuntimeException("Weren't able to setup the test dependencies", e);
         }

--- a/flink/src/test/java/io/delta/flink/table/it/suite/DeltaCatalogTestSuite.java
+++ b/flink/src/test/java/io/delta/flink/table/it/suite/DeltaCatalogTestSuite.java
@@ -13,6 +13,7 @@ import java.util.StringJoiner;
 import io.delta.flink.internal.table.TestTableData;
 import io.delta.flink.utils.DeltaTestUtils;
 import io.delta.flink.utils.resources.NonPartitionedTableInfo;
+import io.delta.flink.utils.resources.PartitionedTableInfo;
 import io.delta.flink.utils.resources.SqlTableInfo;
 import org.apache.commons.io.FileUtils;
 import org.apache.flink.table.api.EnvironmentSettings;
@@ -252,8 +253,8 @@ public abstract class DeltaCatalogTestSuite {
             assertThrows(RuntimeException.class, () -> tableEnv.executeSql(deltaTable).await());
 
         assertThat(exception.getCause().getMessage())
-            .isEqualTo(""
-                + "Table definition contains unsupported column types. Currently, only physical "
+            .isEqualTo(
+                "Table definition contains unsupported column types. Currently, only physical "
                 + "columns are supported by Delta Flink connector.\n"
                 + "Invalid columns and types:\n"
                 + "col4 -> ComputedColumn\n"
@@ -292,8 +293,8 @@ public abstract class DeltaCatalogTestSuite {
             assertThrows(RuntimeException.class, () -> tableEnv.executeSql(deltaTable).await());
 
         assertThat(exception.getCause().getMessage())
-            .isEqualTo(""
-                + "Table definition contains unsupported column types. Currently, only physical "
+            .isEqualTo(
+                "Table definition contains unsupported column types. Currently, only physical "
                 + "columns are supported by Delta Flink connector.\n"
                 + "Invalid columns and types:\n"
                 + "record_time -> MetadataColumn"
@@ -312,7 +313,7 @@ public abstract class DeltaCatalogTestSuite {
         "name INT, surname VARCHAR, age INT", // different type for first column
         "name VARCHAR NOT NULL, surname VARCHAR, age INT" // all columns should be nullable
     })
-    public void shouldThrowIfSchemaDoesNotMatch(String ddlSchema) throws Exception {
+    public void shouldThrowIfSchemaDoesNotMatch(String ddlSchema) {
 
         // GIVEN
         SqlTableInfo tableInfo = NonPartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
@@ -357,14 +358,14 @@ public abstract class DeltaCatalogTestSuite {
     @Test
     public void shouldThrow_createTable_invalidTableProperties() throws Exception {
 
-        String invalidOptions = ""
-            + "'spark.some.option' = 'aValue',\n"
+        String invalidOptions =
+            "'spark.some.option' = 'aValue',\n"
             + "'delta.logStore' = 'myLog',\n"
             + "'io.delta.storage.S3DynamoDBLogStore.ddb.region' = 'Poland',\n"
             + "'parquet.writer.max-padding' = '10'\n";
 
-        String expectedValidationMessage = ""
-            + "DDL contains invalid properties. DDL can have only delta table properties or "
+        String expectedValidationMessage =
+            "DDL contains invalid properties. DDL can have only delta table properties or "
             + "arbitrary user options only.\n"
             + "Invalid options used:\n"
             + " - 'spark.some.option'\n"
@@ -383,8 +384,8 @@ public abstract class DeltaCatalogTestSuite {
 
         // This test will not check if options are mutual excluded.
         // This is covered by table Factory and Source builder tests.
-        String invalidOptions = ""
-            + "'startingVersion' = '10',\n"
+        String invalidOptions =
+            "'startingVersion' = '10',\n"
             + "'startingTimestamp' = '2022-02-24T04:55:00.001',\n"
             + "'updateCheckIntervalMillis' = '1000',\n"
             + "'updateCheckDelayMillis' = '1000',\n"
@@ -393,8 +394,8 @@ public abstract class DeltaCatalogTestSuite {
             + "'versionAsOf' = '10',\n"
             + "'timestampAsOf' = '2022-02-24T04:55:00.001'";
 
-        String expectedValidationMessage = ""
-            + "DDL contains invalid properties. DDL can have only delta table properties or "
+        String expectedValidationMessage =
+            "DDL contains invalid properties. DDL can have only delta table properties or "
             + "arbitrary user options only.\n"
             + "DDL contains job-specific options. Job-specific options can be used only via Query"
             + " hints.\n"
@@ -420,8 +421,8 @@ public abstract class DeltaCatalogTestSuite {
 
         // This test will not check if options are mutual excluded.
         // This is covered by table Factory and Source builder tests.
-        String invalidOptions = ""
-            + "'startingVersion' = '10',\n"
+        String invalidOptions =
+            "'startingVersion' = '10',\n"
             + "'startingTimestamp' = '2022-02-24T04:55:00.001',\n"
             + "'updateCheckIntervalMillis' = '1000',\n"
             + "'updateCheckDelayMillis' = '1000',\n"
@@ -434,8 +435,8 @@ public abstract class DeltaCatalogTestSuite {
             + "'io.delta.storage.S3DynamoDBLogStore.ddb.region' = 'Poland',\n"
             + "'parquet.writer.max-padding' = '10'\n";
 
-        String expectedValidationMessage = ""
-            + "DDL contains invalid properties. DDL can have only delta table properties or "
+        String expectedValidationMessage =
+            "DDL contains invalid properties. DDL can have only delta table properties or "
             + "arbitrary user options only.\n"
             + "Invalid options used:\n"
             + " - 'spark.some.option'\n"
@@ -492,7 +493,7 @@ public abstract class DeltaCatalogTestSuite {
      * has different partition spec that specified in DDL.
      */
     @Test
-    public void shouldThrowIfPartitionSpecDoesNotMatch() throws Exception {
+    public void shouldThrowIfPartitionSpecDoesNotMatch() {
 
         // GIVEN
         SqlTableInfo tableInfo = NonPartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
@@ -534,7 +535,7 @@ public abstract class DeltaCatalogTestSuite {
     }
 
     @Test
-    public void shouldThrowIfTableSchemaAndPartitionSpecDoNotMatch() throws IOException {
+    public void shouldThrowIfTableSchemaAndPartitionSpecDoNotMatch() {
         // GIVEN
         SqlTableInfo tableInfo = NonPartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
         String tablePath = tableInfo.getTablePath();
@@ -579,7 +580,7 @@ public abstract class DeltaCatalogTestSuite {
      * has different delta table properties that specified in DDL.
      */
     @Test
-    public void shouldThrowIfDeltaTablePropertiesDoNotMatch() throws Exception {
+    public void shouldThrowIfDeltaTablePropertiesDoNotMatch() {
 
         // GIVEN
         SqlTableInfo tableInfo = NonPartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
@@ -617,8 +618,8 @@ public abstract class DeltaCatalogTestSuite {
 
         // THEN
         assertThat(exception.getCause().getMessage())
-            .isEqualTo(""
-                + "Invalid DDL options for table [default.sourceTable]. DDL options for Delta "
+            .isEqualTo(
+                "Invalid DDL options for table [default.sourceTable]. DDL options for Delta "
                 + "table connector cannot override table properties already defined in _delta_log"
                 + ".\n"
                 + "DDL option name | DDL option value | Delta option value \n"
@@ -635,7 +636,8 @@ public abstract class DeltaCatalogTestSuite {
     public void shouldDescribeTable() throws Exception {
 
         // GIVEN
-        DeltaTestUtils.initTestForPartitionedTable(tablePath);
+        SqlTableInfo tableInfo = PartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
+        String tablePath = tableInfo.getTablePath();
 
         DeltaLog deltaLog =
             DeltaLog.forTable(DeltaTestUtils.getHadoopConf(), tablePath);
@@ -689,7 +691,8 @@ public abstract class DeltaCatalogTestSuite {
     public void shouldAlterTableName() throws Exception {
 
         // GIVEN
-        DeltaTestUtils.initTestForPartitionedTable(tablePath);
+        SqlTableInfo tableInfo = PartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
+        String tablePath = tableInfo.getTablePath();
 
         DeltaLog deltaLog =
             DeltaLog.forTable(DeltaTestUtils.getHadoopConf(), tablePath);

--- a/flink/src/test/java/io/delta/flink/table/it/suite/DeltaCatalogTestSuite.java
+++ b/flink/src/test/java/io/delta/flink/table/it/suite/DeltaCatalogTestSuite.java
@@ -12,6 +12,8 @@ import java.util.StringJoiner;
 
 import io.delta.flink.internal.table.TestTableData;
 import io.delta.flink.utils.DeltaTestUtils;
+import io.delta.flink.utils.resources.NonPartitionedTableInfo;
+import io.delta.flink.utils.resources.SqlTableInfo;
 import org.apache.commons.io.FileUtils;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
@@ -313,7 +315,8 @@ public abstract class DeltaCatalogTestSuite {
     public void shouldThrowIfSchemaDoesNotMatch(String ddlSchema) throws Exception {
 
         // GIVEN
-        DeltaTestUtils.initTestForNonPartitionedTable(tablePath);
+        SqlTableInfo tableInfo = NonPartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
+        String tablePath = tableInfo.getTablePath();
 
         DeltaLog deltaLog =
             DeltaLog.forTable(DeltaTestUtils.getHadoopConf(), tablePath);
@@ -492,7 +495,8 @@ public abstract class DeltaCatalogTestSuite {
     public void shouldThrowIfPartitionSpecDoesNotMatch() throws Exception {
 
         // GIVEN
-        DeltaTestUtils.initTestForNonPartitionedTable(tablePath);
+        SqlTableInfo tableInfo = NonPartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
+        String tablePath = tableInfo.getTablePath();
 
         DeltaLog deltaLog =
             DeltaLog.forTable(DeltaTestUtils.getHadoopConf(), tablePath);
@@ -532,7 +536,8 @@ public abstract class DeltaCatalogTestSuite {
     @Test
     public void shouldThrowIfTableSchemaAndPartitionSpecDoNotMatch() throws IOException {
         // GIVEN
-        DeltaTestUtils.initTestForNonPartitionedTable(tablePath);
+        SqlTableInfo tableInfo = NonPartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
+        String tablePath = tableInfo.getTablePath();
 
         DeltaLog deltaLog =
             DeltaLog.forTable(DeltaTestUtils.getHadoopConf(), tablePath);
@@ -577,7 +582,8 @@ public abstract class DeltaCatalogTestSuite {
     public void shouldThrowIfDeltaTablePropertiesDoNotMatch() throws Exception {
 
         // GIVEN
-        DeltaTestUtils.initTestForNonPartitionedTable(tablePath);
+        SqlTableInfo tableInfo = NonPartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
+        String tablePath = tableInfo.getTablePath();
 
         Map<String, String> configuration = new HashMap<>();
         configuration.put("delta.appendOnly", "false");

--- a/flink/src/test/java/io/delta/flink/table/it/suite/DeltaEndToEndTableTestSuite.java
+++ b/flink/src/test/java/io/delta/flink/table/it/suite/DeltaEndToEndTableTestSuite.java
@@ -93,7 +93,7 @@ public abstract class DeltaEndToEndTableTestSuite {
             sourceTable.getSqlTableSchema(),
             sourceTable.getTablePath());
 
-        LOG.info("Source Table DDL: " + sinkTablePath);
+        LOG.info("Source Table DDL: " + sourceTableDdl);
     }
 
     @Test
@@ -349,11 +349,6 @@ public abstract class DeltaEndToEndTableTestSuite {
 
         @Override
         public String getPartitions() {
-            return "";
-        }
-
-        @Override
-        public String getTableInitStatePath() {
             return "";
         }
 

--- a/flink/src/test/java/io/delta/flink/table/it/suite/DeltaEndToEndTableTestSuite.java
+++ b/flink/src/test/java/io/delta/flink/table/it/suite/DeltaEndToEndTableTestSuite.java
@@ -76,7 +76,7 @@ public abstract class DeltaEndToEndTableTestSuite {
     public void setUp() {
 
         try {
-            sourceTable = LargeNonPartitionedTableInfo.create(TEMPORARY_FOLDER);
+            sourceTable = LargeNonPartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
             sinkTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
             assertThat(sinkTablePath)
                 .isNotEqualToIgnoringCase(sourceTable.getTablePath());

--- a/flink/src/test/java/io/delta/flink/table/it/suite/DeltaEndToEndTableTestSuite.java
+++ b/flink/src/test/java/io/delta/flink/table/it/suite/DeltaEndToEndTableTestSuite.java
@@ -134,8 +134,8 @@ public abstract class DeltaEndToEndTableTestSuite {
         // streamingMode = false
         StreamTableEnvironment tableEnv = setupTableEnvAndDeltaCatalog(false);
 
-        String sinkTableDdl = String.format(""
-                + "CREATE TABLE sinkTable "
+        String sinkTableDdl = String.format(
+            "CREATE TABLE sinkTable "
                 + "WITH ("
                 + "'connector' = 'delta',"
                 + "'table-path' = '%s'"
@@ -162,8 +162,8 @@ public abstract class DeltaEndToEndTableTestSuite {
         // streamingMode = false
         StreamTableEnvironment tableEnv = setupTableEnvAndDeltaCatalog(false);
 
-        String sinkTableDdl = String.format(""
-                + "CREATE TABLE sinkTable "
+        String sinkTableDdl = String.format(
+            "CREATE TABLE sinkTable "
                 + "WITH ("
                 + "'connector' = 'delta',"
                 + "'table-path' = '%s'"
@@ -358,12 +358,12 @@ public abstract class DeltaEndToEndTableTestSuite {
         }
 
         @Override
-        public String[] getDataColumnNames() {
+        public String[] getColumnNames() {
             return rowType.getFieldNames().toArray(new String[0]);
         }
 
         @Override
-        public LogicalType[] getDataColumnTypes() {
+        public LogicalType[] getColumnTypes() {
             return rowType.getFields().stream().map(RowField::getType).toArray(LogicalType[]::new);
         }
 

--- a/flink/src/test/java/io/delta/flink/table/it/suite/DeltaEndToEndTableTestSuite.java
+++ b/flink/src/test/java/io/delta/flink/table/it/suite/DeltaEndToEndTableTestSuite.java
@@ -376,6 +376,11 @@ public abstract class DeltaEndToEndTableTestSuite {
         public RowType getRowType() {
             return rowType;
         }
+
+        @Override
+        public boolean isPartitioned() {
+            return false;
+        }
     }
 
 }

--- a/flink/src/test/java/io/delta/flink/table/it/suite/DeltaSourceTableTestSuite.java
+++ b/flink/src/test/java/io/delta/flink/table/it/suite/DeltaSourceTableTestSuite.java
@@ -105,7 +105,8 @@ public abstract class DeltaSourceTableTestSuite {
         try {
             miniClusterResource.before();
             nonPartitionedTable = NonPartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
-            largeNonPartitionedTable = LargeNonPartitionedTableInfo.create(TEMPORARY_FOLDER);
+            largeNonPartitionedTable =
+                LargeNonPartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
             partitionedTable = PartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
         } catch (Exception e) {
             throw new RuntimeException("Weren't able to setup the test dependencies", e);

--- a/flink/src/test/java/io/delta/flink/table/it/suite/DeltaSourceTableTestSuite.java
+++ b/flink/src/test/java/io/delta/flink/table/it/suite/DeltaSourceTableTestSuite.java
@@ -104,9 +104,9 @@ public abstract class DeltaSourceTableTestSuite {
     public void setUp() {
         try {
             miniClusterResource.before();
-            nonPartitionedTable = NonPartitionedTableInfo.create(TEMPORARY_FOLDER);
+            nonPartitionedTable = NonPartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
             largeNonPartitionedTable = LargeNonPartitionedTableInfo.create(TEMPORARY_FOLDER);
-            partitionedTable = PartitionedTableInfo.create(TEMPORARY_FOLDER);
+            partitionedTable = PartitionedTableInfo.createWithInitData(TEMPORARY_FOLDER);
         } catch (Exception e) {
             throw new RuntimeException("Weren't able to setup the test dependencies", e);
         }

--- a/flink/src/test/java/io/delta/flink/utils/DeltaTableUpdater.java
+++ b/flink/src/test/java/io/delta/flink/utils/DeltaTableUpdater.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.UUID;
 
 import io.delta.flink.utils.TestDescriptor.Descriptor;
+import io.delta.flink.utils.resources.TableInfo;
 import org.apache.flink.api.common.serialization.BulkWriter;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.Path;
@@ -37,6 +38,10 @@ public class DeltaTableUpdater {
 
     public DeltaTableUpdater(String deltaTablePath) {
         this.deltaTablePath = deltaTablePath;
+    }
+
+    public DeltaTableUpdater(TableInfo nonPartitionedTable) {
+        this(nonPartitionedTable.getTablePath());
     }
 
     /**

--- a/flink/src/test/java/io/delta/flink/utils/DeltaTestUtils.java
+++ b/flink/src/test/java/io/delta/flink/utils/DeltaTestUtils.java
@@ -111,19 +111,11 @@ public class DeltaTestUtils {
     // test data utils
     ///////////////////////////////////////////////////////////////////////////
 
-    public static final String TEST_DELTA_TABLE_INITIAL_STATE_P_DIR =
-        "/test-data/test-partitioned-delta-table-initial-state";
-
     public static final String TEST_VERSIONED_DELTA_TABLE =
         "/test-data/test-non-partitioned-delta-table-4-versions";
 
     public static final String TEST_DELTA_TABLE_INITIAL_STATE_TABLE_API_DIR =
         "/test-data/test-table-api";
-
-    public static void initTestForPartitionedTable(String targetTablePath)
-        throws IOException {
-        initTestFor(TEST_DELTA_TABLE_INITIAL_STATE_P_DIR, targetTablePath);
-    }
 
     public static void initTestForVersionedTable(String targetTablePath)
         throws IOException {

--- a/flink/src/test/java/io/delta/flink/utils/DeltaTestUtils.java
+++ b/flink/src/test/java/io/delta/flink/utils/DeltaTestUtils.java
@@ -111,9 +111,6 @@ public class DeltaTestUtils {
     // test data utils
     ///////////////////////////////////////////////////////////////////////////
 
-    public static final String TEST_DELTA_TABLE_INITIAL_STATE_NP_DIR =
-        "/test-data/test-non-partitioned-delta-table-initial-state";
-
     public static final String TEST_DELTA_TABLE_INITIAL_STATE_P_DIR =
         "/test-data/test-partitioned-delta-table-initial-state";
 
@@ -122,11 +119,6 @@ public class DeltaTestUtils {
 
     public static final String TEST_DELTA_TABLE_INITIAL_STATE_TABLE_API_DIR =
         "/test-data/test-table-api";
-
-    public static void initTestForNonPartitionedTable(String targetTablePath)
-        throws IOException {
-        initTestFor(TEST_DELTA_TABLE_INITIAL_STATE_NP_DIR, targetTablePath);
-    }
 
     public static void initTestForPartitionedTable(String targetTablePath)
         throws IOException {

--- a/flink/src/test/java/io/delta/flink/utils/DeltaTestUtils.java
+++ b/flink/src/test/java/io/delta/flink/utils/DeltaTestUtils.java
@@ -111,22 +111,6 @@ public class DeltaTestUtils {
     // test data utils
     ///////////////////////////////////////////////////////////////////////////
 
-    public static final String TEST_VERSIONED_DELTA_TABLE =
-        "/test-data/test-non-partitioned-delta-table-4-versions";
-
-    public static final String TEST_DELTA_TABLE_INITIAL_STATE_TABLE_API_DIR =
-        "/test-data/test-table-api";
-
-    public static void initTestForVersionedTable(String targetTablePath)
-        throws IOException {
-        initTestFor(TEST_VERSIONED_DELTA_TABLE, targetTablePath);
-    }
-
-    public static void initTestForTableApiTable(String targetTablePath)
-        throws IOException {
-        initTestFor(TEST_DELTA_TABLE_INITIAL_STATE_TABLE_API_DIR, targetTablePath);
-    }
-
     public static void initTestFor(String testDeltaTableInitialStateNpDir, String targetTablePath)
         throws IOException {
         File resourcesDirectory = new File("src/test/resources");

--- a/flink/src/test/java/io/delta/flink/utils/ExecutionITCaseTestConstants.java
+++ b/flink/src/test/java/io/delta/flink/utils/ExecutionITCaseTestConstants.java
@@ -5,27 +5,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.flink.table.types.logical.BigIntType;
-import org.apache.flink.table.types.logical.BooleanType;
-import org.apache.flink.table.types.logical.CharType;
-import org.apache.flink.table.types.logical.DecimalType;
-import org.apache.flink.table.types.logical.DoubleType;
-import org.apache.flink.table.types.logical.FloatType;
-import org.apache.flink.table.types.logical.IntType;
-import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.SmallIntType;
-import org.apache.flink.table.types.logical.TimestampType;
-import org.apache.flink.table.types.logical.TinyIntType;
-import org.apache.flink.table.types.logical.VarCharType;
-
 public final class ExecutionITCaseTestConstants {
 
     private ExecutionITCaseTestConstants() {
 
     }
-
-    public static final LogicalType[] DATA_COLUMN_TYPES =
-        {new CharType(), new CharType(), new IntType()};
 
     public static final List<String> NAME_COLUMN_VALUES =
         Stream.of("Jan", "Jan").collect(Collectors.toList());
@@ -35,32 +19,5 @@ public final class ExecutionITCaseTestConstants {
 
     public static final Set<Integer> AGE_COLUMN_VALUES =
         Stream.of(1, 2).collect(Collectors.toSet());
-
-    public static final String[] ALL_DATA_TABLE_COLUMN_NAMES = {
-        "col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8", "col9", "col10"
-    };
-
-    public static final LogicalType[] ALL_DATA_TABLE_COLUMN_TYPES = {
-        new TinyIntType(), new SmallIntType(), new IntType(), new DoubleType(), new FloatType(),
-        new DecimalType(), new DecimalType(), new TimestampType(), new VarCharType(),
-        new BooleanType()
-    };
-
-    public static final int ALL_DATA_TABLE_RECORD_COUNT = 5;
-
-    /**
-     * Columns that are not used as a partition columns.
-     */
-    public static final String[] DATA_COLUMN_NAMES = {"name", "surname", "age"};
-
-    // Large table has no partitions.
-    public static final String[] LARGE_TABLE_ALL_COLUMN_NAMES = {"col1", "col2", "col3"};
-
-    public static final LogicalType[] LARGE_TABLE_ALL_COLUMN_TYPES =
-        {new BigIntType(), new BigIntType(), new VarCharType()};
-
-    public static final int SMALL_TABLE_COUNT = 2;
-
-    public static final int LARGE_TABLE_RECORD_COUNT = 1100;
 
 }

--- a/flink/src/test/java/io/delta/flink/utils/TestDescriptor.java
+++ b/flink/src/test/java/io/delta/flink/utils/TestDescriptor.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import io.delta.flink.utils.resources.TableInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
 
@@ -32,6 +33,10 @@ public class TestDescriptor {
     public TestDescriptor(String tablePath, int initialDataSize) {
         this.tablePath = tablePath;
         this.initialDataSize = initialDataSize;
+    }
+
+    public TestDescriptor(TableInfo partitionedTable) {
+        this(partitionedTable.getTablePath(), partitionedTable.getInitialRecordCount());
     }
 
     /**

--- a/flink/src/test/java/io/delta/flink/utils/resources/AllTypesNonPartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/AllTypesNonPartitionedTableInfo.java
@@ -14,6 +14,10 @@ import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.junit.rules.TemporaryFolder;
 
+/**
+ * {@link TableInfo} non-implementation for partitioned Delta table containing rows with all
+ * supported simple data types.
+ */
 public class AllTypesNonPartitionedTableInfo implements TableInfo {
 
     private static final String tableInitStatePath =
@@ -35,6 +39,22 @@ public class AllTypesNonPartitionedTableInfo implements TableInfo {
         this.runtimePath = runtimePath;
     }
 
+    /**
+     * Initialized non-partitioned test Delta table that can be used for IT tests.
+     * Created table will contain 5 with columns representing every simple Flink column type.
+     * Table will be backed with files from {@code resources/test-data/test-non-partitioned-delta
+     * -table-alltypes}. The original files will be compiled to the temporary folder provided via
+     * the argument. The path to created Delta table can be obtained from {@link #getTablePath()}.
+     * <p>
+     * Schema for created table will be:
+     * <ul>
+     *     <li> column names: "col1 - col10"</li>
+     *     <li> column types: TinyIntType, SmallIntType, IntType, DoubleType, FloatType,
+     *      DecimalType, TimestampType, VarCharType, BooleanType</li>
+     * </ul>
+     *
+     * @param tmpFolder Temporary folder where table files should be copied to.
+     */
     public static AllTypesNonPartitionedTableInfo create(TemporaryFolder tmpFolder) {
         try {
             String runtimePath = tmpFolder.newFolder().getAbsolutePath();

--- a/flink/src/test/java/io/delta/flink/utils/resources/AllTypesNonPartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/AllTypesNonPartitionedTableInfo.java
@@ -1,0 +1,82 @@
+package io.delta.flink.utils.resources;
+
+import io.delta.flink.utils.DeltaTestUtils;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.junit.rules.TemporaryFolder;
+
+public class AllTypesNonPartitionedTableInfo implements TableInfo {
+
+    private static final String tableInitStatePath =
+        "/test-data/test-non-partitioned-delta-table-alltypes";
+
+    private static final String[] dataColumnNames = {
+        "col1", "col2", "col3", "col4", "col5", "col6", "col7", "col8", "col9", "col10"
+    };
+
+    private static final LogicalType[] dataColumnTypes = {
+        new TinyIntType(), new SmallIntType(), new IntType(), new DoubleType(), new FloatType(),
+        new DecimalType(), new DecimalType(), new TimestampType(), new VarCharType(),
+        new BooleanType()
+    };
+
+    private final String runtimePath;
+
+    private AllTypesNonPartitionedTableInfo(String runtimePath) {
+        this.runtimePath = runtimePath;
+    }
+
+    public static AllTypesNonPartitionedTableInfo create(TemporaryFolder tmpFolder) {
+        try {
+            String runtimePath = tmpFolder.newFolder().getAbsolutePath();
+            DeltaTestUtils.initTestFor(tableInitStatePath, runtimePath);
+            return new AllTypesNonPartitionedTableInfo(runtimePath);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String getTablePath() {
+        return runtimePath;
+    }
+
+    @Override
+    public String getPartitions() {
+        return null;
+    }
+
+    @Override
+    public String getTableInitStatePath() {
+        return null;
+    }
+
+    @Override
+    public String[] getDataColumnNames() {
+        return dataColumnNames;
+    }
+
+    @Override
+    public LogicalType[] getDataColumnTypes() {
+        return dataColumnTypes;
+    }
+
+    @Override
+    public int getInitialRecordCount() {
+        return 5;
+    }
+
+    @Override
+    public RowType getRowType() {
+        return RowType.of(dataColumnTypes, dataColumnNames);
+    }
+}

--- a/flink/src/test/java/io/delta/flink/utils/resources/AllTypesNonPartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/AllTypesNonPartitionedTableInfo.java
@@ -56,11 +56,6 @@ public class AllTypesNonPartitionedTableInfo implements TableInfo {
     }
 
     @Override
-    public String getTableInitStatePath() {
-        return null;
-    }
-
-    @Override
     public String[] getColumnNames() {
         return dataColumnNames;
     }

--- a/flink/src/test/java/io/delta/flink/utils/resources/AllTypesNonPartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/AllTypesNonPartitionedTableInfo.java
@@ -79,4 +79,9 @@ public class AllTypesNonPartitionedTableInfo implements TableInfo {
     public RowType getRowType() {
         return RowType.of(dataColumnTypes, dataColumnNames);
     }
+
+    @Override
+    public boolean isPartitioned() {
+        return false;
+    }
 }

--- a/flink/src/test/java/io/delta/flink/utils/resources/AllTypesNonPartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/AllTypesNonPartitionedTableInfo.java
@@ -61,12 +61,12 @@ public class AllTypesNonPartitionedTableInfo implements TableInfo {
     }
 
     @Override
-    public String[] getDataColumnNames() {
+    public String[] getColumnNames() {
         return dataColumnNames;
     }
 
     @Override
-    public LogicalType[] getDataColumnTypes() {
+    public LogicalType[] getColumnTypes() {
         return dataColumnTypes;
     }
 

--- a/flink/src/test/java/io/delta/flink/utils/resources/LargeNonPartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/LargeNonPartitionedTableInfo.java
@@ -1,0 +1,77 @@
+package io.delta.flink.utils.resources;
+
+import io.delta.flink.utils.DeltaTestUtils;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.junit.rules.TemporaryFolder;
+
+public class LargeNonPartitionedTableInfo implements SqlTableInfo {
+
+    private static final String tableInitStatePath =
+        "/test-data/test-non-partitioned-delta-table_1100_records";
+
+    private static final String sqlTableSchema = "col1 BIGINT, col2 BIGINT, col3 VARCHAR";
+
+    private static final String[] dataColumnNames = {"col1", "col2", "col3"};
+
+    private static final LogicalType[] dataColumnTypes =
+        {new BigIntType(), new BigIntType(), new VarCharType()};
+
+    private final String runtimePath;
+
+    private LargeNonPartitionedTableInfo(String runtimePath) {
+        this.runtimePath = runtimePath;
+    }
+
+    public static LargeNonPartitionedTableInfo create(TemporaryFolder tmpFolder) {
+        try {
+            String runtimePath = tmpFolder.newFolder().getAbsolutePath();
+            DeltaTestUtils.initTestFor(tableInitStatePath, runtimePath);
+            return new LargeNonPartitionedTableInfo(runtimePath);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String getSqlTableSchema() {
+        return sqlTableSchema;
+    }
+
+    @Override
+    public String getTablePath() {
+        return runtimePath;
+    }
+
+    @Override
+    public String getPartitions() {
+        return "";
+    }
+
+    @Override
+    public String getTableInitStatePath() {
+        return tableInitStatePath;
+    }
+
+    @Override
+    public String[] getDataColumnNames() {
+        return dataColumnNames;
+    }
+
+    @Override
+    public LogicalType[] getDataColumnTypes() {
+        return dataColumnTypes;
+    }
+
+    @Override
+    public int getInitialRecordCount() {
+        return 1100;
+    }
+
+    @Override
+    public RowType getRowType() {
+        return RowType.of(dataColumnTypes, dataColumnNames);
+    }
+}

--- a/flink/src/test/java/io/delta/flink/utils/resources/LargeNonPartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/LargeNonPartitionedTableInfo.java
@@ -74,4 +74,9 @@ public class LargeNonPartitionedTableInfo implements SqlTableInfo {
     public RowType getRowType() {
         return RowType.of(dataColumnTypes, dataColumnNames);
     }
+
+    @Override
+    public boolean isPartitioned() {
+        return false;
+    }
 }

--- a/flink/src/test/java/io/delta/flink/utils/resources/LargeNonPartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/LargeNonPartitionedTableInfo.java
@@ -56,12 +56,12 @@ public class LargeNonPartitionedTableInfo implements SqlTableInfo {
     }
 
     @Override
-    public String[] getDataColumnNames() {
+    public String[] getColumnNames() {
         return dataColumnNames;
     }
 
     @Override
-    public LogicalType[] getDataColumnTypes() {
+    public LogicalType[] getColumnTypes() {
         return dataColumnTypes;
     }
 

--- a/flink/src/test/java/io/delta/flink/utils/resources/LargeNonPartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/LargeNonPartitionedTableInfo.java
@@ -7,6 +7,9 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.junit.rules.TemporaryFolder;
 
+/**
+ * {@link TableInfo} non-implementation for partitioned Delta table with 1100 rows.
+ */
 public class LargeNonPartitionedTableInfo implements SqlTableInfo {
 
     private static final String tableInitStatePath =
@@ -25,7 +28,22 @@ public class LargeNonPartitionedTableInfo implements SqlTableInfo {
         this.runtimePath = runtimePath;
     }
 
-    public static LargeNonPartitionedTableInfo create(TemporaryFolder tmpFolder) {
+    /**
+     * Initialized non-partitioned test Delta table that can be used for IT tests.
+     * Created table will contain 1100 records and will be backed by predefined delta table data
+     * from {@code resources/test-data/test-non-partitioned-delta-table_1100_records}.
+     * The original files will be compiled to the temporary folder provided via the argument
+     * The path to created Delta table can be obtained from {@link #getTablePath()}.
+     * <p>
+     * Schema for created table will be:
+     * <ul>
+     *     <li> column names: "col1", "col2", "col3"</li>
+     *     <li> column types: BIGINT, BIGINT, VARCHAR</li>
+     * </ul>
+     *
+     * @param tmpFolder Temporary folder where table files should be copied to.
+     */
+    public static LargeNonPartitionedTableInfo createWithInitData(TemporaryFolder tmpFolder) {
         try {
             String runtimePath = tmpFolder.newFolder().getAbsolutePath();
             DeltaTestUtils.initTestFor(tableInitStatePath, runtimePath);

--- a/flink/src/test/java/io/delta/flink/utils/resources/NonPartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/NonPartitionedTableInfo.java
@@ -1,0 +1,74 @@
+package io.delta.flink.utils.resources;
+
+import io.delta.flink.utils.DeltaTestUtils;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.junit.rules.TemporaryFolder;
+
+public class NonPartitionedTableInfo implements SqlTableInfo {
+
+    private static final String tableInitStatePath =
+        "/test-data/test-non-partitioned-delta-table-initial-state";
+
+    private static final String sqlTableSchema = "name VARCHAR, surname VARCHAR, age INT";
+
+    private static final String[] dataColumnNames = {"name", "surname", "age"};
+
+    private static final LogicalType[] dataColumnTypes =
+        {new CharType(), new CharType(), new IntType()};
+
+    private final String runtimePath;
+
+    private NonPartitionedTableInfo(String runtimePath) {
+        this.runtimePath = runtimePath;
+    }
+
+    public static NonPartitionedTableInfo create(TemporaryFolder tmpFolder) {
+        try {
+            String runtimePath = tmpFolder.newFolder().getAbsolutePath();
+            DeltaTestUtils.initTestFor(tableInitStatePath, runtimePath);
+            return new NonPartitionedTableInfo(runtimePath);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getTablePath() {
+        return runtimePath;
+    }
+
+    @Override
+    public String getPartitions() {
+        return "";
+    }
+
+    public String getTableInitStatePath() {
+        return tableInitStatePath;
+    }
+
+    @Override
+    public String[] getDataColumnNames() {
+        return dataColumnNames;
+    }
+
+    @Override
+    public LogicalType[] getDataColumnTypes() {
+        return dataColumnTypes;
+    }
+
+    @Override
+    public int getInitialRecordCount() {
+        return 2;
+    }
+
+    @Override
+    public RowType getRowType() {
+        return RowType.of(dataColumnTypes, dataColumnNames);
+    }
+
+    public String getSqlTableSchema() {
+        return sqlTableSchema;
+    }
+}

--- a/flink/src/test/java/io/delta/flink/utils/resources/NonPartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/NonPartitionedTableInfo.java
@@ -7,6 +7,9 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.junit.rules.TemporaryFolder;
 
+/**
+ * {@link TableInfo} implementation for unpartitioned Delta table.
+ */
 public class NonPartitionedTableInfo implements SqlTableInfo {
 
     private static final String tableInitStatePath =
@@ -25,6 +28,21 @@ public class NonPartitionedTableInfo implements SqlTableInfo {
         this.runtimePath = runtimePath;
     }
 
+    /**
+     * Initialized non-partitioned test Delta table that can be used for IT tests. This table will
+     * be backed by predefined delta table data from
+     * {@code resources/test-data/test-non-partitioned-delta-table-initial-state}. Original files
+     * will be compiled to the temporary folder provided via the argument. The path to created Delta
+     * table can be obtained from {@link #getTablePath()}.
+     * <p>
+     * Schema for created table will be:
+     * <ul>
+     *     <li> column names: "name", "surname", "age"</li>
+     *     <li> column types: VARCHAR, VARCHAR, INT</li>
+     * </ul>
+     *
+     * @param tmpFolder Temporary folder where table files should be copied to.
+     */
     public static NonPartitionedTableInfo createWithInitData(TemporaryFolder tmpFolder) {
         try {
             String runtimePath = tmpFolder.newFolder().getAbsolutePath();
@@ -35,6 +53,21 @@ public class NonPartitionedTableInfo implements SqlTableInfo {
         }
     }
 
+    /**
+     * Initialized non-partitioned test Delta table without any records that can be used for IT
+     * tests. This table will be backed by predefined delta table data from
+     * {@code resources/test-data/test-non-partitioned-delta-table-initial-state}. Original files
+     * will be compiled to the temporary folder provided via the argument. The path to created Delta
+     * table can be obtained from {@link #getTablePath()}.
+     * <p>
+     * Schema for created table will be:
+     * <ul>
+     *     <li> column names: "name", "surname", "age"</li>
+     *     <li> column types: VARCHAR, VARCHAR, INT</li>
+     * </ul>
+     *
+     * @param tmpFolder Temporary folder where table files should be copied to.
+     */
     public static TableInfo createWithoutInitData(TemporaryFolder tmpFolder) {
         try {
             String runtimePath = tmpFolder.newFolder().getAbsolutePath();

--- a/flink/src/test/java/io/delta/flink/utils/resources/NonPartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/NonPartitionedTableInfo.java
@@ -25,10 +25,19 @@ public class NonPartitionedTableInfo implements SqlTableInfo {
         this.runtimePath = runtimePath;
     }
 
-    public static NonPartitionedTableInfo create(TemporaryFolder tmpFolder) {
+    public static NonPartitionedTableInfo createWithInitData(TemporaryFolder tmpFolder) {
         try {
             String runtimePath = tmpFolder.newFolder().getAbsolutePath();
             DeltaTestUtils.initTestFor(tableInitStatePath, runtimePath);
+            return new NonPartitionedTableInfo(runtimePath);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static TableInfo createWithoutInitData(TemporaryFolder tmpFolder) {
+        try {
+            String runtimePath = tmpFolder.newFolder().getAbsolutePath();
             return new NonPartitionedTableInfo(runtimePath);
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -66,6 +75,11 @@ public class NonPartitionedTableInfo implements SqlTableInfo {
     @Override
     public RowType getRowType() {
         return RowType.of(dataColumnTypes, dataColumnNames);
+    }
+
+    @Override
+    public boolean isPartitioned() {
+        return false;
     }
 
     public String getSqlTableSchema() {

--- a/flink/src/test/java/io/delta/flink/utils/resources/PartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/PartitionedTableInfo.java
@@ -1,10 +1,10 @@
 package io.delta.flink.utils.resources;
 
 import io.delta.flink.utils.DeltaTestUtils;
-import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.junit.rules.TemporaryFolder;
 
 public class PartitionedTableInfo implements SqlTableInfo {
@@ -15,10 +15,25 @@ public class PartitionedTableInfo implements SqlTableInfo {
     private static final String sqlTableSchema =
         "name VARCHAR, surname VARCHAR, age INT, col1 VARCHAR, col2 VARCHAR";
 
+    private static final String[] columnNames = {"name", "surname", "age", "col1", "col2"};
+
     private static final String[] dataColumnNames = {"name", "surname", "age"};
 
+    private static final LogicalType[] columnTypes =
+    {
+        new VarCharType(VarCharType.MAX_LENGTH),
+        new VarCharType(VarCharType.MAX_LENGTH),
+        new IntType(),
+        new VarCharType(VarCharType.MAX_LENGTH),
+        new VarCharType(VarCharType.MAX_LENGTH)
+    };
+
     private static final LogicalType[] dataColumnTypes =
-        {new CharType(), new CharType(), new IntType()};
+    {
+        new VarCharType(VarCharType.MAX_LENGTH),
+        new VarCharType(VarCharType.MAX_LENGTH),
+        new IntType()
+    };
 
     private static final int initialRecordCount = 2;
 
@@ -68,11 +83,17 @@ public class PartitionedTableInfo implements SqlTableInfo {
     }
 
     @Override
+    public String[] getColumnNames() {
+        return columnNames;
+    }
     public String[] getDataColumnNames() {
         return dataColumnNames;
     }
 
     @Override
+    public LogicalType[] getColumnTypes() {
+        return columnTypes;
+    }
     public LogicalType[] getDataColumnTypes() {
         return dataColumnTypes;
     }
@@ -84,7 +105,7 @@ public class PartitionedTableInfo implements SqlTableInfo {
 
     @Override
     public RowType getRowType() {
-        return RowType.of(dataColumnTypes, dataColumnNames);
+        return RowType.of(columnTypes, columnNames);
     }
 
     @Override

--- a/flink/src/test/java/io/delta/flink/utils/resources/PartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/PartitionedTableInfo.java
@@ -7,6 +7,9 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.junit.rules.TemporaryFolder;
 
+/**
+ * {@link TableInfo} implementation for partitioned Delta table.
+ */
 public class PartitionedTableInfo implements SqlTableInfo {
 
     private static final String tableInitStatePath =
@@ -43,6 +46,23 @@ public class PartitionedTableInfo implements SqlTableInfo {
         this.runtimePath = runtimePath;
     }
 
+    /**
+     * Initialized partitioned test Delta table that can be used for IT tests. This table will
+     * be backed by predefined delta table data from
+     * {@code resources/test-data/test-partitioned-delta-table-initial-state}. Original files
+     * will be compiled to the temporary folder provided via the argument. The path to created Delta
+     * table can be obtained from {@link #getTablePath()}.
+     * <p>
+     * Schema for created table will be:
+     * <ul>
+     *     <li> column names: "name", "surname", "age, col1, col2"</li>
+     *     <li> column types: VARCHAR, VARCHAR, INT, VARCHAR, VARCHAR</li>
+     * </ul>
+     *
+     * Columns "col1" and "col2" are partitioned columns.
+     *
+     * @param tmpFolder Temporary folder where table files should be copied to.
+     */
     public static PartitionedTableInfo createWithInitData(TemporaryFolder tmpFolder) {
         try {
             String runtimePath = tmpFolder.newFolder().getAbsolutePath();
@@ -53,6 +73,23 @@ public class PartitionedTableInfo implements SqlTableInfo {
         }
     }
 
+    /**
+     * Initialized partitioned test Delta table without any records, that can be used for IT tests.
+     * This table will be backed by predefined delta table data from
+     * {@code resources/test-data/test-partitioned-delta-table-initial-state}. Original files will
+     * be compiled to the temporary folder provided via the argument.
+     * The path to created Delta table can be obtained from {@link #getTablePath()}.
+     * <p>
+     * Schema for created table will be:
+     * <ul>
+     *     <li> column names: "name", "surname", "age, col1, col2"</li>
+     *     <li> column types: VARCHAR, VARCHAR, INT, VARCHAR, VARCHAR</li>
+     * </ul>
+     * <p>
+     * Columns "col1" and "col2" are partitioned columns.
+     *
+     * @param tmpFolder Temporary folder where table files should be copied to.
+     */
     public static TableInfo createWithoutInitData(TemporaryFolder tmpFolder) {
         try {
             String runtimePath = tmpFolder.newFolder().getAbsolutePath();

--- a/flink/src/test/java/io/delta/flink/utils/resources/PartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/PartitionedTableInfo.java
@@ -28,10 +28,19 @@ public class PartitionedTableInfo implements SqlTableInfo {
         this.runtimePath = runtimePath;
     }
 
-    public static PartitionedTableInfo create(TemporaryFolder tmpFolder) {
+    public static PartitionedTableInfo createWithInitData(TemporaryFolder tmpFolder) {
         try {
             String runtimePath = tmpFolder.newFolder().getAbsolutePath();
             DeltaTestUtils.initTestFor(tableInitStatePath, runtimePath);
+            return new PartitionedTableInfo(runtimePath);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static TableInfo createWithoutInitData(TemporaryFolder tmpFolder) {
+        try {
+            String runtimePath = tmpFolder.newFolder().getAbsolutePath();
             return new PartitionedTableInfo(runtimePath);
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -76,5 +85,10 @@ public class PartitionedTableInfo implements SqlTableInfo {
     @Override
     public RowType getRowType() {
         return RowType.of(dataColumnTypes, dataColumnNames);
+    }
+
+    @Override
+    public boolean isPartitioned() {
+        return true;
     }
 }

--- a/flink/src/test/java/io/delta/flink/utils/resources/PartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/PartitionedTableInfo.java
@@ -1,0 +1,80 @@
+package io.delta.flink.utils.resources;
+
+import io.delta.flink.utils.DeltaTestUtils;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.junit.rules.TemporaryFolder;
+
+public class PartitionedTableInfo implements SqlTableInfo {
+
+    private static final String tableInitStatePath =
+        "/test-data/test-partitioned-delta-table-initial-state";
+
+    private static final String sqlTableSchema =
+        "name VARCHAR, surname VARCHAR, age INT, col1 VARCHAR, col2 VARCHAR";
+
+    private static final String[] dataColumnNames = {"name", "surname", "age"};
+
+    private static final LogicalType[] dataColumnTypes =
+        {new CharType(), new CharType(), new IntType()};
+
+    private static final int initialRecordCount = 2;
+
+    private final String runtimePath;
+
+    private PartitionedTableInfo(String runtimePath) {
+        this.runtimePath = runtimePath;
+    }
+
+    public static PartitionedTableInfo create(TemporaryFolder tmpFolder) {
+        try {
+            String runtimePath = tmpFolder.newFolder().getAbsolutePath();
+            DeltaTestUtils.initTestFor(tableInitStatePath, runtimePath);
+            return new PartitionedTableInfo(runtimePath);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String getSqlTableSchema() {
+        return sqlTableSchema;
+    }
+
+    @Override
+    public String getTablePath() {
+        return runtimePath;
+    }
+
+    @Override
+    public String getPartitions() {
+        return "col1, col2";
+    }
+
+    @Override
+    public String getTableInitStatePath() {
+        return tableInitStatePath;
+    }
+
+    @Override
+    public String[] getDataColumnNames() {
+        return dataColumnNames;
+    }
+
+    @Override
+    public LogicalType[] getDataColumnTypes() {
+        return dataColumnTypes;
+    }
+
+    @Override
+    public int getInitialRecordCount() {
+        return initialRecordCount;
+    }
+
+    @Override
+    public RowType getRowType() {
+        return RowType.of(dataColumnTypes, dataColumnNames);
+    }
+}

--- a/flink/src/test/java/io/delta/flink/utils/resources/PartitionedTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/PartitionedTableInfo.java
@@ -78,11 +78,6 @@ public class PartitionedTableInfo implements SqlTableInfo {
     }
 
     @Override
-    public String getTableInitStatePath() {
-        return tableInitStatePath;
-    }
-
-    @Override
     public String[] getColumnNames() {
         return columnNames;
     }
@@ -94,6 +89,7 @@ public class PartitionedTableInfo implements SqlTableInfo {
     public LogicalType[] getColumnTypes() {
         return columnTypes;
     }
+
     public LogicalType[] getDataColumnTypes() {
         return dataColumnTypes;
     }

--- a/flink/src/test/java/io/delta/flink/utils/resources/SqlTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/SqlTableInfo.java
@@ -1,6 +1,22 @@
 package io.delta.flink.utils.resources;
 
+/**
+ * Provides information about Table path, schema, record count and SQL schema for predefined Delta
+ * tables used in Integration tests.
+ */
 public interface SqlTableInfo extends TableInfo {
 
+    /**
+     * @return Flink DDL table schema definition that can be used in Flink CREATE TABLE statement.
+     * For example:
+     * <pre>
+     * String tableDdl = String.format("CREATE TABLE sourceTable (%s) WITH
+     * ('connector' = 'delta','table-path' = '/some/path'), sourceTable.getSqlTableSchema());
+     * </pre>
+     * Where {@code sourceTable.getSqlTableSchema()} returns String like:
+     * <pre>
+     *      {col1 VARCHAR, col2 VARCHAR}
+     * </pre>
+     */
     String getSqlTableSchema();
 }

--- a/flink/src/test/java/io/delta/flink/utils/resources/SqlTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/SqlTableInfo.java
@@ -1,0 +1,6 @@
+package io.delta.flink.utils.resources;
+
+public interface SqlTableInfo extends TableInfo {
+
+    String getSqlTableSchema();
+}

--- a/flink/src/test/java/io/delta/flink/utils/resources/TableApiTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/TableApiTableInfo.java
@@ -7,6 +7,9 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.junit.rules.TemporaryFolder;
 
+/**
+ * {@link TableInfo} non-implementation for partitioned Delta table.
+ */
 public class TableApiTableInfo implements SqlTableInfo {
 
     private static final String tableInitStatePath =
@@ -25,6 +28,20 @@ public class TableApiTableInfo implements SqlTableInfo {
         this.runtimePath = runtimePath;
     }
 
+    /**
+     * Initialized non-partitioned test Delta table that can be used for IT tests.
+     * Table will be backed with files from {@code resources/test-data/test-table-api}.
+     * The original files will be compiled to the temporary folder provided via
+     * the argument. The path to created Delta table can be obtained from {@link #getTablePath()}.
+     * <p>
+     * Schema for created table will be:
+     * <ul>
+     *     <li> column names: "col1, col2, col3"</li>
+     *     <li> column types: CharType, CharType, IntType</li>
+     * </ul>
+     *
+     * @param tmpFolder Temporary folder where table files should be copied to.
+     */
     public static TableApiTableInfo createWithInitData(TemporaryFolder tmpFolder) {
         try {
             String runtimePath = tmpFolder.newFolder().getAbsolutePath();

--- a/flink/src/test/java/io/delta/flink/utils/resources/TableApiTableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/TableApiTableInfo.java
@@ -1,35 +1,35 @@
 package io.delta.flink.utils.resources;
 
 import io.delta.flink.utils.DeltaTestUtils;
-import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.VarCharType;
 import org.junit.rules.TemporaryFolder;
 
-public class LargeNonPartitionedTableInfo implements SqlTableInfo {
+public class TableApiTableInfo implements SqlTableInfo {
 
     private static final String tableInitStatePath =
-        "/test-data/test-non-partitioned-delta-table_1100_records";
+        "/test-data/test-table-api";
 
-    private static final String sqlTableSchema = "col1 BIGINT, col2 BIGINT, col3 VARCHAR";
+    private static final String sqlTableSchema = "col1 VARCHAR, col2 VARCHAR, col3 INT";
 
     private static final String[] dataColumnNames = {"col1", "col2", "col3"};
 
     private static final LogicalType[] dataColumnTypes =
-        {new BigIntType(), new BigIntType(), new VarCharType()};
+        {new CharType(), new CharType(), new IntType()};
 
     private final String runtimePath;
 
-    private LargeNonPartitionedTableInfo(String runtimePath) {
+    private TableApiTableInfo(String runtimePath) {
         this.runtimePath = runtimePath;
     }
 
-    public static LargeNonPartitionedTableInfo create(TemporaryFolder tmpFolder) {
+    public static TableApiTableInfo createWithInitData(TemporaryFolder tmpFolder) {
         try {
             String runtimePath = tmpFolder.newFolder().getAbsolutePath();
             DeltaTestUtils.initTestFor(tableInitStatePath, runtimePath);
-            return new LargeNonPartitionedTableInfo(runtimePath);
+            return new TableApiTableInfo(runtimePath);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -47,7 +47,7 @@ public class LargeNonPartitionedTableInfo implements SqlTableInfo {
 
     @Override
     public String getPartitions() {
-        return "";
+        return null;
     }
 
     @Override
@@ -62,7 +62,7 @@ public class LargeNonPartitionedTableInfo implements SqlTableInfo {
 
     @Override
     public int getInitialRecordCount() {
-        return 1100;
+        return 0;
     }
 
     @Override

--- a/flink/src/test/java/io/delta/flink/utils/resources/TableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/TableInfo.java
@@ -3,19 +3,47 @@ package io.delta.flink.utils.resources;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
+/**
+ * Provides information about Table path, schema and record count for predefined Delta tables used
+ * in Integration tests.
+ */
 public interface TableInfo {
 
+    /**
+     * @return path to test Delta table. The path should be unique for every test run.
+     */
     String getTablePath();
 
+    /**
+     * @return String containing comma separated partition column names for Delta table.
+     * Empty string if table has no partitions.
+     */
     String getPartitions();
 
+    /**
+     * @return array of column names for particular test Delta table. If table is partitioned,
+     * this array must contain also partition column names.
+     */
     String[] getColumnNames();
 
+    /**
+     * @return array of column Flink types for particular test Delta table. If table is partitioned,
+     * this array must contain also partition column types.
+     */
     LogicalType[] getColumnTypes();
 
+    /**
+     * @return number of records that this table have after initialization.
+     */
     int getInitialRecordCount();
 
+    /**
+     * @return Flink {@link RowType} representing a row schema for given table.
+     */
     RowType getRowType();
 
+    /**
+     * @return true if table is partitioned, false otherwise.
+     */
     boolean isPartitioned();
 }

--- a/flink/src/test/java/io/delta/flink/utils/resources/TableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/TableInfo.java
@@ -11,9 +11,9 @@ public interface TableInfo {
 
     String getTableInitStatePath();
 
-    String[] getDataColumnNames();
+    String[] getColumnNames();
 
-    LogicalType[] getDataColumnTypes();
+    LogicalType[] getColumnTypes();
 
     int getInitialRecordCount();
 

--- a/flink/src/test/java/io/delta/flink/utils/resources/TableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/TableInfo.java
@@ -1,0 +1,21 @@
+package io.delta.flink.utils.resources;
+
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+public interface TableInfo {
+
+    String getTablePath();
+
+    String getPartitions();
+
+    String getTableInitStatePath();
+
+    String[] getDataColumnNames();
+
+    LogicalType[] getDataColumnTypes();
+
+    int getInitialRecordCount();
+
+    RowType getRowType();
+}

--- a/flink/src/test/java/io/delta/flink/utils/resources/TableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/TableInfo.java
@@ -18,4 +18,6 @@ public interface TableInfo {
     int getInitialRecordCount();
 
     RowType getRowType();
+
+    boolean isPartitioned();
 }

--- a/flink/src/test/java/io/delta/flink/utils/resources/TableInfo.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/TableInfo.java
@@ -9,8 +9,6 @@ public interface TableInfo {
 
     String getPartitions();
 
-    String getTableInitStatePath();
-
     String[] getColumnNames();
 
     LogicalType[] getColumnTypes();

--- a/flink/src/test/java/io/delta/flink/utils/resources/VersionedNonPartitionedTable.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/VersionedNonPartitionedTable.java
@@ -49,11 +49,6 @@ public class VersionedNonPartitionedTable implements SqlTableInfo {
     }
 
     @Override
-    public String getTableInitStatePath() {
-        return tableInitStatePath;
-    }
-
-    @Override
     public String[] getColumnNames() {
         return dataColumnNames;
     }

--- a/flink/src/test/java/io/delta/flink/utils/resources/VersionedNonPartitionedTable.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/VersionedNonPartitionedTable.java
@@ -1,49 +1,44 @@
 package io.delta.flink.utils.resources;
 
 import io.delta.flink.utils.DeltaTestUtils;
+import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.CharType;
-import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.junit.rules.TemporaryFolder;
 
-public class NonPartitionedTableInfo implements SqlTableInfo {
+public class VersionedNonPartitionedTable implements SqlTableInfo {
 
     private static final String tableInitStatePath =
-        "/test-data/test-non-partitioned-delta-table-initial-state";
+        "/test-data/test-non-partitioned-delta-table-4-versions";
 
-    private static final String sqlTableSchema = "name VARCHAR, surname VARCHAR, age INT";
-
-    private static final String[] dataColumnNames = {"name", "surname", "age"};
+    private static final String[] dataColumnNames = {"col1", "col2", "col3"};
 
     private static final LogicalType[] dataColumnTypes =
-        {new CharType(), new CharType(), new IntType()};
+        {new BigIntType(), new BigIntType(), new CharType()};
 
     private final String runtimePath;
 
-    private NonPartitionedTableInfo(String runtimePath) {
+    private VersionedNonPartitionedTable(String runtimePath) {
         this.runtimePath = runtimePath;
     }
 
-    public static NonPartitionedTableInfo createWithInitData(TemporaryFolder tmpFolder) {
+    public static VersionedNonPartitionedTable createWithInitData(TemporaryFolder tmpFolder) {
         try {
             String runtimePath = tmpFolder.newFolder().getAbsolutePath();
             DeltaTestUtils.initTestFor(tableInitStatePath, runtimePath);
-            return new NonPartitionedTableInfo(runtimePath);
+            return new VersionedNonPartitionedTable(runtimePath);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static TableInfo createWithoutInitData(TemporaryFolder tmpFolder) {
-        try {
-            String runtimePath = tmpFolder.newFolder().getAbsolutePath();
-            return new NonPartitionedTableInfo(runtimePath);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    @Override
+    public String getSqlTableSchema() {
+        return null;
     }
 
+    @Override
     public String getTablePath() {
         return runtimePath;
     }
@@ -53,6 +48,7 @@ public class NonPartitionedTableInfo implements SqlTableInfo {
         return "";
     }
 
+    @Override
     public String getTableInitStatePath() {
         return tableInitStatePath;
     }
@@ -69,7 +65,7 @@ public class NonPartitionedTableInfo implements SqlTableInfo {
 
     @Override
     public int getInitialRecordCount() {
-        return 2;
+        return 4;
     }
 
     @Override
@@ -80,9 +76,5 @@ public class NonPartitionedTableInfo implements SqlTableInfo {
     @Override
     public boolean isPartitioned() {
         return false;
-    }
-
-    public String getSqlTableSchema() {
-        return sqlTableSchema;
     }
 }

--- a/flink/src/test/java/io/delta/flink/utils/resources/VersionedNonPartitionedTable.java
+++ b/flink/src/test/java/io/delta/flink/utils/resources/VersionedNonPartitionedTable.java
@@ -7,6 +7,9 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.junit.rules.TemporaryFolder;
 
+/**
+ * {@link TableInfo} non-implementation for partitioned Delta table with four Delta versions.
+ */
 public class VersionedNonPartitionedTable implements SqlTableInfo {
 
     private static final String tableInitStatePath =
@@ -23,6 +26,21 @@ public class VersionedNonPartitionedTable implements SqlTableInfo {
         this.runtimePath = runtimePath;
     }
 
+    /**
+     * Initialized non-partitioned test Delta table that can be used for IT tests.
+     * Table will have four Delta table versions and will be backed with files from
+     * {@code resources/test-data/test-non-partitioned-delta-table-4-versions}.
+     * The original files will be compiled to the temporary folder provided via
+     * the argument. The path to created Delta table can be obtained from {@link #getTablePath()}.
+     * <p>
+     * Schema for created table will be:
+     * <ul>
+     *     <li> column names: "col1, col2, col3"</li>
+     *     <li> column types: CharType, CharType, IntType</li>
+     * </ul>
+     *
+     * @param tmpFolder Temporary folder where table files should be copied to.
+     */
     public static VersionedNonPartitionedTable createWithInitData(TemporaryFolder tmpFolder) {
         try {
             String runtimePath = tmpFolder.newFolder().getAbsolutePath();


### PR DESCRIPTION
Add TableInfo class that contained the path, column names, column types, so all this information is coupled together. Use this class in all IT tests where we use predefined Tables.
Solves  - https://github.com/delta-io/connectors/issues/499

TableInfo classes were added to `io.delta.flink.utils.resources` package under `test` folder.